### PR TITLE
fix(release): point validate step at crates/noyalib/Cargo.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,27 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          # Workspace root Cargo.toml has no top-level version field;
+          # the per-crate versions live under crates/*/Cargo.toml.
+          # Read the canonical version from `noyalib` (every other
+          # publishable crate is kept in lockstep via release-prep
+          # `cargo workspaces version` runs).
+          CARGO_VERSION=$(grep '^version' crates/noyalib/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match Cargo.toml version ($CARGO_VERSION)"
+            echo "::error::Tag version ($TAG_VERSION) does not match crates/noyalib/Cargo.toml version ($CARGO_VERSION)"
             exit 1
           fi
-          echo "Version verified: $TAG_VERSION"
+          # Cross-check that every publishable satellite is on the
+          # same version (catches a partial workspaces-bump that
+          # forgot to update one crate).
+          for crate in noya-cli noyalib-mcp noyalib-lsp noyalib-wasm; do
+            v=$(grep '^version' "crates/$crate/Cargo.toml" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+            if [ "$v" != "$CARGO_VERSION" ]; then
+              echo "::error::crates/$crate/Cargo.toml version ($v) is out of sync with crates/noyalib ($CARGO_VERSION)"
+              exit 1
+            fi
+          done
+          echo "Version verified across noyalib + 4 satellites: $TAG_VERSION"
 
   # ── Build checksums & SBOM ──────────────────────────────────────────
   artifacts:


### PR DESCRIPTION
## Summary

The `Release` workflow's validate step on the v0.0.1 tag run failed
with:

```
Tag version (0.0.1) does not match Cargo.toml version ()
```

Root cause: workspace root `Cargo.toml` has no top-level
`version` field (it's a `[workspace]`-only manifest), so the
extraction `grep '^version' Cargo.toml | head -1 | sed …`
produced an empty CARGO_VERSION.

## Fix

- Read the canonical version from `crates/noyalib/Cargo.toml`
  instead of the workspace root.
- Add a lockstep cross-check across the 4 publishable satellite
  crates (`noya-cli`, `noyalib-mcp`, `noyalib-lsp`, `noyalib-wasm`)
  so a partial `cargo workspaces version` bump that forgets one
  crate fails the release before the partial publish lands.

## Post-merge

- Re-tag `v0.0.1` from the new `main` HEAD (the existing tag
  pointed at `fa3342c` which lacks this fix).
- Push the new tag — `release.yml` fires again with the corrected
  validate step.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, re-tag and confirm the `Validate` step prints
      "Version verified across noyalib + 4 satellites: 0.0.1".

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co