### PR TITLE
fix(release-binaries): bash on Windows + llvm-tools install for strip

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -162,8 +162,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # ── Compile ───────────────────────────────────────────────
+      # `shell: bash` is required so the bash-style `\` line
+      # continuation works on Windows runners too (the default
+      # PowerShell parses `\` + newline as "missing expression
+      # after unary operator '--'"). Git Bash ships on every
+      # GitHub-hosted Windows runner.
       - name: Build (cargo)
         if: ${{ !matrix.cross }}
+        shell: bash
         run: |
           cargo build --release --locked --target ${{ matrix.target }} \
               --manifest-path crates/noya-cli/Cargo.toml \
@@ -171,22 +177,33 @@ jobs:
 
       - name: Build (cross)
         if: matrix.cross
+        shell: bash
         run: |
           cross build --release --locked --target ${{ matrix.target }} \
               --manifest-path crates/noya-cli/Cargo.toml \
               --bin noyafmt --bin noyavalidate
 
       # ── Debug-symbol split (Linux gnu only) ────────────────────
+      - name: Install llvm-tools (for llvm-objcopy)
+        if: matrix.deb && !matrix.cross
+        run: rustup component add llvm-tools-preview
+
       - name: Strip + extract debug symbols
         if: matrix.deb && !matrix.cross
         shell: bash
         run: |
           set -euo pipefail
+          # `llvm-tools-preview` ships `llvm-objcopy` under the
+          # rustup toolchain dir, not on PATH. Resolve it via
+          # `rustc --print sysroot`.
+          SYSROOT=$(rustc --print sysroot)
+          HOST_TUPLE=$(rustc --print host-tuple)
+          OBJCOPY="$SYSROOT/lib/rustlib/$HOST_TUPLE/bin/llvm-objcopy"
           for bin in noyafmt noyavalidate; do
             BIN="target/${{ matrix.target }}/release/${bin}"
-            llvm-objcopy --only-keep-debug "${BIN}" "${BIN}.debug"
-            llvm-objcopy --strip-debug --strip-unneeded "${BIN}"
-            llvm-objcopy --add-gnu-debuglink="${BIN}.debug" "${BIN}"
+            "$OBJCOPY" --only-keep-debug "${BIN}" "${BIN}.debug"
+            "$OBJCOPY" --strip-debug --strip-unneeded "${BIN}"
+            "$OBJCOPY" --add-gnu-debuglink="${BIN}.debug" "${BIN}"
             file "${BIN}"
           done
 
@@ -445,6 +462,7 @@ jobs:
         env:
           RUSTFLAGS: '--remap-path-prefix=$HOME=~ --remap-path-prefix=${{ github.workspace }}=/build'
           NOYA_GEN_ASSETS: '1'
+        shell: bash
         run: |
           cargo build --release --locked --target ${{ env.TARGET }} \
               --manifest-path crates/noya-cli/Cargo.toml \


### PR DESCRIPTION
## Summary

The first run of `release-binaries.yml` against the `v0.0.1` tag
failed 5 of 12 cross-build matrix legs:

- **Linux gnu**: `llvm-objcopy: command not found` on
  `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu`.
- **Windows msvc**: PowerShell rejected `\` line continuation
  with `Missing expression after unary operator '--'` on
  `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, and
  `i686-pc-windows-msvc`.

Every downstream channel (Homebrew, AUR, Scoop, VS Code, npm,
GHCR) was `skipped` because the build matrix gated them.

## Fix

(1) Pin `shell: bash` on the build / rebuild steps so Git Bash
    handles the `\` continuation on Windows runners.

(2) Add a `rustup component add llvm-tools-preview` step before
    the strip step on Linux gnu, and resolve `llvm-objcopy` via
    `rustc --print sysroot` (same pattern as noyalib's
    `scripts/pgo.sh`).

## Re-dispatch after merge

```
gh workflow run release-binaries.yml --ref main \\
    -f tag=v0.0.1 -f dry_run=false
```

Safe to re-run because the failed build matrix produced no
published artefacts on any channel (every Bump / Publish step
was `skipped`).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge + re-dispatch, all 12 cross-build legs succeed.
- [ ] Downstream Bump / Publish steps execute (Homebrew, AUR,
      Scoop, VS Code Marketplace, Open VSX, npm, GHCR).

---
THE ARCHITECT ᛫ Sebastien Rousseau ᛫ https://sebastienrousseau.com
THE ENGINE ᛞ EUXIS ᛫ Enterprise Unified Execution Intelligence System ᛫ https://euxis.co