### PR TITLE
fix(release): workspace-aware checksums + explicit per-crate publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,26 @@ jobs:
 
       - name: Generate checksums
         run: |
+          set -euo pipefail
           cd target/package
-          CRATE_FILE=$(ls *.crate)
-          sha256sum "$CRATE_FILE" > SHA256SUMS.txt
-          sha512sum "$CRATE_FILE" > SHA512SUMS.txt
-          echo "CRATE_FILE=$CRATE_FILE" >> "$GITHUB_ENV"
+          # `cargo package --workspace` produces one `.crate` per
+          # publishable crate (noyalib, noya-cli, noyalib-mcp,
+          # noyalib-lsp, noyalib-wasm, plus xtask which is private).
+          # The original implementation captured `$(ls *.crate)`
+          # as a single string and passed it to sha*sum — which
+          # treats embedded newlines as part of the filename and
+          # fails. Iterate explicitly so each crate gets its own
+          # checksum line in SHA256SUMS.txt / SHA512SUMS.txt.
+          : > SHA256SUMS.txt
+          : > SHA512SUMS.txt
+          for f in *.crate; do
+            sha256sum "$f" >> SHA256SUMS.txt
+            sha512sum "$f" >> SHA512SUMS.txt
+          done
+          # Surface the list of crate files for downstream cosign /
+          # upload steps that want to reference each one explicitly.
+          ls *.crate > CRATE_FILES.txt
+          echo "CRATE_COUNT=$(wc -l < CRATE_FILES.txt)" >> "$GITHUB_ENV"
 
       # ── SLSA L3 build provenance ───────────────────────────────────
       # Records the build's exact source commit, builder identity, and
@@ -238,4 +253,24 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --all-features
+        # Publish each crate explicitly. The workspace root has no
+        # package, so a bare `cargo publish` would fail. Order:
+        #   1. `noyalib` — the library (no intra-workspace deps).
+        #   2. Wait for crates.io's index to settle (~30s for new
+        #      crate; 60s for first-publish since the API needs to
+        #      provision the namespace).
+        #   3. Satellite crates that depend on `noyalib`. Publish
+        #      them in any order — they don't depend on each other.
+        # `xtask` is `publish = false`; cargo refuses anyway.
+        # `noyalib-wasm` is `publish = false` (npm-distributed);
+        # cargo refuses.
+        run: |
+          set -euxo pipefail
+          cargo publish -p noyalib --all-features
+          # Crates.io's sparse index can take a moment to surface
+          # a new crate version; sleep briefly so the satellite
+          # publish doesn't fail with "could not find `noyalib`".
+          sleep 60
+          cargo publish -p noya-cli --all-features
+          cargo publish -p noyalib-mcp --all-features
+          cargo publish -p noyalib-lsp --all-features


### PR DESCRIPTION
## Summary

The v0.0.1 release run got past `Validate` (fixed in #34) but
failed in `Build artifacts` and would have failed again at
`Publish to crates.io`. Both bugs come from treating the
workspace as a single crate.

## Fixes

### Generate checksums step

`CRATE_FILE=$(ls *.crate)` returned one filename per line.
`cargo package --workspace` emits 6 `.crate` files. `sha256sum
"$CRATE_FILE"` then tried to interpret the entire multi-line
string as a single filename → "No such file or directory".

Fix: iterate `for f in *.crate` and append per-crate hashes to
the checksum files.

### Publish step

`cargo publish --all-features` (no `-p`) ran from the workspace
root which has no package. Even if it ran from a crate dir, only
one crate would be published.

Fix: publish each crate explicitly in dependency order:

```
noyalib (library)
  → sleep 60s for crates.io index propagation
  → noya-cli + noyalib-mcp + noyalib-lsp (each depends on noyalib)
```

`xtask` is `publish = false`; `noyalib-wasm` is npm-distributed
and `publish = false` on crates.io.

## Post-merge

After this lands, delete the existing `v0.0.1` tag and re-create
it from the new `main` HEAD:

```bash
git checkout main
git pull --rebase
git tag -d v0.0.1 && git push origin :v0.0.1
git tag -s v0.0.1 -m "noyalib v0.0.1 …"
git push origin v0.0.1
```

The previous `v0.0.1` tag run failed at `Build artifacts` —
nothing was published anywhere — so re-tagging is safe.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge + re-tag, `Build artifacts` produces 6
      checksum lines and `Publish to crates.io` walks the 4
      publishable crates without error.

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co