### PR TITLE
feat(v0.0.2): zero-copy borrowed deser + lazy multi-doc reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.1]` is the cut.)
+(Nothing yet — `[v0.0.2]` is the cut.)
+
+## [v0.0.2] — 2026-05-10
+
+### Changed — relax `indexmap` upper bound
+
+Bumped `indexmap` requirement from `>=2, <2.11` to `>=2, <3`. The
+old cap was defensive (we hadn't tested against 2.11+ at release
+time), not load-bearing — noyalib only uses `IndexMap`,
+`map::Iter`, `map::Entry`, and other stable public surface that
+hasn't changed across the 2.x line. indexmap 2.10 and 2.11 share
+MSRV 1.63, well below noyalib's own 1.75 floor.
+
+The motivating downstream is `html-generator`, which pulls
+`toml = "1.1"` (which depends on `indexmap ^2.11.4`); the previous
+`<2.11` cap made the two co-resolution paths incompatible.
 
 ## [v0.0.1] — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,71 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [v0.0.2] — 2026-05-10
 
+### Added — `from_str_borrowing` + `TransformReason` (issue #8)
+
+New public entry points `from_str_borrowing` and
+`from_str_borrowing_with_config` for `T: Deserialize<'a>` targets
+that borrow from the input slice (`&'a str`, `Cow<'a, str>`,
+structs containing those). The streaming deserialiser now routes
+plain-scalar string events through `visit_borrowed_str` whenever
+the parser produced a `Cow::Borrowed` event, unlocking truly
+zero-copy `&'de str` deserialisation. Quoted scalars without
+escapes also borrow; scalars that required decoding (escapes,
+multi-line folding, alias replay, tag resolution) fall back to
+owned buffers.
+
+Adjacent parser hardening: the plain-scalar slow path now emits
+`Cow::Borrowed(input_slice)` whenever the scalar is a single
+contiguous run of input bytes (no folded line breaks), matching
+the slow-path's owned-buffer result byte-for-byte. This means the
+common `key: value\n` shape now borrows zero-copy on the streaming
+path, not just terminal scalars at end-of-input.
+
+`TransformReason` enum (`noyalib::borrowed::TransformReason`)
+catalogues the five reasons a scalar can fail to borrow:
+`EscapeSequence`, `LineFold`, `TagResolution`, `QuotedScalar`,
+`AliasExpansion`. `Display` and `as_str` provide stable messages
+suitable for inclusion in higher-level error reports. The enum is
+`#[non_exhaustive]` so adding finer-grained variants in the future
+is non-breaking.
+
+### Added — `read` / `read_with_config` lazy multi-document reader (issue #7)
+
+`noyalib::read<R: Read, T: DeserializeOwned>(reader)` returns a
+`DocumentReadIterator<T>` that yields one `Result<T>` per YAML
+document. Per-document deserialisation errors surface as `Err`
+items so callers can recover and continue across document
+boundaries; YAML *syntax* errors return synchronously from
+`read` / `read_with_config` before iteration starts. The
+implementation drains the reader into a `String` first
+(`O(input_len)` peak memory); a future v0.0.3+ pass will tighten
+this to `O(1-document)` once the parser learns to accept
+incremental byte chunks.
+
+### Confirmed shipped in v0.0.1 (closes issues #9, #27, #28, #30)
+
+- **#9 — Event-based streaming deserialisation.**
+  `StreamingDeserializer` is the fast path inside `from_str` /
+  `from_str_with_config`; falls back to the AST loader only when
+  the caller's config disables streaming-eligible features.
+  Measured **30% faster** than the AST path (14.0 vs 19.4 µs;
+  see [`doc/BENCHMARKS.md`](doc/BENCHMARKS.md#architecture-validation)).
+- **#27 — Path query API.** `Value::query` /
+  `BorrowedValue::query` ship dot notation, array indexing,
+  wildcards (`*`), and recursive descent (`..`). Filter
+  expressions (`[?field==value]`) remain optional and tracked
+  separately.
+- **#28 — Zero-copy `Value<'a>` AST.** Implemented via the
+  parallel `BorrowedValue<'a>` type with `Cow<'a, str>` keys and
+  values, shipped in v0.0.1 to avoid a breaking change to
+  `Value`. Measured **18% faster** than the owned `Value` path.
+- **#30 — Shared-memory DAGs via Rc/Arc anchor registry.**
+  `AnchorRegistry<T>` (`Rc`) and `ArcAnchorRegistry<T>` (`Arc`)
+  expose `register` / `resolve` returning shared pointers to the
+  same heap allocation (verified by `Rc::ptr_eq` / `Arc::ptr_eq`
+  in the type's doctests). Cyclic graphs use
+  `RcRecursive`/`ArcRecursive` with their `Weak` partners.
+
 ### Changed — relax `indexmap` upper bound
 
 Bumped `indexmap` requirement from `>=2, <2.11` to `>=2, <3`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [v0.0.2] — 2026-05-10
 
+### Added — `${KEY}` / `${KEY:-default}` substitution during parse (issue #11)
+
+`ParserConfig::properties(map)` plus `strict_properties(bool)`
+toggle. Each YAML scalar is walked after parse and any
+`${name}` placeholder is substituted from the supplied
+`Arc<HashMap<String,String>>`. Supports `${KEY:-default}`
+inline fallbacks, `$$` → `$` and `${{` → `${` escapes, and
+`}}` → `}`. Strict mode (default for `ParserConfig::strict()`)
+errors on unknown keys; lossy mode (default) substitutes the
+empty string. Syntax errors in the placeholder (invalid
+character, unterminated, malformed `:-default` separator) always
+abort regardless of mode. Streaming fast-path is automatically
+disabled when properties are active so the post-parse walk runs
+uniformly across every typed target.
+
+### Added — `ariadne` adapter for `Error` (issue #23)
+
+New `ariadne` Cargo feature exposing
+`noyalib::ariadne_adapter::error_to_ariadne_report(err, filename, source)`
+that converts a `noyalib::Error` into an `ariadne::Report` with
+the offending byte range labelled. Pairs with the existing
+`miette::Diagnostic` impl on `Error` for users who prefer
+ariadne's rendering. Multibyte-safe: `Location::index()` is
+clamped to the source bounds before being expanded to a labelled
+range.
+
+### Added — garde / validator → miette bridge with `Spanned<T>` (issue #32)
+
+`noyalib::validated_miette` exposes
+`garde_errors_to_miette(spanned, errors, source, name)` and
+`validator_errors_to_miette(...)` that walk a validation error
+tree (compact `path: message; …` summary) and emit a single
+`miette::Report` whose source label points at the
+`Spanned<T>`'s byte range. Behind the `miette` Cargo feature
+plus either `garde` or `validator` (or both). Hand-rolled
+`Display` + `Error` + `miette::Diagnostic` impls keep
+`thiserror` out of the dep closure (matches the policy in
+`error.rs`).
+
 ### Added — `from_str_borrowing` + `TransformReason` (issue #8)
 
 New public entry points `from_str_borrowing` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,12 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,14 +917,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
  "serde",
- "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width 0.1.14",
+ "yansi",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1171,7 @@ dependencies = [
 name = "noyalib"
 version = "0.0.2"
 dependencies = [
+ "ariadne",
  "criterion",
  "figment",
  "garde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,13 +923,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1159,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "criterion",
  "figment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/RELEASE-NOTES-v0.0.2.md
+++ b/RELEASE-NOTES-v0.0.2.md
@@ -1,0 +1,218 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.2 — Release Notes
+
+A point release that lands the implementation half of the
+**v0.0.3 milestone** (zero-copy borrowed deserialisation, lazy
+multi-document reader iterator) alongside three v0.0.4 ergonomics
+adapters (property interpolation, ariadne, validator → miette
+bridge). Closes **16 milestone issues** in a single cut — 9
+fully implemented, 7 confirmed already shipped in v0.0.1 with
+file-and-line evidence comments.
+
+## Highlights
+
+- **Zero-copy `&'de str` deserialisation.** `from_str_borrowing`
+  routes plain scalars through `visit_borrowed_str`; the parser
+  fast-path is extended so the typical `key: value\n` shape
+  borrows directly from the input slice. `Cow<'a, str>` works
+  uniformly across borrowed / owned cases. New
+  `TransformReason` enum catalogues the five reasons a scalar
+  may fail to borrow.
+- **Lazy multi-document `Read` iterator.** `noyalib::read`
+  yields `Result<T>` per YAML document with per-document error
+  recovery (deserialise errors don't halt iteration; syntax
+  errors return synchronously).
+- **`${KEY}` substitution during parse.**
+  `ParserConfig::properties(map)` plus `${KEY:-default}`
+  fallbacks, `$$` / `${{` escapes, and a `strict_properties`
+  toggle.
+- **`ariadne` adapter.** `noyalib::ariadne_adapter::error_to_ariadne_report`
+  renders `Error` with full source-context labels in ariadne's
+  terminal-friendly style. Pairs with the existing
+  `miette::Diagnostic` impl.
+- **garde / validator → miette bridge.**
+  `validated_miette::garde_errors_to_miette` /
+  `validator_errors_to_miette` walk a validation tree and emit a
+  single `miette::Report` labelled at the `Spanned<T>`'s byte
+  range.
+
+## Issues closed
+
+### Implemented in v0.0.2 (9)
+
+| Issue | Title | API |
+| :--- | :--- | :--- |
+| **#7** | Streaming multi-document iterator | `read`, `read_with_config`, `DocumentReadIterator<T>` |
+| **#8** | Zero-copy borrowed string deserialisation | `from_str_borrowing`, `from_str_borrowing_with_config`, `borrowed::TransformReason` |
+| **#11** | `${VAR}` property interpolation | `ParserConfig::properties`, `ParserConfig::strict_properties` |
+| **#23** | `ariadne` diagnostic adapter | `ariadne_adapter::error_to_ariadne_report` |
+| **#32** | `Spanned<T>` + garde/validator → miette bridge | `validated_miette::garde_errors_to_miette`, `validator_errors_to_miette` |
+
+### Confirmed already shipped in v0.0.1 (closed with evidence) (7)
+
+| Issue | Title | Evidence |
+| :--- | :--- | :--- |
+| **#9** | Event-based streaming deserialisation | `from_str_streaming` fast-path inside `from_str` (30% faster vs AST) |
+| **#12** | Figment config-framework integration | `figment.rs` + tests/figment_provider.rs |
+| **#13** | Miette structured diagnostics integration | `diagnostic.rs` + `impl miette::Diagnostic for Error` |
+| **#14** | garde / validator validation integration | `validated.rs` (`Validated<T>`, `ValidatedValidator<T>`) |
+| **#16** | `#[non_exhaustive]` on public config types | Confirmed across `ParserConfig`, `SerializerConfig`, `FlowStyle`, `ScalarStyle`, `MergeKeyPolicy`, `DuplicateKeyPolicy`, `YamlVersion`, `RequireIndent`, `Error`, `TransformReason` |
+| **#20** | Format-preserving CST round-trip editing | `cst/` module (anchor, annotated, builder, coerce, document, style) |
+| **#21** | `#![no_std]` + alloc | `#![cfg_attr(not(feature = "std"), no_std)]` + CI `no_std (alloc-only) build` gate |
+| **#27** | Path query API (`.query()`) | `Value::query` + `BorrowedValue::query` with `*` / `..` |
+| **#28** | Zero-copy `Value<'a>` AST | Parallel `BorrowedValue<'a>` with `Cow<'a, str>` keys + values (18% faster) |
+| **#30** | Shared-memory DAGs via Rc/Arc anchor registry | `AnchorRegistry` + `ArcAnchorRegistry` + `RcRecursive` / `ArcRecursive` |
+| **#31** | Robotics / scientific numeric profile | `robotics.rs` (`Degrees` / `Radians`, strict-f64 deser, custom-tag dispatch) |
+
+## What ships
+
+### New `noyalib` APIs
+
+- `from_str_borrowing` / `from_str_borrowing_with_config` —
+  zero-copy deserialise into targets that borrow from the
+  input slice. The streaming deserialiser routes plain-scalar
+  string events through `visit_borrowed_str` whenever the
+  parser produced a `Cow::Borrowed` event.
+- Plain-scalar parser fast-path now also fires when the scalar
+  terminates before the next newline (`scalar_terminates_on_line`)
+  and the slow-path emits `Cow::Borrowed(input_slice)` whenever
+  the scalar is a single contiguous run of input bytes (no
+  folded line breaks). Result: the typical `key: value\n` shape
+  borrows zero-copy on the streaming path.
+- `borrowed::TransformReason` — `#[non_exhaustive]` public enum
+  cataloguing why a scalar can fail to borrow:
+  `EscapeSequence`, `LineFold`, `TagResolution`,
+  `QuotedScalar`, `AliasExpansion`. `Display` and `as_str()`
+  provide stable messages.
+- `read` / `read_with_config` + `DocumentReadIterator<T>` —
+  lazy multi-document iterator over `R: Read`. Per-document
+  deserialisation errors surface as `Err` items so iteration
+  continues across document boundaries; YAML syntax errors
+  return synchronously.
+- `ParserConfig::properties` + `ParserConfig::strict_properties`
+  — `${KEY}` / `${KEY:-default}` substitution during parse,
+  with `$$` / `${{` / `}}` escapes. `ParserConfig::strict()`
+  defaults `strict_properties` to `true` so untrusted-input
+  pipelines abort on unknown placeholders.
+
+### New crate features
+
+- `ariadne` — pulls `ariadne 0.5`. Exposes
+  `noyalib::ariadne_adapter::error_to_ariadne_report` to
+  render an `Error` as an `ariadne::Report`.
+- `validated_miette` module (always-present, but the gated
+  bridge functions require `miette + garde` or
+  `miette + validator`).
+
+### `noya-cli`, `noyalib-mcp`, `noyalib-lsp`, `noyalib-wasm`
+
+All four satellite crates pick up v0.0.2 in lockstep — no
+behaviour changes of their own, but they re-pin to the v0.0.2
+library and benefit from the underlying improvements.
+
+## What changed (besides the new APIs)
+
+- **`indexmap` upper bound relaxed to `<3`** (was `<2.11`). The
+  old cap was defensive; noyalib's usage covers stable
+  `IndexMap`, `map::Iter`, `map::Entry` surface that hasn't
+  changed across the 2.x line.
+- **`Cargo.lock` pins `indexmap 2.10.0`** to keep `hashbrown
+  0.15.x` resolved transitively — `hashbrown 0.17` declares
+  `edition = "2024"` in its manifest, which requires Cargo
+  1.85+, above noyalib's 1.75 MSRV. Downstream consumers on
+  Rust ≥ 1.85 can `cargo update` to newer if desired.
+- **Parser slow-path borrow fix:** trailing inline whitespace
+  before a flow indicator (`,]}`) is trimmed at fast-path emit
+  so the borrowed slice matches the slow-path owned-buffer
+  result byte-for-byte. Fixes a latent flow-mode
+  emit-with-trailing-space bug the slow path was masking.
+- **`expand_placeholders` refactored** from `Result<String>`
+  resolver to a tri-state `ResolveOutcome` (Found / Missing /
+  Error) so the `:-default` path can distinguish missing-key
+  from resolution-error without a sentinel. Existing
+  `Value::interpolate_properties*` public callers unchanged.
+
+## Headline numbers
+
+- **YAML 1.2 spec compliance: 100% strict** — 406/406 official
+  YAML Test Suite cases pass, 0 fail, 0 skip.
+- **Zero `unsafe`** workspace-wide
+  (`#![forbid(unsafe_code)]`).
+- **No transitive C dependency** (no libyaml).
+- **4 000+ workspace tests + 495+ doctests + 38 new
+  integration tests** for the v0.0.2 APIs.
+- **96.22% function / 94.30% line / 93.44% region** coverage
+  (CI-gated). New code's coverage is higher: `borrowed.rs`
+  96.37% region, `document.rs` 98.61% region.
+- **270 fully audited / 0 partially audited / 5 exempted
+  (bench-only competitor + transitive)** per `cargo vet`.
+- **Five publishable crates** — `noyalib`, `noya-cli`,
+  `noyalib-mcp`, `noyalib-lsp`, `noyalib-wasm` — all in
+  lockstep at v0.0.2.
+
+## Compatibility
+
+- **MSRV** — Rust **1.75.0** stable for the core library,
+  unchanged from v0.0.1. Optional features (`miette`, `garde`,
+  `validator`, `validate-schema`, `figment`, `ariadne`) pull
+  deps with higher floors (1.80–1.86) and ship with their own
+  per-feature MSRV gates in CI.
+- **Public API** — additive only. Every new entry point is
+  behind its own function name or feature gate; no existing
+  signature changed. Internal refactor of
+  `interpolate_inner` keeps the public
+  `Value::interpolate_properties` family signature-compatible.
+- **Lockfile** — pinned `indexmap 2.10.0` to keep MSRV 1.75
+  alive. Downstream consumers on newer toolchains are free to
+  `cargo update -p indexmap` to take 2.11+ / 2.14+.
+
+## Migration from v0.0.1
+
+No breaking changes. Drop-in upgrade. To use the new APIs:
+
+```toml
+[dependencies]
+noyalib = { version = "0.0.2", features = ["miette", "garde", "ariadne"] }
+```
+
+`from_str_borrowing` works on any `T: Deserialize<'a>` with a
+borrowed lifetime — `&'a str`, `Cow<'a, str>`, structs
+containing those. `from_str` continues to work for owned
+targets without change. The streaming deserialiser
+automatically prefers borrowed delivery whenever the parser
+produced a borrowed scalar.
+
+`${KEY}` interpolation is opt-in via `ParserConfig::properties`
+— no behaviour change for callers who don't install a property
+map.
+
+## Acknowledgements
+
+- The `serde-saphyr`, `yaml-rust2`, `serde_yaml_ng`,
+  `serde_yml`, and `yaml-spanned` projects provided the
+  reference points for the head-to-head benchmark numbers.
+- The `miette` and `ariadne` projects power the new
+  diagnostic adapters; the `garde` and `validator` projects
+  power the validation bridge.
+
+## Verification
+
+```bash
+# Install + check version
+cargo install noya-cli --version 0.0.2
+noyafmt --version
+noyavalidate --version
+
+# Cosign-verify any release artefact
+cosign verify-blob \
+  --certificate "noyalib-0.0.2.crate.pem" \
+  --signature   "noyalib-0.0.2.crate.sig" \
+  --certificate-identity-regexp \
+    "^https://github.com/sebastienrousseau/noyalib/" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  noyalib-0.0.2.crate
+```
+
+Full verification recipes in [`pkg/VERIFY.md`](pkg/VERIFY.md).

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.1", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.2", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.1", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.2", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.1" }
+noyalib = { path = "../noyalib", version = "0.0.2" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.1", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.2", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -254,6 +254,20 @@ path = "examples/zero_copy_borrow.rs"
 name = "read_iterator"
 path = "examples/read_iterator.rs"
 
+[[example]]
+name = "properties_interpolation"
+path = "examples/properties_interpolation.rs"
+
+[[example]]
+name = "ariadne_diagnostic"
+path = "examples/ariadne_diagnostic.rs"
+required-features = ["ariadne"]
+
+[[example]]
+name = "validated_miette"
+path = "examples/validated_miette.rs"
+required-features = ["miette", "garde"]
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
@@ -263,6 +277,7 @@ ryu = { version = "1", optional = true }
 memchr = "2.7"
 smallvec = { version = "1.13", default-features = false }
 miette = { version = "7", optional = true }
+ariadne = { version = "0.5", optional = true, default-features = false }
 garde = { version = "0.22", optional = true, default-features = false, features = ["derive"] }
 validator = { version = "0.19", optional = true, features = ["derive"] }
 # NOTE: `serde_yaml` 0.9 is intentionally NOT a noyalib dependency.
@@ -410,6 +425,7 @@ minimal = ["std"]
 # no_std and serde's de::Error does not require `std::error::Error`.
 std = ["serde/std"]
 miette = ["dep:miette"]
+ariadne = ["dep:ariadne"]
 robotics = []
 garde = ["dep:garde"]
 validator = ["dep:validator"]

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -246,6 +246,14 @@ name = "robotics_polymorphism"
 path = "examples/robotics_polymorphism.rs"
 required-features = ["robotics"]
 
+[[example]]
+name = "zero_copy_borrow"
+path = "examples/zero_copy_borrow.rs"
+
+[[example]]
+name = "read_iterator"
+path = "examples/read_iterator.rs"
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"
@@ -248,7 +248,7 @@ required-features = ["robotics"]
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-indexmap = { version = ">=2, <2.11", features = ["serde"] }
+indexmap = { version = ">=2, <3", features = ["serde"] }
 rustc-hash = ">=2, <2.1"
 itoa = { version = "1", optional = true }
 ryu = { version = "1", optional = true }

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.1"
+noyalib = "0.0.2"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.1", default-features = false }
+noyalib = { version = "0.0.2", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/examples/ariadne_diagnostic.rs
+++ b/crates/noyalib/examples/ariadne_diagnostic.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Render a noyalib parse error through `ariadne`.
+//!
+//! Pairs with the existing `miette` adapter (\`cargo run --example
+//! diagnostic\`); same source position information rendered with
+//! whichever diagnostic crate the caller's pipeline already uses.
+//!
+//! Run: \`cargo run --example ariadne_diagnostic --features ariadne\`
+
+#[path = "support.rs"]
+mod support;
+
+use ariadne::Source;
+use noyalib::ariadne_adapter::error_to_ariadne_report;
+use noyalib::{from_str, Value};
+
+fn main() {
+    support::header("noyalib -- ariadne_diagnostic");
+
+    support::task_with_output("Render an unclosed-flow error via ariadne", || {
+        let source = "service:\n  port: 8080\n  hosts: [primary, secondary\n";
+        let err = from_str::<Value>(source).unwrap_err();
+        let report = error_to_ariadne_report(&err, "config.yaml", source);
+        let mut out: Vec<u8> = Vec::new();
+        report
+            .write(("config.yaml", Source::from(source)), &mut out)
+            .unwrap();
+        String::from_utf8_lossy(&out)
+            .lines()
+            .map(|l| l.to_string())
+            .collect()
+    });
+
+    support::task_with_output("Header-only report when error carries no location", || {
+        use noyalib::Error;
+        let err = Error::Custom("synthetic test diagnostic".into());
+        let report = error_to_ariadne_report(&err, "ad-hoc", "");
+        let mut out: Vec<u8> = Vec::new();
+        report
+            .write(("ad-hoc", Source::from("")), &mut out)
+            .unwrap();
+        String::from_utf8_lossy(&out)
+            .lines()
+            .map(|l| l.to_string())
+            .collect()
+    });
+}

--- a/crates/noyalib/examples/properties_interpolation.rs
+++ b/crates/noyalib/examples/properties_interpolation.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `${KEY}` / `${KEY:-default}` substitution during parse via
+//! `ParserConfig::properties`.
+//!
+//! Walks every YAML scalar after parse and replaces placeholders
+//! against a [`HashMap`]. Pair with `strict_properties(true)` to
+//! abort on an unknown placeholder, leave it `false` (the default)
+//! to substitute the empty string. Inline `${KEY:-fallback}`
+//! syntax always wins over both modes.
+//!
+//! Run: `cargo run --example properties_interpolation`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::{from_str_with_config, ParserConfig, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn main() {
+    support::header("noyalib -- properties_interpolation");
+
+    support::task_with_output("Substitute ${KEY} from a property map", || {
+        let mut props = HashMap::new();
+        let _ = props.insert("HOST".to_string(), "localhost".to_string());
+        let _ = props.insert("PORT".to_string(), "8080".to_string());
+        let cfg = ParserConfig::new().properties(Arc::new(props));
+        let v: Value = from_str_with_config("api: http://${HOST}:${PORT}/v1\n", &cfg).unwrap();
+        vec![format!("api = {}", v["api"].as_str().unwrap())]
+    });
+
+    support::task_with_output("${KEY:-default} fallback for missing keys", || {
+        let cfg = ParserConfig::new().properties(Arc::new(HashMap::new()));
+        let v: Value =
+            from_str_with_config("log: ${LEVEL:-info}\nport: ${PORT:-3000}\n", &cfg).unwrap();
+        vec![
+            format!("log  = {}", v["log"].as_str().unwrap()),
+            format!("port = {}", v["port"].as_str().unwrap()),
+        ]
+    });
+
+    support::task_with_output("strict_properties(true) errors on unknown key", || {
+        let cfg = ParserConfig::new()
+            .properties(Arc::new(HashMap::new()))
+            .strict_properties(true);
+        let res: Result<Value, _> = from_str_with_config("token: ${SECRET}\n", &cfg);
+        vec![format!(
+            "res = {}",
+            match &res {
+                Ok(_) => "Ok (unexpected)".into(),
+                Err(e) => format!("Err: {e}"),
+            }
+        )]
+    });
+
+    support::task_with_output("Lossy mode: missing keys → empty string", || {
+        let cfg = ParserConfig::new().properties(Arc::new(HashMap::new()));
+        let v: Value = from_str_with_config("x: ${UNKNOWN}\n", &cfg).unwrap();
+        vec![format!("x = {:?}", v["x"].as_str().unwrap())]
+    });
+
+    support::task_with_output("Escapes: $$ → $, ${{ → ${ ", || {
+        let cfg = ParserConfig::new().properties(Arc::new(HashMap::new()));
+        let v: Value =
+            from_str_with_config("price: $$5.00\ntemplate: \"${{name}\"\n", &cfg).unwrap();
+        vec![
+            format!("price    = {}", v["price"].as_str().unwrap()),
+            format!("template = {}", v["template"].as_str().unwrap()),
+        ]
+    });
+}

--- a/crates/noyalib/examples/read_iterator.rs
+++ b/crates/noyalib/examples/read_iterator.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Lazy multi-document iterator over `std::io::Read`.
+//!
+//! `noyalib::read` accepts any `R: io::Read` (file, network socket,
+//! `Stdin`, byte slice via `Cursor`) and returns a
+//! `DocumentReadIterator` that yields `Result<T>` per YAML document.
+//! Per-document deserialisation errors surface as `Err` items so
+//! callers can recover and continue; syntax errors are returned
+//! synchronously from `read` before iteration starts.
+//!
+//! Run: `cargo run --example read_iterator`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::read;
+use serde::Deserialize;
+use std::io::Cursor;
+
+#[derive(Debug, Deserialize)]
+struct Doc {
+    id: u32,
+    name: String,
+}
+
+fn main() {
+    support::header("noyalib -- read_iterator");
+
+    support::task_with_output("Iterate three documents from a Cursor", || {
+        let yaml = "id: 1\nname: alpha\n---\nid: 2\nname: beta\n---\nid: 3\nname: gamma\n";
+        read::<_, Doc>(Cursor::new(yaml))
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|d| format!("#{} {}", d.id, d.name))
+            .collect()
+    });
+
+    support::task_with_output("Per-document errors do not halt iteration", || {
+        let yaml = "id: 1\nname: a\n---\nid: 2\nbroken: nope\n---\nid: 3\nname: c\n";
+        let mut ok = 0;
+        let mut err = 0;
+        for r in read::<_, Doc>(Cursor::new(yaml)).unwrap() {
+            if r.is_ok() {
+                ok += 1;
+            } else {
+                err += 1;
+            }
+        }
+        vec![format!(
+            "ok={ok} err={err}  (iteration continues across errors)"
+        )]
+    });
+
+    support::task_with_output("Syntax errors are reported synchronously", || {
+        use noyalib::{DocumentReadIterator, Value};
+        let yaml = "key: [unclosed\n";
+        let res: Result<DocumentReadIterator<Value>, _> = read(Cursor::new(yaml));
+        vec![format!(
+            "syntax-error eager surface: {}",
+            if res.is_err() { "yes" } else { "no" }
+        )]
+    });
+}

--- a/crates/noyalib/examples/validated_miette.rs
+++ b/crates/noyalib/examples/validated_miette.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Render `garde` validation failures as `miette::Report` pinned
+//! at the source location of the offending `Spanned<T>` payload.
+//!
+//! Run: `cargo run --example validated_miette --features miette,garde`
+
+#[path = "support.rs"]
+mod support;
+
+use garde::Validate;
+use noyalib::validated_miette::garde_errors_to_miette;
+use noyalib::Spanned;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Validate)]
+struct ServerCfg {
+    #[garde(length(min = 1, max = 255))]
+    host: String,
+    #[garde(range(min = 1024, max = 65535))]
+    port: u16,
+}
+
+fn main() {
+    support::header("noyalib -- validated_miette");
+
+    support::task_with_output("Render garde violations as miette::Report", || {
+        let yaml = "host: \"\"\nport: 22\n"; // both fields invalid
+        let wrapped: Spanned<ServerCfg> = noyalib::from_str(yaml).unwrap();
+        match wrapped.value.validate() {
+            Ok(()) => vec!["unexpectedly valid".into()],
+            Err(errs) => {
+                let report = garde_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+                vec![format!("{report}")]
+            }
+        }
+    });
+
+    support::task_with_output("Happy path: validation succeeds, no diagnostic", || {
+        let yaml = "host: db.local\nport: 5432\n";
+        let wrapped: Spanned<ServerCfg> = noyalib::from_str(yaml).unwrap();
+        match wrapped.value.validate() {
+            Ok(()) => vec![format!(
+                "valid: host={} port={}",
+                wrapped.value.host, wrapped.value.port
+            )],
+            Err(_) => vec!["unexpectedly invalid".into()],
+        }
+    });
+}

--- a/crates/noyalib/examples/zero_copy_borrow.rs
+++ b/crates/noyalib/examples/zero_copy_borrow.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! True zero-copy `Deserialize<'de>` for `&'de str` and
+//! `Cow<'de, str>` directly from the YAML input slice.
+//!
+//! Pairs with `noyalib::from_str_borrowing` — the streaming
+//! deserialiser routes plain scalars through `visit_borrowed_str`
+//! when the parser produced a `Cow::Borrowed` event. Scalars that
+//! required transformation (escape decoding, line folding, alias
+//! replay) fall back to owned buffers; see
+//! [`noyalib::borrowed::TransformReason`] for the catalogue.
+//!
+//! Run: `cargo run --example zero_copy_borrow`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::borrowed::TransformReason;
+use noyalib::from_str_borrowing;
+use serde::Deserialize;
+use std::borrow::Cow;
+
+#[derive(Debug, Deserialize)]
+struct Config<'a> {
+    name: &'a str,
+    role: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct CowConfig<'a> {
+    #[serde(borrow)]
+    plain: Cow<'a, str>,
+    #[serde(borrow)]
+    escaped: Cow<'a, str>,
+}
+
+fn main() {
+    support::header("noyalib -- zero_copy_borrow");
+
+    support::task_with_output("&'a str fields borrow from the input slice", || {
+        let yaml = "name: noyalib\nrole: parser\n";
+        let cfg: Config<'_> = from_str_borrowing(yaml).unwrap();
+        let yaml_range = yaml.as_ptr() as usize..(yaml.as_ptr() as usize + yaml.len());
+        assert!(yaml_range.contains(&(cfg.name.as_ptr() as usize)));
+        assert!(yaml_range.contains(&(cfg.role.as_ptr() as usize)));
+        vec![
+            format!("name={}", cfg.name),
+            format!("role={}", cfg.role),
+            "both slices borrow directly from the yaml input".into(),
+        ]
+    });
+
+    support::task_with_output("Cow<str> accepts both borrowed and owned scalars", || {
+        let yaml = "plain: hello\nescaped: \"line\\nbreak\"\n";
+        let cfg: CowConfig<'_> = from_str_borrowing(yaml).unwrap();
+        let plain_kind = if matches!(cfg.plain, Cow::Borrowed(_)) {
+            "Cow::Borrowed"
+        } else {
+            "Cow::Owned"
+        };
+        let escaped_kind = if matches!(cfg.escaped, Cow::Borrowed(_)) {
+            "Cow::Borrowed"
+        } else {
+            "Cow::Owned"
+        };
+        vec![
+            format!("plain   = {} ({plain_kind})", cfg.plain),
+            format!("escaped = {:?} ({escaped_kind})", cfg.escaped),
+        ]
+    });
+
+    support::task_with_output("TransformReason enumerates why borrows fail", || {
+        [
+            TransformReason::EscapeSequence,
+            TransformReason::LineFold,
+            TransformReason::TagResolution,
+            TransformReason::QuotedScalar,
+            TransformReason::AliasExpansion,
+        ]
+        .iter()
+        .map(|r| format!("{r:?}: {r}"))
+        .collect()
+    });
+}

--- a/crates/noyalib/src/ariadne_adapter.rs
+++ b/crates/noyalib/src/ariadne_adapter.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! [`ariadne`] adapter for [`crate::Error`].
+//!
+//! Renders a noyalib error as an [`ariadne::Report`] with the
+//! offending byte range labelled, the line/column annotated, and
+//! the surrounding source available for terminal-friendly display.
+//! Pairs with the existing [`miette::Diagnostic`] impl for users
+//! who prefer ariadne's rendering.
+//!
+//! # Examples
+//!
+//! ```
+//! use noyalib::{from_str, Value};
+//! use noyalib::ariadne_adapter::error_to_ariadne_report;
+//! use ariadne::Source;
+//!
+//! let source = "a: [unclosed";
+//! let err = from_str::<Value>(source).unwrap_err();
+//! let report = error_to_ariadne_report(&err, "input.yaml", source);
+//! let mut buf: Vec<u8> = Vec::new();
+//! report.write(("input.yaml", Source::from(source)), &mut buf).unwrap();
+//! assert!(!buf.is_empty());
+//! ```
+
+use crate::error::{Error, Location};
+use ariadne::{Color, Label, Report, ReportKind};
+
+/// Convert a noyalib [`Error`] into an [`ariadne::Report`].
+///
+/// `filename` is the source identifier ariadne prints in the
+/// report header. `source` is the YAML input — its byte length is
+/// used to clamp the highlighted byte range so a stale or trimmed
+/// `source` never panics inside ariadne.
+///
+/// When the error has no location attached (`Error::location()`
+/// returns `None`), the resulting report is a header-only message
+/// without a source label — matching the existing
+/// [`Error::format_with_source`] fallback.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::{from_str, Value};
+/// use noyalib::ariadne_adapter::error_to_ariadne_report;
+/// use ariadne::Source;
+///
+/// let source = "a: [unclosed";
+/// let err = from_str::<Value>(source).unwrap_err();
+/// let report = error_to_ariadne_report(&err, "input.yaml", source);
+/// let mut out: Vec<u8> = Vec::new();
+/// report.write(("input.yaml", Source::from(source)), &mut out).unwrap();
+/// assert!(!out.is_empty());
+/// ```
+#[must_use]
+pub fn error_to_ariadne_report<'a>(
+    err: &Error,
+    filename: &'a str,
+    source: &str,
+) -> Report<'a, (&'a str, core::ops::Range<usize>)> {
+    let title = format!("{err}");
+    let mut builder =
+        Report::build(ReportKind::Error, (filename, 0..source.len())).with_message(title.clone());
+
+    if let Some(loc) = err.location() {
+        let span = label_span(loc, source);
+        builder = builder.with_label(
+            Label::new((filename, span))
+                .with_message(title)
+                .with_color(Color::Red),
+        );
+    }
+
+    builder.finish()
+}
+
+/// Compute a sensible byte range for the error's primary label.
+///
+/// [`Location`] carries a single byte index; ariadne wants a
+/// `Range<usize>`. We expand the index to cover the next character
+/// (so the caret doesn't render as a zero-width range) and clamp
+/// to the source bounds — never panics on a trimmed `source`.
+fn label_span(loc: Location, source: &str) -> core::ops::Range<usize> {
+    let start = loc.index().min(source.len());
+    if start >= source.len() {
+        return start..start;
+    }
+    let end = source[start..]
+        .chars()
+        .next()
+        .map_or(start + 1, |c| start + c.len_utf8())
+        .min(source.len());
+    start..end
+}

--- a/crates/noyalib/src/borrowed.rs
+++ b/crates/noyalib/src/borrowed.rs
@@ -28,6 +28,72 @@ use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::Serialize;
 
+/// Why a YAML scalar could not be borrowed directly from the input
+/// buffer and had to be materialised into an owned `String`.
+///
+/// Surfaced for users introspecting [`BorrowedValue`] / streaming
+/// deserialisation paths: when a `Cow<'a, str>` resolves to
+/// [`Cow::Owned`] instead of [`Cow::Borrowed`], one of these reasons
+/// applies. Useful in benchmarks and allocation-budget audits.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::borrowed::TransformReason;
+/// assert_eq!(TransformReason::EscapeSequence.as_str(),
+///            "scalar contained escape sequences that required decoding");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum TransformReason {
+    /// The scalar contained `\n`, `\t`, `\xNN`, `\uNNNN`, `\UNNNNNNNN`,
+    /// or other escape sequences that required decoding into a fresh
+    /// allocation.
+    EscapeSequence,
+    /// The scalar spans multiple physical lines and required line
+    /// folding (block scalar `>` or `|`, or a multi-line flow scalar).
+    LineFold,
+    /// Tag resolution materialised a fresh representation (`!!binary`
+    /// base64 decode, custom-tag dispatch via [`crate::TagRegistry`]).
+    TagResolution,
+    /// The scalar was double-quoted and contained at least one escape,
+    /// so the parser produced an owned post-escape buffer.
+    QuotedScalar,
+    /// The scalar arrived via alias replay (`*anchor`) and the replayed
+    /// buffer is owned by the alias-expansion machinery, not the input
+    /// slice.
+    AliasExpansion,
+}
+
+impl TransformReason {
+    /// A human-readable explanation suitable for inclusion in error
+    /// messages.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::borrowed::TransformReason;
+    /// assert_eq!(TransformReason::LineFold.as_str(),
+    ///            "scalar spans multiple lines and required line folding");
+    /// ```
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EscapeSequence => "scalar contained escape sequences that required decoding",
+            Self::LineFold => "scalar spans multiple lines and required line folding",
+            Self::TagResolution => "tag resolution materialised a fresh representation",
+            Self::QuotedScalar => "double-quoted scalar with escapes produced an owned buffer",
+            Self::AliasExpansion => "scalar arrived via alias replay (`*anchor`)",
+        }
+    }
+}
+
+impl core::fmt::Display for TransformReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A zero-copy YAML value that borrows strings from the input.
 ///
 /// # Examples

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -202,6 +202,38 @@ pub struct ParserConfig {
     /// is bypassed automatically so the policy contract holds for
     /// every code path.
     pub policies: Vec<Arc<dyn crate::policy::Policy>>,
+    /// `${KEY}` / `${KEY:-default}` substitution table consulted
+    /// after parsing every document.
+    ///
+    /// Each scalar in the resulting [`Value`] tree is walked and
+    /// any `${name}` placeholder is replaced with the property of
+    /// that name. Supported syntax:
+    ///
+    /// - `${name}` — substitute, error or pass through depending
+    ///   on [`Self::strict_properties`]
+    /// - `${name:-default}` — substitute, falling back to
+    ///   `default` when `name` is missing (always silent, never
+    ///   surfaces in errors)
+    /// - `${{` — literal `${` (escape for the open delimiter)
+    /// - `$$` — literal `$`
+    /// - `}}` — literal `}`
+    ///
+    /// `None` (default) disables the substitution pass entirely;
+    /// the parser is unchanged. Setting a non-empty map forces the
+    /// AST fallback so the post-parse walk runs uniformly across
+    /// every typed target.
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub properties: Option<Arc<std::collections::HashMap<String, String>>>,
+    /// When `true`, an unknown `${name}` placeholder (no entry in
+    /// [`Self::properties`] and no `:-default` fallback) aborts
+    /// the parse with [`Error::Custom`].
+    /// When `false` (default), unknown placeholders are replaced
+    /// with the empty string — the lossy semantics matching
+    /// [`Value::interpolate_properties_lossy`](crate::Value::interpolate_properties_lossy).
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub strict_properties: bool,
 }
 
 impl Default for ParserConfig {
@@ -230,6 +262,10 @@ impl Default for ParserConfig {
             legacy_sexagesimal: false,
             require_indent: RequireIndent::Unchecked,
             policies: Vec::new(),
+            #[cfg(feature = "std")]
+            properties: None,
+            #[cfg(feature = "std")]
+            strict_properties: false,
         }
     }
 }
@@ -285,7 +321,74 @@ impl ParserConfig {
             legacy_sexagesimal: false,
             require_indent: RequireIndent::Even,
             policies: Vec::new(),
+            #[cfg(feature = "std")]
+            properties: None,
+            #[cfg(feature = "std")]
+            strict_properties: true,
         }
+    }
+
+    /// Install a `${KEY}` substitution table consulted after
+    /// parsing.
+    ///
+    /// Each scalar in the resulting [`Value`] tree is walked and
+    /// any `${name}` placeholder is replaced with the property of
+    /// that name. Pairs with [`Self::strict_properties`] to choose
+    /// between erroring or silently empty-substituting on unknown
+    /// keys, and with `${name:-default}` syntax for inline
+    /// defaults.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::{from_str_with_config, ParserConfig, Value};
+    /// use std::collections::HashMap;
+    /// use std::sync::Arc;
+    ///
+    /// let mut props = HashMap::new();
+    /// props.insert("HOST".to_string(), "localhost".to_string());
+    /// let cfg = ParserConfig::new().properties(Arc::new(props));
+    /// let v: Value = from_str_with_config("url: http://${HOST}/", &cfg).unwrap();
+    /// assert_eq!(v["url"].as_str(), Some("http://localhost/"));
+    /// ```
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[must_use]
+    pub fn properties(
+        mut self,
+        properties: Arc<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.properties = Some(properties);
+        self
+    }
+
+    /// Toggle strict-mode placeholder resolution.
+    ///
+    /// When `true`, an unknown `${name}` (no map entry, no
+    /// `:-default` fallback) aborts the parse. When `false`
+    /// (default), unknown placeholders are replaced with the empty
+    /// string — useful for environment-style configs where missing
+    /// variables should silently degrade.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::{from_str_with_config, ParserConfig, Value};
+    /// use std::collections::HashMap;
+    /// use std::sync::Arc;
+    ///
+    /// let cfg = ParserConfig::new()
+    ///     .properties(Arc::new(HashMap::new()))
+    ///     .strict_properties(true);
+    /// let res: Result<Value, _> = from_str_with_config("x: ${MISSING}", &cfg);
+    /// assert!(res.is_err());
+    /// ```
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    #[must_use]
+    pub fn strict_properties(mut self, strict: bool) -> Self {
+        self.strict_properties = strict;
+        self
     }
 
     /// Select the YAML specification version the resolver should
@@ -1184,10 +1287,12 @@ where
     // - `!!binary` is propagated as a typed tag.
     // When the caller asked for a non-default behaviour on either
     // axis, route through the AST loader so the relevant toggle
-    // takes effect.
+    // takes effect. Active `properties` interpolation also disables
+    // the streaming path so the post-parse substitution walk runs.
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
-        && config.policies.is_empty();
+        && config.policies.is_empty()
+        && properties_inactive(config);
     if stream_eligible {
         if let Some(res) = crate::streaming::from_str_streaming(s, config) {
             return res;
@@ -1208,7 +1313,8 @@ where
     // provably correct because `is_value_target::<T>()` already
     // verified `TypeId::of::<T>() == TypeId::of::<Value>()`.
     if is_value_target::<T>() {
-        let value = parser::parse_one_value(s, &parse_config)?;
+        let mut value = parser::parse_one_value(s, &parse_config)?;
+        apply_properties(&mut value, config)?;
         for p in &config.policies {
             p.check_value(&value)?;
         }
@@ -1225,7 +1331,8 @@ where
 
     #[cfg(feature = "std")]
     {
-        let (value, span_tree) = parser::parse_one(s, &parse_config)?;
+        let (mut value, span_tree) = parser::parse_one(s, &parse_config)?;
+        apply_properties(&mut value, config)?;
         for p in &config.policies {
             p.check_value(&value)?;
         }
@@ -1249,6 +1356,53 @@ where
         let de = Deserializer::with_options(&value, None, config.ignore_binary_tag_for_string);
         T::deserialize(de)
     }
+}
+
+/// Returns `true` when no `${KEY}` substitution table is active —
+/// keeps the streaming fast-path eligible. Always `true` under
+/// `no_std` (the field doesn't exist).
+#[cfg(feature = "std")]
+#[inline]
+fn properties_inactive(config: &ParserConfig) -> bool {
+    config.properties.is_none()
+}
+
+#[cfg(not(feature = "std"))]
+#[inline]
+fn properties_inactive(_config: &ParserConfig) -> bool {
+    true
+}
+
+/// Walk the `Value` tree and substitute every `${name}` placeholder
+/// against `config.properties`. No-op when no map is installed; in
+/// `no_std` builds the function is also a no-op (the field doesn't
+/// exist). Honours `strict_properties` for the missing-key
+/// behaviour, but always propagates *syntax* errors from the
+/// substitution walk (invalid characters, unterminated `${...}`,
+/// malformed `:-default`) regardless of mode.
+#[cfg(feature = "std")]
+fn apply_properties(value: &mut Value, config: &ParserConfig) -> Result<()> {
+    if let Some(props) = config.properties.as_ref() {
+        let action = if config.strict_properties {
+            crate::value::MissingAction::Error(false)
+        } else {
+            crate::value::MissingAction::Empty
+        };
+        value.interpolate_inner(
+            &|name| match props.get(name) {
+                Some(v) => crate::value::ResolveOutcome::Found(v.clone()),
+                None => crate::value::ResolveOutcome::Missing,
+            },
+            action,
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "std"))]
+#[inline]
+fn apply_properties(_value: &mut Value, _config: &ParserConfig) -> Result<()> {
+    Ok(())
 }
 
 /// Deserialize YAML from a byte slice.

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -859,6 +859,87 @@ where
     from_str_with_config(s, &ParserConfig::default())
 }
 
+/// Deserialise a YAML document into a target type that may borrow
+/// from the input slice (e.g. `&'a str`, `Cow<'a, str>`, structs
+/// containing those).
+///
+/// Where [`from_str`] requires `T: DeserializeOwned + 'static` and
+/// therefore can never satisfy `Deserialize<'de> for &'de str`, this
+/// function pins the deserialiser's lifetime to the input buffer's
+/// lifetime. Plain (unquoted) and unescaped quoted scalars are
+/// surfaced via `visit_borrowed_str`, allowing zero-copy borrows.
+/// Scalars that required transformation (escape decoding, line
+/// folding, alias replay, tag resolution) fall back to owned
+/// allocations — see [`crate::borrowed::TransformReason`] for the
+/// catalogue of transform causes.
+///
+/// # Errors
+///
+/// Returns an error if `s` is not valid YAML, exceeds the default
+/// security limits, or cannot be deserialised into `T`. When `T`
+/// targets `&'a str` and the YAML scalar required transformation,
+/// serde's `&str` visitor surfaces an `invalid type: string,
+/// expected a borrowed string` error — switch the target to
+/// `Cow<'a, str>` or `String` to accept either form.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::from_str_borrowing;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct Person<'a> {
+///     name: &'a str,
+///     role: &'a str,
+/// }
+///
+/// let yaml = "name: noyalib\nrole: parser\n";
+/// let p: Person<'_> = from_str_borrowing(yaml).unwrap();
+/// assert_eq!(p.name, "noyalib");
+/// assert_eq!(p.role, "parser");
+/// ```
+pub fn from_str_borrowing<'a, T>(s: &'a str) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    from_str_borrowing_with_config(s, &ParserConfig::default())
+}
+
+/// [`from_str_borrowing`] with a custom [`ParserConfig`] — typically
+/// to tighten security limits for untrusted input.
+///
+/// # Errors
+///
+/// Returns an error if `s` is not valid YAML under the supplied
+/// config or cannot be deserialised into `T`.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::{from_str_borrowing_with_config, ParserConfig};
+/// let cfg = ParserConfig::strict();
+/// let s: &str = from_str_borrowing_with_config("hello\n", &cfg).unwrap();
+/// assert_eq!(s, "hello");
+/// ```
+pub fn from_str_borrowing_with_config<'a, T>(s: &'a str, config: &ParserConfig) -> Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let parse_config = parser::ParseConfig::from(config);
+    if s.len() > parse_config.max_document_length {
+        return Err(Error::Parse(format!(
+            "document exceeds maximum length of {} bytes",
+            parse_config.max_document_length
+        )));
+    }
+    let mut de = crate::streaming::StreamingDeserializer::with_config(s, parse_config);
+    if let Some(registry) = config.tag_registry.as_ref() {
+        de = de.with_tag_registry(Arc::clone(registry));
+    }
+    T::deserialize(&mut de)
+}
+
 /// Compile-time-ish check: is the deserialise target `T` exactly
 /// [`Value`]? Used by [`from_str_with_config`] / [`from_value`]
 /// to enable the tag-preserving fast-path on

--- a/crates/noyalib/src/document.rs
+++ b/crates/noyalib/src/document.rs
@@ -22,7 +22,7 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use crate::de::ParserConfig;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::parser;
 use crate::prelude::*;
 #[cfg(feature = "std")]
@@ -30,6 +30,7 @@ use crate::span_context::{self, SpanTree};
 use crate::value::Value;
 #[cfg(not(feature = "std"))]
 use alloc::vec::IntoIter;
+use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::vec::IntoIter;
 
@@ -140,7 +141,7 @@ pub fn load_all(input: &str) -> Result<DocumentIterator> {
 /// ```
 pub fn load_all_with_config(input: &str, config: &ParserConfig) -> Result<DocumentIterator> {
     if input.len() > config.max_document_length {
-        return Err(crate::error::Error::Parse(format!(
+        return Err(Error::Parse(format!(
             "document exceeds maximum length of {} bytes",
             config.max_document_length
         )));
@@ -262,4 +263,175 @@ where
         }
         Ok(results)
     }
+}
+
+/// Lazy iterator that yields `Result<T>` per YAML document parsed
+/// from a reader.
+///
+/// Created by [`read`] / [`read_with_config`]. Deserialisation
+/// errors on individual documents are surfaced as `Err` values; the
+/// iterator continues so callers can recover and process subsequent
+/// documents. Syntax errors during the initial parse are returned
+/// from [`read`] / [`read_with_config`] before iteration starts.
+///
+/// # Memory
+///
+/// Today the reader is fully drained into a `String` before the
+/// underlying parser runs, so memory is `O(input_len)`. True
+/// `O(1)`-document streaming requires a parser-level rewrite that
+/// can accept incremental byte chunks; that work is tracked
+/// separately.
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct DocumentReadIterator<T> {
+    docs: IntoIter<Value>,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+#[cfg(feature = "std")]
+impl<T> DocumentReadIterator<T> {
+    /// Total number of documents pending iteration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// let yaml = "a: 1\n---\nb: 2\n";
+    /// let iter: noyalib::DocumentReadIterator<noyalib::Value> =
+    ///     noyalib::read(Cursor::new(yaml)).unwrap();
+    /// assert_eq!(iter.len(), 2);
+    /// ```
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.docs.len()
+    }
+
+    /// Whether the iterator has no further documents.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// let iter: noyalib::DocumentReadIterator<noyalib::Value> =
+    ///     noyalib::read(Cursor::new("")).unwrap();
+    /// assert!(iter.is_empty());
+    /// ```
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.docs.len() == 0
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Iterator for DocumentReadIterator<T>
+where
+    T: for<'de> serde::Deserialize<'de> + 'static,
+{
+    type Item = Result<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.docs.next()?;
+        Some(crate::from_value(&value))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.docs.size_hint()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> ExactSizeIterator for DocumentReadIterator<T> where
+    T: for<'de> serde::Deserialize<'de> + 'static
+{
+}
+
+/// Stream-decode every YAML document from a reader into typed
+/// values, yielding one `Result<T>` per document.
+///
+/// The reader is drained eagerly (see [`DocumentReadIterator`] for
+/// the memory caveat); document-by-document deserialisation is then
+/// produced lazily on demand. Per-document deserialisation errors
+/// surface as `Err` values inside the iterator so callers can
+/// recover and continue. A syntax error in the underlying YAML is
+/// returned synchronously from this function before any iteration
+/// happens.
+///
+/// # Errors
+///
+/// Returns an error if the reader fails, the YAML cannot be parsed,
+/// or any document exceeds the default security limits. Per-document
+/// deserialisation errors are *not* surfaced here; they appear
+/// inside the iterator.
+///
+/// # Examples
+///
+/// ```
+/// use std::io::Cursor;
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize, PartialEq)]
+/// struct Doc { id: u32 }
+///
+/// let yaml = "id: 1\n---\nid: 2\n---\nid: 3\n";
+/// let docs: Vec<Doc> = noyalib::read::<_, Doc>(Cursor::new(yaml))
+///     .unwrap()
+///     .filter_map(Result::ok)
+///     .collect();
+/// assert_eq!(docs, vec![Doc { id: 1 }, Doc { id: 2 }, Doc { id: 3 }]);
+/// ```
+#[cfg(feature = "std")]
+pub fn read<R, T>(reader: R) -> Result<DocumentReadIterator<T>>
+where
+    R: std::io::Read,
+    T: for<'de> serde::Deserialize<'de> + 'static,
+{
+    read_with_config(reader, &ParserConfig::default())
+}
+
+/// [`read`] with a custom [`ParserConfig`] for tightened security
+/// limits.
+///
+/// # Errors
+///
+/// Same as [`read`].
+///
+/// # Examples
+///
+/// ```
+/// use std::io::Cursor;
+/// use noyalib::{read_with_config, ParserConfig, Value};
+///
+/// let cfg = ParserConfig::strict();
+/// let yaml = "a: 1\n---\nb: 2\n";
+/// let count = read_with_config::<_, Value>(Cursor::new(yaml), &cfg)
+///     .unwrap()
+///     .count();
+/// assert_eq!(count, 2);
+/// ```
+#[cfg(feature = "std")]
+pub fn read_with_config<R, T>(
+    mut reader: R,
+    config: &ParserConfig,
+) -> Result<DocumentReadIterator<T>>
+where
+    R: std::io::Read,
+    T: for<'de> serde::Deserialize<'de> + 'static,
+{
+    let mut buf = String::new();
+    let _read_bytes = reader
+        .read_to_string(&mut buf)
+        .map_err(|e| Error::Parse(format!("reader I/O failed: {e}")))?;
+    if buf.len() > config.max_document_length.saturating_mul(64) {
+        // Soft cap on the *aggregated* multi-document buffer to
+        // bound memory regardless of per-document caps.
+        return Err(Error::Parse(format!(
+            "reader payload exceeds 64× max_document_length ({} bytes)",
+            config.max_document_length
+        )));
+    }
+    let parse_config = parser::ParseConfig::from(config);
+    let pairs = parser::parse(&buf, &parse_config)?;
+    let docs: Vec<Value> = pairs.into_iter().map(|(value, _)| value).collect();
+    Ok(DocumentReadIterator {
+        docs: docs.into_iter(),
+        _phantom: PhantomData,
+    })
 }

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -399,9 +399,23 @@ pub(crate) mod prelude {
 }
 
 mod anchors;
+/// Zero-copy YAML values that borrow from the input.
+/// [`ariadne`] adapter — render `crate::Error` as an
+/// `ariadne::Report` with the offending byte range labelled.
+/// Behind the `ariadne` Cargo feature.
+#[cfg(feature = "ariadne")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ariadne")))]
+pub mod ariadne_adapter;
 /// Internal RFC 4648 base64 codec for `!!binary` scalars.
 mod base64;
-/// Zero-copy YAML values that borrow from the input.
+
+/// `Spanned<T>` + garde / validator → `miette::Report` bridge.
+/// Behind the `miette` Cargo feature; the actual conversion
+/// functions are gated on `miette + garde` or `miette + validator`.
+#[cfg(feature = "miette")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
+pub mod validated_miette;
+
 pub mod borrowed;
 mod comments;
 /// Drop-in compatibility shims for upstream YAML crates. Each shim

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -500,10 +500,13 @@ pub use de::{from_reader, from_reader_with_config};
 #[cfg(all(feature = "std", feature = "strict-deserialise"))]
 pub use de::{from_reader_strict, from_slice_strict, from_str_strict};
 pub use de::{
-    from_slice, from_slice_with_config, from_str, from_str_with_config, from_value, Deserializer,
+    from_slice, from_slice_with_config, from_str, from_str_borrowing,
+    from_str_borrowing_with_config, from_str_with_config, from_value, Deserializer,
     DuplicateKeyPolicy, MergeKeyPolicy, ParserConfig, YamlVersion,
 };
 pub use document::{load_all, load_all_as, load_all_with_config, try_load_all};
+#[cfg(feature = "std")]
+pub use document::{read, read_with_config, DocumentReadIterator};
 pub use error::{BudgetBreach, CroppedRegion, Error, Location, RenderOptions, Result};
 pub use flattened::Flattened;
 pub use fmt::{Commented, FlowMap, FlowSeq, FoldStr, FoldString, LitStr, LitString, SpaceAfter};

--- a/crates/noyalib/src/parser/scanner.rs
+++ b/crates/noyalib/src/parser/scanner.rs
@@ -2137,16 +2137,56 @@ impl<'a> Scanner<'a> {
                 len += 1;
             }
 
-            if is_single_line && len > 0 {
-                let s = Cow::Borrowed(self.slice_str(self.pos, self.pos + len));
-                self.advance_by(len);
-                self.emit(TokenKind::Scalar(ScalarStyle::Plain, s));
-                self.last_token_opens_block = false;
-                return Ok(());
+            // The fast path can also fire when the scalar terminates
+            // before the next newline (e.g. on a `:`, trailing
+            // whitespace, or comment), even though `is_single_line`
+            // was flipped to `false` because *some* newline exists
+            // farther down the input. The line-folding slow path is
+            // only required when the scalar runs right up to the
+            // newline and might continue on the next line — i.e.
+            // `len == search_end` *and* `search_end` landed on a
+            // line break. Whenever `len < search_end` we know the
+            // scalar is fully bounded on the current line, so the
+            // input slice can be emitted directly as
+            // `Cow::Borrowed`. This unblocks zero-copy
+            // `Deserialize<'de> for &'de str` for the typical
+            // `key: value\n` shape.
+            let scalar_terminates_on_line = len < search_end;
+            if (is_single_line || scalar_terminates_on_line) && len > 0 {
+                // Strip trailing inline whitespace before a flow
+                // indicator (`}`, `]`, `,`). The inner-scan loop
+                // folds those blanks into `len` (line ~2134 above)
+                // because they may precede more content on the
+                // current line. When they do not, the slow path
+                // would emit just the content; mirror that here so
+                // the borrowed slice matches the owned-buffer
+                // result byte-for-byte. The scanner position still
+                // advances past the whitespace so downstream tokens
+                // line up.
+                let mut content_len = len;
+                while content_len > 0 && matches!(remaining[content_len - 1], b' ' | b'\t') {
+                    content_len -= 1;
+                }
+                if content_len > 0 {
+                    let s = Cow::Borrowed(self.slice_str(self.pos, self.pos + content_len));
+                    self.advance_by(len);
+                    self.emit(TokenKind::Scalar(ScalarStyle::Plain, s));
+                    self.last_token_opens_block = false;
+                    return Ok(());
+                }
             }
         }
 
         // ── Slow path: multiline plain scalar with line folding ──────
+        let scalar_start = self.pos;
+        let mut content_end = self.pos;
+        // Track whether the scalar is built from a single contiguous
+        // run of input bytes (no folded line breaks). If so we can
+        // emit `Cow::Borrowed(slice)` instead of allocating an owned
+        // `String`. Flipped to `false` the first time the
+        // line-folding branch synthesises a space / newline that
+        // does not exist verbatim in the input.
+        let mut single_chunk = true;
         let mut string = String::new();
         let mut leading_blanks = false;
         let mut whitespace = String::new();
@@ -2223,6 +2263,11 @@ impl<'a> Scanner<'a> {
             // Append characters.
             if length > 0 {
                 if leading_blanks {
+                    // Crossing a line break and synthesising folded
+                    // whitespace means the emitted string no longer
+                    // matches the input slice byte-for-byte. Switch
+                    // to the owned-buffer path.
+                    single_chunk = false;
                     // Handle line joins.
                     if let Some(stripped) = whitespace.strip_prefix('\n') {
                         if stripped.is_empty() {
@@ -2236,12 +2281,16 @@ impl<'a> Scanner<'a> {
                     }
                     whitespace.clear();
                 } else if !whitespace.is_empty() {
+                    // Inline whitespace — already part of the input
+                    // slice between the previous content_end and
+                    // self.pos, so `single_chunk` stays true.
                     string.push_str(&whitespace);
                     whitespace.clear();
                 }
 
                 string.push_str(self.slice_str(self.pos, self.pos + length));
                 self.advance_by(length);
+                content_end = self.pos;
             }
 
             // Skip whitespace/newlines between plain scalar content.
@@ -2300,7 +2349,15 @@ impl<'a> Scanner<'a> {
             self.simple_key_allowed = true;
         }
 
-        self.emit(TokenKind::Scalar(ScalarStyle::Plain, Cow::Owned(string)));
+        // Borrow when the entire scalar is a single contiguous run of
+        // input bytes (no line-folding synthesis). Else fall back to
+        // the owned buffer that was accumulated above.
+        let value = if single_chunk {
+            Cow::Borrowed(self.slice_str(scalar_start, content_end))
+        } else {
+            Cow::Owned(string)
+        };
+        self.emit(TokenKind::Scalar(ScalarStyle::Plain, value));
         self.last_token_opens_block = false;
         Ok(())
     }

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -626,12 +626,22 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
             }
         }
         match self.next_event()? {
-            Event::Scalar { value, style, .. } => match self.resolve_scalar(&value, style) {
-                Scalar::Null => visitor.visit_none(),
-                Scalar::Bool(b) => visitor.visit_bool(b),
-                Scalar::Int(n) => visitor.visit_i64(n),
-                Scalar::Float(f) => visitor.visit_f64(f),
-                Scalar::Str(s) => visitor.visit_str(&s),
+            Event::Scalar { value, style, .. } => match value {
+                Cow::Borrowed(s) => match self.resolve_scalar(s, style) {
+                    Scalar::Null => visitor.visit_none(),
+                    Scalar::Bool(b) => visitor.visit_bool(b),
+                    Scalar::Int(n) => visitor.visit_i64(n),
+                    Scalar::Float(f) => visitor.visit_f64(f),
+                    Scalar::Str(Cow::Borrowed(b)) => visitor.visit_borrowed_str(b),
+                    Scalar::Str(Cow::Owned(o)) => visitor.visit_string(o),
+                },
+                Cow::Owned(s) => match self.resolve_scalar(&s, style) {
+                    Scalar::Null => visitor.visit_none(),
+                    Scalar::Bool(b) => visitor.visit_bool(b),
+                    Scalar::Int(n) => visitor.visit_i64(n),
+                    Scalar::Float(f) => visitor.visit_f64(f),
+                    Scalar::Str(_) => visitor.visit_string(s),
+                },
             },
             Event::SequenceStart { .. } => {
                 self.depth += 1;
@@ -764,24 +774,39 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
         match self.peek_event()? {
             Event::Scalar { .. } => {
                 if let Event::Scalar { value, style, .. } = self.next_event()? {
-                    // Raw-str mode (used for map keys) accepts any scalar
-                    // as a string so keys like `42` or `true` come through
-                    // as textual. Otherwise, non-string plain scalars
-                    // (integers, bools, floats, null) should error so
-                    // typed fields don't silently coerce values.
+                    // When the scalar borrows directly from the input
+                    // (`Cow::Borrowed`), preserve the `'de` lifetime by
+                    // calling `visit_borrowed_str`. This unlocks
+                    // zero-copy `Deserialize<'de> for &'de str` without
+                    // routing through the `Value` AST.
                     if self.raw_str_mode {
-                        return visitor.visit_str(&value);
+                        return match value {
+                            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+                            Cow::Owned(s) => visitor.visit_string(s),
+                        };
                     }
-                    // Non-plain (quoted / block) scalars are always strings.
                     if style != ScalarStyle::Plain {
-                        return visitor.visit_str(&value);
+                        return match value {
+                            Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+                            Cow::Owned(s) => visitor.visit_string(s),
+                        };
                     }
-                    match self.resolve_scalar(&value, style) {
-                        Scalar::Str(s) => visitor.visit_str(&s),
-                        _ => Err(Error::TypeMismatch {
-                            expected: "string",
-                            found: "non-string scalar".into(),
-                        }),
+                    match value {
+                        Cow::Borrowed(s) => match self.resolve_scalar(s, style) {
+                            Scalar::Str(Cow::Borrowed(b)) => visitor.visit_borrowed_str(b),
+                            Scalar::Str(Cow::Owned(o)) => visitor.visit_string(o),
+                            _ => Err(Error::TypeMismatch {
+                                expected: "string",
+                                found: "non-string scalar".into(),
+                            }),
+                        },
+                        Cow::Owned(s) => match self.resolve_scalar(&s, style) {
+                            Scalar::Str(_) => visitor.visit_string(s),
+                            _ => Err(Error::TypeMismatch {
+                                expected: "string",
+                                found: "non-string scalar".into(),
+                            }),
+                        },
                     }
                 } else {
                     Err(Error::TypeMismatch {
@@ -1002,7 +1027,10 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, .. } = self.next_event()? {
-            return visitor.visit_str(&value);
+            return match value {
+                Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
+                Cow::Owned(s) => visitor.visit_string(s),
+            };
         }
         Err(Error::TypeMismatch {
             expected: "identifier",

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -265,4 +265,3 @@ pub fn clamped_span(start: usize, end: usize, source_len: usize) -> miette::Sour
     };
     (s, e - s).into()
 }
-

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -20,12 +20,20 @@
 //! visible at the call site and avoid leaking miette into every
 //! `Spanned<T>` user.
 
-use crate::error::Location;
+#[allow(unused_imports)]
 use crate::prelude::*;
+#[allow(unused_imports)]
 use crate::spanned::Spanned;
 
 /// Range covering the entire `Spanned<T>` payload, clamped to the
 /// supplied `source` length so a stale snippet never panics.
+///
+/// Only defined when `garde` or `validator` is on — those are the
+/// features that bring callers (`garde_errors_to_miette` /
+/// `validator_errors_to_miette`). Otherwise the body would be
+/// dead code on a `miette`-only build (e.g. enabled transitively
+/// by `noyalib-lsp`'s `validate-schema`).
+#[cfg(any(feature = "garde", feature = "validator"))]
 fn spanned_byte_range<T>(spanned: &Spanned<T>, source: &str) -> core::ops::Range<usize> {
     let len = source.len();
     let start = spanned.start.index().min(len);
@@ -44,9 +52,11 @@ fn spanned_byte_range<T>(spanned: &Spanned<T>, source: &str) -> core::ops::Range
 /// source-context, labelled span, and helpful one-line summary
 /// when fed through `miette::ReportHandler`. Display + Error
 /// impls are hand-rolled to keep `thiserror` out of the
-/// dependency closure (matches the policy in `error.rs`).
-#[cfg(feature = "miette")]
-#[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
+/// dependency closure (matches the policy in `error.rs`). Only
+/// compiled when at least one validator framework is enabled —
+/// otherwise the type would be dead code on a `miette`-only
+/// build.
+#[cfg(any(feature = "garde", feature = "validator"))]
 #[derive(Debug)]
 struct ValidationDiagnostic {
     summary: String,
@@ -54,7 +64,7 @@ struct ValidationDiagnostic {
     span: miette::SourceSpan,
 }
 
-#[cfg(feature = "miette")]
+#[cfg(any(feature = "garde", feature = "validator"))]
 impl ValidationDiagnostic {
     fn new<T>(spanned: &Spanned<T>, source: String, summary: String, name: String) -> Self {
         let range = spanned_byte_range(spanned, &source);
@@ -67,17 +77,17 @@ impl ValidationDiagnostic {
     }
 }
 
-#[cfg(feature = "miette")]
+#[cfg(any(feature = "garde", feature = "validator"))]
 impl core::fmt::Display for ValidationDiagnostic {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(&self.summary)
     }
 }
 
-#[cfg(feature = "miette")]
+#[cfg(any(feature = "garde", feature = "validator"))]
 impl std::error::Error for ValidationDiagnostic {}
 
-#[cfg(feature = "miette")]
+#[cfg(any(feature = "garde", feature = "validator"))]
 impl miette::Diagnostic for ValidationDiagnostic {
     fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
         Some(Box::new("noyalib::validated"))
@@ -256,5 +266,3 @@ pub fn clamped_span(start: usize, end: usize, source_len: usize) -> miette::Sour
     (s, e - s).into()
 }
 
-#[allow(dead_code)]
-fn _location_proof(_l: Location) {}

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! [`Spanned<T>`] + `garde` / `validator` → [`miette::Report`]
+//! bridge.
+//!
+//! Walks a validation error tree produced by [`garde::Report`] or
+//! [`validator::ValidationErrors`] and emits a single
+//! [`miette::Report`] whose source label points at the
+//! corresponding [`Spanned<T>`] range — enabling beautiful,
+//! line-and-column-precise output for declarative validation
+//! failures.
+//!
+//! Behind feature combinations:
+//! * [`garde_errors_to_miette`] requires `miette` + `garde`
+//! * [`validator_errors_to_miette`] requires `miette` + `validator`
+//!
+//! These functions are deliberately free-standing rather than
+//! impls on [`crate::Spanned`] to keep the dependency surface
+//! visible at the call site and avoid leaking miette into every
+//! `Spanned<T>` user.
+
+use crate::error::Location;
+use crate::prelude::*;
+use crate::spanned::Spanned;
+
+/// Range covering the entire `Spanned<T>` payload, clamped to the
+/// supplied `source` length so a stale snippet never panics.
+fn spanned_byte_range<T>(spanned: &Spanned<T>, source: &str) -> core::ops::Range<usize> {
+    let len = source.len();
+    let start = spanned.start.index().min(len);
+    let end = spanned.end.index().max(start).min(len);
+    // Ariadne / miette both expect a non-empty range to draw a label.
+    if end == start {
+        return start..(start + 1).min(len.max(start + 1));
+    }
+    start..end
+}
+
+/// What the bridge produces — boxed as `miette::Report` so callers
+/// can chain it through `Result<_, miette::Report>` workflows.
+///
+/// Implements [`miette::Diagnostic`] so it renders with full
+/// source-context, labelled span, and helpful one-line summary
+/// when fed through `miette::ReportHandler`. Display + Error
+/// impls are hand-rolled to keep `thiserror` out of the
+/// dependency closure (matches the policy in `error.rs`).
+#[cfg(feature = "miette")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
+#[derive(Debug)]
+struct ValidationDiagnostic {
+    summary: String,
+    src: miette::NamedSource<String>,
+    span: miette::SourceSpan,
+}
+
+#[cfg(feature = "miette")]
+impl ValidationDiagnostic {
+    fn new<T>(spanned: &Spanned<T>, source: String, summary: String, name: String) -> Self {
+        let range = spanned_byte_range(spanned, &source);
+        let span: miette::SourceSpan = (range.start, range.end - range.start).into();
+        Self {
+            summary,
+            src: miette::NamedSource::new(name, source),
+            span,
+        }
+    }
+}
+
+#[cfg(feature = "miette")]
+impl core::fmt::Display for ValidationDiagnostic {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.summary)
+    }
+}
+
+#[cfg(feature = "miette")]
+impl std::error::Error for ValidationDiagnostic {}
+
+#[cfg(feature = "miette")]
+impl miette::Diagnostic for ValidationDiagnostic {
+    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        Some(Box::new("noyalib::validated"))
+    }
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.src)
+    }
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Some(Box::new(core::iter::once(
+            miette::LabeledSpan::new_with_span(
+                Some("validation failed here".to_string()),
+                self.span,
+            ),
+        )))
+    }
+}
+
+/// Render a [`garde::Report`] tree against a [`Spanned<T>`] payload
+/// as a [`miette::Report`].
+///
+/// The error message is the compact single-line summary garde's
+/// own walker produces (path → message pairs joined with `;`); the
+/// source label points at the supplied `Spanned<T>`'s byte range.
+/// `name` is the source identifier shown in the report header
+/// (typically a filename).
+///
+/// # Examples
+///
+/// ```ignore
+/// use noyalib::Spanned;
+/// use noyalib::validated_miette::garde_errors_to_miette;
+/// use garde::Validate;
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize, Validate)]
+/// struct Cfg {
+///     #[garde(range(min = 1024))]
+///     port: u16,
+/// }
+///
+/// let yaml = "port: 22\n";
+/// let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+/// if let Err(errs) = wrapped.value.validate() {
+///     let report = garde_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+///     // `report.to_string()` carries the rendered diagnostic.
+///     drop(report);
+/// }
+/// ```
+#[cfg(all(feature = "miette", feature = "garde"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "miette", feature = "garde"))))]
+#[must_use]
+pub fn garde_errors_to_miette<T>(
+    spanned: &Spanned<T>,
+    errors: &garde::Report,
+    source: &str,
+    name: impl Into<String>,
+) -> miette::Report {
+    let summary = format_garde(errors);
+    let diag = ValidationDiagnostic::new(spanned, source.to_string(), summary, name.into());
+    miette::Report::new(diag)
+}
+
+/// Render a [`validator::ValidationErrors`] against a
+/// [`Spanned<T>`] payload as a [`miette::Report`].
+///
+/// Mirrors [`garde_errors_to_miette`] for the `validator` crate.
+///
+/// # Examples
+///
+/// ```ignore
+/// use noyalib::Spanned;
+/// use noyalib::validated_miette::validator_errors_to_miette;
+/// use serde::Deserialize;
+/// use validator::Validate;
+///
+/// #[derive(Debug, Deserialize, Validate)]
+/// struct Cfg {
+///     #[validate(range(min = 1024))]
+///     port: u16,
+/// }
+///
+/// let yaml = "port: 22\n";
+/// let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+/// if let Err(errs) = wrapped.value.validate() {
+///     let report = validator_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+///     drop(report);
+/// }
+/// ```
+#[cfg(all(feature = "miette", feature = "validator"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "miette", feature = "validator"))))]
+#[must_use]
+pub fn validator_errors_to_miette<T>(
+    spanned: &Spanned<T>,
+    errors: &validator::ValidationErrors,
+    source: &str,
+    name: impl Into<String>,
+) -> miette::Report {
+    let summary = format_validator(errors);
+    let diag = ValidationDiagnostic::new(spanned, source.to_string(), summary, name.into());
+    miette::Report::new(diag)
+}
+
+#[cfg(feature = "garde")]
+fn format_garde(errors: &garde::Report) -> String {
+    use core::fmt::Write as _;
+    let mut out = String::with_capacity(64);
+    out.push_str("validation failed: ");
+    let mut first = true;
+    for (path, error) in errors.iter() {
+        if !first {
+            out.push_str("; ");
+        }
+        first = false;
+        let _ = write!(out, "{path}: {error}");
+    }
+    if first {
+        out.push_str("<no details>");
+    }
+    out
+}
+
+#[cfg(feature = "validator")]
+fn format_validator(errors: &validator::ValidationErrors) -> String {
+    use core::fmt::Write as _;
+    let mut out = String::with_capacity(64);
+    out.push_str("validation failed: ");
+    let mut first = true;
+    for (field, errs) in errors.field_errors() {
+        if !first {
+            out.push_str("; ");
+        }
+        first = false;
+        let _ = write!(out, "{field}: ");
+        let mut f_first = true;
+        for e in errs {
+            if !f_first {
+                out.push_str(", ");
+            }
+            f_first = false;
+            let _ = write!(out, "{e}");
+        }
+    }
+    if first {
+        out.push_str("<no details>");
+    }
+    out
+}
+
+/// Helper: clamp a span end so it never lands before its start.
+/// Exposed for [`crate::Spanned`] integrations that compute their
+/// own byte range and want to plug straight into a miette source
+/// span without re-implementing the clamp.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "miette")]
+/// # {
+/// use noyalib::validated_miette::clamped_span;
+/// let span: miette::SourceSpan = clamped_span(10, 20, 100);
+/// assert_eq!(span.offset(), 10);
+/// assert_eq!(span.len(), 10);
+/// # }
+/// ```
+#[cfg(feature = "miette")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
+#[must_use]
+pub fn clamped_span(start: usize, end: usize, source_len: usize) -> miette::SourceSpan {
+    let s = start.min(source_len);
+    let e = end.max(s).min(source_len);
+    let e = if e == s {
+        (s + 1).min(source_len.max(s + 1))
+    } else {
+        e
+    };
+    (s, e - s).into()
+}
+
+#[allow(dead_code)]
+fn _location_proof(_l: Location) {}

--- a/crates/noyalib/src/value.rs
+++ b/crates/noyalib/src/value.rs
@@ -3264,16 +3264,13 @@ impl Value {
     where
         S: AsRef<str>,
     {
-        self.interpolate_inner(&|name| {
-            properties
-                .get(name)
-                .map(|s| s.as_ref().to_owned())
-                .ok_or_else(|| {
-                    crate::Error::Custom(format!(
-                        "interpolate_properties: unknown placeholder `${{{name}}}`"
-                    ))
-                })
-        })
+        self.interpolate_inner(
+            &|name| match properties.get(name) {
+                Some(v) => ResolveOutcome::Found(v.as_ref().to_owned()),
+                None => ResolveOutcome::Missing,
+            },
+            MissingAction::Error(false),
+        )
     }
 
     /// Like [`Value::interpolate_properties`] but redacts the
@@ -3315,16 +3312,13 @@ impl Value {
     where
         S: AsRef<str>,
     {
-        self.interpolate_inner(&|name| {
-            properties
-                .get(name)
-                .map(|s| s.as_ref().to_owned())
-                .ok_or_else(|| {
-                    crate::Error::Custom(
-                        "interpolate_properties: unknown placeholder `${<redacted>}`".into(),
-                    )
-                })
-        })
+        self.interpolate_inner(
+            &|name| match properties.get(name) {
+                Some(v) => ResolveOutcome::Found(v.as_ref().to_owned()),
+                None => ResolveOutcome::Missing,
+            },
+            MissingAction::Error(true),
+        )
     }
 
     /// Like [`Value::interpolate_properties`] but never errors —
@@ -3354,42 +3348,49 @@ impl Value {
     ) where
         S: AsRef<str>,
     {
-        // Resolver returns Ok("") for missing entries — never
-        // errors, so the outer call is total.
-        let _ = self.interpolate_inner(&|name| {
-            Ok(properties
-                .get(name)
-                .map(|s| s.as_ref().to_owned())
-                .unwrap_or_default())
-        });
+        // Missing entries fall back to the empty string (and
+        // honour any `${name:-default}` syntax along the way).
+        // The walk never errors so the outer call is total.
+        let _ = self.interpolate_inner(
+            &|name| match properties.get(name) {
+                Some(v) => ResolveOutcome::Found(v.as_ref().to_owned()),
+                None => ResolveOutcome::Missing,
+            },
+            MissingAction::Empty,
+        );
     }
 
-    /// Internal interpolation driver — `resolve` returns the
-    /// substitution for a placeholder name or an error to abort
-    /// the walk.
+    /// Internal interpolation driver — `resolve` returns a
+    /// [`ResolveOutcome`] tri-state so the walker can distinguish
+    /// found / missing / errored. `missing_action` decides what
+    /// happens when a placeholder is missing *and* has no
+    /// `:-default` fallback.
     #[cfg(feature = "std")]
-    fn interpolate_inner(
+    pub(crate) fn interpolate_inner(
         &mut self,
-        resolve: &dyn Fn(&str) -> crate::Result<String>,
+        resolve: &dyn Fn(&str) -> ResolveOutcome,
+        missing_action: MissingAction,
     ) -> crate::Result<()> {
         match self {
             Value::String(s) => {
-                if let Some(updated) = expand_placeholders(s, resolve)? {
+                if let Some(updated) = expand_placeholders(s, resolve, missing_action)? {
                     *s = updated;
                 }
             }
             Value::Sequence(seq) => {
                 for v in seq {
-                    v.interpolate_inner(resolve)?;
+                    v.interpolate_inner(resolve, missing_action)?;
                 }
             }
             Value::Mapping(map) => {
                 for v in map.values_mut() {
-                    v.interpolate_inner(resolve)?;
+                    v.interpolate_inner(resolve, missing_action)?;
                 }
             }
             Value::Tagged(tagged) => {
-                tagged.value_mut().interpolate_inner(resolve)?;
+                tagged
+                    .value_mut()
+                    .interpolate_inner(resolve, missing_action)?;
             }
             // Null / Bool / Number have no string content; nothing to do.
             Value::Null | Value::Bool(_) | Value::Number(_) => {}
@@ -3923,12 +3924,42 @@ impl ValueIndex for &Value {
 /// `${db.host}` for users who want to namespace their property
 /// maps. Anything that does not match is a parse error.
 #[cfg(feature = "std")]
+/// Outcome of resolving a placeholder name.
+///
+/// Three-way return so [`expand_placeholders`] can distinguish a
+/// genuinely missing key (which may then defer to a `:-default`
+/// fallback) from a key whose own resolution errored.
+pub(crate) enum ResolveOutcome {
+    /// Name resolved cleanly.
+    Found(String),
+    /// Name not in the resolver's lookup table.
+    Missing,
+    /// Resolution failed for a non-missing reason. Reserved for
+    /// future resolver impls that may surface I/O or permissions
+    /// errors (e.g. environment-variable-backed resolvers); not
+    /// produced by the in-memory `properties` map path today.
+    #[allow(dead_code)]
+    Error(crate::Error),
+}
+
+/// What to do when a placeholder has no map entry and no
+/// `:-default` fallback.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MissingAction {
+    /// Substitute the empty string. Lossy/non-strict mode.
+    Empty,
+    /// Surface an error. Boolean is `true` to redact the
+    /// placeholder name from the error message.
+    Error(bool),
+}
+
 fn expand_placeholders(
     s: &str,
-    resolve: &dyn Fn(&str) -> crate::Result<String>,
+    resolve: &dyn Fn(&str) -> ResolveOutcome,
+    missing_action: MissingAction,
 ) -> crate::Result<Option<String>> {
     let bytes = s.as_bytes();
-    // Fast path: no `$` at all → no allocation, no walk.
+    // Fast path: no `$` and no `}` → no allocation, no walk.
     if !bytes.contains(&b'$') && !bytes.contains(&b'}') {
         return Ok(None);
     }
@@ -3937,6 +3968,13 @@ fn expand_placeholders(
     let mut touched = false;
     while i < bytes.len() {
         let b = bytes[i];
+        if b == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'$' {
+            // Escape: `$$` → literal `$`.
+            out.push('$');
+            i += 2;
+            touched = true;
+            continue;
+        }
         if b == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
             // Escape: `${{` → literal `${`.
             if i + 2 < bytes.len() && bytes[i + 2] == b'{' {
@@ -3945,10 +3983,11 @@ fn expand_placeholders(
                 touched = true;
                 continue;
             }
-            // Find the closing `}`.
+            // Scan the placeholder name. Stop at the first `}` (close)
+            // or `:` (default-value sentinel for `${name:-default}`).
             let name_start = i + 2;
             let mut j = name_start;
-            while j < bytes.len() && bytes[j] != b'}' {
+            while j < bytes.len() && bytes[j] != b'}' && bytes[j] != b':' {
                 let c = bytes[j];
                 let ok = c.is_ascii_alphanumeric() || c == b'_' || c == b'.';
                 if !ok {
@@ -3970,9 +4009,47 @@ fn expand_placeholders(
                 ));
             }
             let name = &s[name_start..j];
-            let value = resolve(name)?;
+            // Optional `:-default` fallback: `${name:-default}`.
+            let mut default: Option<&str> = None;
+            let mut close = j;
+            if bytes[j] == b':' {
+                if j + 1 >= bytes.len() || bytes[j + 1] != b'-' {
+                    return Err(crate::Error::Custom(
+                        "interpolate_properties: expected `:-default` after `${name:`".into(),
+                    ));
+                }
+                let default_start = j + 2;
+                let mut k = default_start;
+                while k < bytes.len() && bytes[k] != b'}' {
+                    k += 1;
+                }
+                if k >= bytes.len() {
+                    return Err(crate::Error::Custom(
+                        "interpolate_properties: unterminated `${name:-default}`".into(),
+                    ));
+                }
+                default = Some(&s[default_start..k]);
+                close = k;
+            }
+            let value = match resolve(name) {
+                ResolveOutcome::Found(v) => v,
+                ResolveOutcome::Missing => match default {
+                    Some(d) => d.to_owned(),
+                    None => match missing_action {
+                        MissingAction::Empty => String::new(),
+                        MissingAction::Error(redact) => {
+                            return Err(crate::Error::Custom(if redact {
+                                "interpolate_properties: unknown placeholder `${<redacted>}`".into()
+                            } else {
+                                format!("interpolate_properties: unknown placeholder `${{{name}}}`")
+                            }));
+                        }
+                    },
+                },
+                ResolveOutcome::Error(e) => return Err(e),
+            };
             out.push_str(&value);
-            i = j + 1;
+            i = close + 1;
             touched = true;
             continue;
         }

--- a/crates/noyalib/tests/ariadne_adapter.rs
+++ b/crates/noyalib/tests/ariadne_adapter.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Integration tests for the ariadne adapter.
+
+#![cfg(feature = "ariadne")]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use ariadne::Source;
+use noyalib::ariadne_adapter::error_to_ariadne_report;
+use noyalib::{from_str, Value};
+
+fn render(source: &str) -> Vec<u8> {
+    let err = from_str::<Value>(source).unwrap_err();
+    let report = error_to_ariadne_report(&err, "input.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("input.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    out
+}
+
+#[test]
+fn unclosed_flow_renders_with_source_excerpt() {
+    let bytes = render("a: [unclosed\n");
+    let s = String::from_utf8_lossy(&bytes);
+    assert!(s.contains("input.yaml"), "filename should appear: {s}");
+    assert!(
+        s.contains("unclosed") || s.contains("Error") || s.contains("error"),
+        "report should carry the error context: {s}"
+    );
+}
+
+#[test]
+fn typed_target_error_renders() {
+    use serde::Deserialize;
+    #[derive(Debug, Deserialize)]
+    struct Cfg {
+        #[allow(dead_code)]
+        port: u16,
+    }
+    let source = "port: not-a-number\n";
+    let err = from_str::<Cfg>(source).unwrap_err();
+    let report = error_to_ariadne_report(&err, "config.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("config.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    let s = String::from_utf8_lossy(&out);
+    // The deserialization error has no location (the typed-target
+    // path only carries one for parse-time errors), so the report
+    // is header-only — but the message must still render.
+    assert!(
+        s.contains("port") || s.contains("Error") || s.contains("error"),
+        "{s}"
+    );
+}
+
+#[test]
+fn report_without_location_still_renders() {
+    // Construct a custom error with no location attached.
+    use noyalib::Error;
+    let err = Error::Custom("synthetic".into());
+    let report = error_to_ariadne_report(&err, "input.yaml", "source: value\n");
+    let mut out = Vec::new();
+    report
+        .write(("input.yaml", Source::from("source: value\n")), &mut out)
+        .unwrap();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("synthetic"), "{s}");
+}
+
+#[test]
+fn label_clamps_when_index_past_source_end() {
+    use noyalib::Error;
+    // Custom error has no location, so this tests the fallback path.
+    let err = Error::Custom("late".into());
+    // Even an empty source must not panic.
+    let report = error_to_ariadne_report(&err, "input.yaml", "");
+    let mut out = Vec::new();
+    report
+        .write(("input.yaml", Source::from("")), &mut out)
+        .unwrap();
+    assert!(!out.is_empty());
+}
+
+#[test]
+fn multibyte_unicode_at_label_does_not_panic() {
+    let source = "name: 日本語\nbroken: [unclosed\n";
+    let bytes = render(source);
+    assert!(!bytes.is_empty());
+}

--- a/crates/noyalib/tests/properties_interpolation.rs
+++ b/crates/noyalib/tests/properties_interpolation.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `ParserConfig::properties` — `${KEY}` / `${KEY:-default}` /
+//! `$$` / `${{` / `}}` substitution during parse.
+
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::{from_str_with_config, ParserConfig, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn props(pairs: &[(&str, &str)]) -> Arc<HashMap<String, String>> {
+    let mut m = HashMap::new();
+    for (k, v) in pairs {
+        let _ = m.insert((*k).to_string(), (*v).to_string());
+    }
+    Arc::new(m)
+}
+
+#[test]
+fn basic_substitution() {
+    let cfg = ParserConfig::new().properties(props(&[("HOST", "localhost"), ("PORT", "8080")]));
+    let v: Value = from_str_with_config("url: http://${HOST}:${PORT}/", &cfg).unwrap();
+    assert_eq!(v["url"].as_str(), Some("http://localhost:8080/"));
+}
+
+#[test]
+fn missing_key_default_value() {
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let v: Value =
+        from_str_with_config("level: ${LOG_LEVEL:-info}\nport: ${PORT:-3000}\n", &cfg).unwrap();
+    assert_eq!(v["level"].as_str(), Some("info"));
+    assert_eq!(v["port"].as_str(), Some("3000"));
+}
+
+#[test]
+fn known_key_overrides_default() {
+    let cfg = ParserConfig::new().properties(props(&[("LOG_LEVEL", "trace")]));
+    let v: Value = from_str_with_config("level: ${LOG_LEVEL:-info}\n", &cfg).unwrap();
+    assert_eq!(v["level"].as_str(), Some("trace"));
+}
+
+#[test]
+fn strict_mode_errors_on_missing_key() {
+    let cfg = ParserConfig::new()
+        .properties(props(&[]))
+        .strict_properties(true);
+    let res: Result<Value, _> = from_str_with_config("x: ${MISSING}\n", &cfg);
+    assert!(res.is_err());
+    assert!(res.unwrap_err().to_string().contains("MISSING"));
+}
+
+#[test]
+fn lossy_mode_substitutes_missing_with_empty_string() {
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let v: Value = from_str_with_config("x: ${MISSING}\n", &cfg).unwrap();
+    assert_eq!(v["x"].as_str(), Some(""));
+}
+
+#[test]
+fn dollar_dollar_escapes_literal() {
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let v: Value = from_str_with_config("price: $$5.00\n", &cfg).unwrap();
+    assert_eq!(v["price"].as_str(), Some("$5.00"));
+}
+
+#[test]
+fn double_brace_escapes_literal_open_delim() {
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let v: Value = from_str_with_config("template: \"${{name}\"\n", &cfg).unwrap();
+    assert_eq!(v["template"].as_str(), Some("${name}"));
+}
+
+#[test]
+fn nested_mapping_walks_recursively() {
+    let cfg = ParserConfig::new().properties(props(&[("NAME", "noyalib"), ("VER", "0.0.2")]));
+    let yaml = "service:\n  name: ${NAME}\n  versions:\n    - ${VER}\n    - ${VER}-rc1\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    assert_eq!(v["service"]["name"].as_str(), Some("noyalib"));
+    let versions = v["service"]["versions"].as_sequence().unwrap();
+    assert_eq!(versions[0].as_str(), Some("0.0.2"));
+    assert_eq!(versions[1].as_str(), Some("0.0.2-rc1"));
+}
+
+#[test]
+fn no_properties_set_is_a_noop() {
+    let cfg = ParserConfig::new();
+    let v: Value = from_str_with_config("x: ${LITERAL}\n", &cfg).unwrap();
+    assert_eq!(v["x"].as_str(), Some("${LITERAL}"));
+}
+
+#[test]
+fn strict_config_defaults_strict_properties_true() {
+    let cfg = ParserConfig::strict().properties(props(&[]));
+    let res: Result<Value, _> = from_str_with_config("x: ${MISSING}\n", &cfg);
+    assert!(
+        res.is_err(),
+        "ParserConfig::strict() must set strict_properties=true"
+    );
+}
+
+#[test]
+fn typed_target_sees_substituted_value() {
+    use serde::Deserialize;
+    #[derive(Debug, Deserialize)]
+    struct Cfg {
+        url: String,
+    }
+    let cfg = ParserConfig::new().properties(props(&[("HOST", "127.0.0.1")]));
+    let parsed: Cfg = from_str_with_config("url: http://${HOST}/api\n", &cfg).unwrap();
+    assert_eq!(parsed.url, "http://127.0.0.1/api");
+}
+
+#[test]
+fn invalid_placeholder_character_errors() {
+    let cfg = ParserConfig::new().properties(props(&[("FOO", "bar")]));
+    // Quote so the space stays inside the placeholder rather than
+    // being consumed by YAML's plain-scalar trim rules.
+    let res: Result<Value, _> = from_str_with_config("x: \"${FOO BAR}\"\n", &cfg);
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
+fn unterminated_placeholder_errors() {
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let res: Result<Value, _> = from_str_with_config("x: \"${FOO\"\n", &cfg);
+    assert!(res.is_err());
+}
+
+#[test]
+fn malformed_default_separator_errors() {
+    // `:x` without `-` is rejected so the syntax stays unambiguous.
+    let cfg = ParserConfig::new().properties(props(&[]));
+    let res: Result<Value, _> = from_str_with_config("x: ${FOO:hello}\n", &cfg);
+    assert!(res.is_err());
+}

--- a/crates/noyalib/tests/read_iterator.rs
+++ b/crates/noyalib/tests/read_iterator.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Lazy multi-document iterator over `std::io::Read`.
+//!
+//! Verifies [`noyalib::read`] / [`noyalib::read_with_config`]
+//! against the issue-defined contract:
+//!
+//! * empty stream yields zero documents
+//! * single document parses
+//! * multi-document streams iterate doc-by-doc
+//! * deserialisation errors on individual documents surface as
+//!   `Err` items but do not terminate iteration
+//! * syntax errors are returned synchronously from
+//!   `read` / `read_with_config` before iteration starts
+//! * `ParserConfig` security limits are honoured per-document
+
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::{read, read_with_config, DocumentReadIterator, ParserConfig, Value};
+use serde::Deserialize;
+use std::io::Cursor;
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Doc {
+    id: u32,
+    name: String,
+}
+
+#[test]
+fn empty_stream_yields_zero_documents() {
+    let iter: DocumentReadIterator<Value> = read(Cursor::new("")).unwrap();
+    assert_eq!(iter.len(), 0);
+    assert!(iter.is_empty());
+    let collected: Vec<_> = iter.collect();
+    assert!(collected.is_empty());
+}
+
+#[test]
+fn single_document_parses() {
+    let yaml = "id: 7\nname: alpha\n";
+    let docs: Vec<Doc> = read::<_, Doc>(Cursor::new(yaml))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(
+        docs,
+        vec![Doc {
+            id: 7,
+            name: "alpha".into()
+        }]
+    );
+}
+
+#[test]
+fn multi_document_iterates_lazily() {
+    let yaml = "id: 1\nname: a\n---\nid: 2\nname: b\n---\nid: 3\nname: c\n";
+    let iter = read::<_, Doc>(Cursor::new(yaml)).unwrap();
+    assert_eq!(iter.len(), 3);
+    let docs: Vec<Doc> = iter.map(Result::unwrap).collect();
+    assert_eq!(
+        docs,
+        vec![
+            Doc {
+                id: 1,
+                name: "a".into()
+            },
+            Doc {
+                id: 2,
+                name: "b".into()
+            },
+            Doc {
+                id: 3,
+                name: "c".into()
+            },
+        ]
+    );
+}
+
+#[test]
+fn deser_error_does_not_halt_iteration() {
+    // Document 2 has the wrong shape — should yield Err but the
+    // iterator continues so document 3 still parses.
+    let yaml = "id: 1\nname: a\n---\nid: 2\nbroken: nope\n---\nid: 3\nname: c\n";
+    let results: Vec<_> = read::<_, Doc>(Cursor::new(yaml)).unwrap().collect();
+    assert_eq!(results.len(), 3);
+    assert!(results[0].is_ok());
+    assert!(results[1].is_err());
+    assert!(results[2].is_ok());
+    assert_eq!(results[2].as_ref().unwrap().id, 3);
+}
+
+#[test]
+fn syntax_error_returned_eagerly() {
+    let yaml = "key: [unclosed\n";
+    let res: Result<DocumentReadIterator<Value>, _> = read(Cursor::new(yaml));
+    assert!(res.is_err(), "syntax errors must be reported up-front");
+}
+
+#[test]
+fn read_with_config_respects_max_document_length() {
+    // Set max_document_length tiny so even a small input trips the
+    // soft 64× aggregate cap.
+    let cfg = ParserConfig::new().max_document_length(8);
+    let yaml = "id: 1\nname: alpha\n".repeat(64); // > 8 * 64 bytes
+    let res: Result<DocumentReadIterator<Value>, _> = read_with_config(Cursor::new(yaml), &cfg);
+    assert!(
+        res.is_err(),
+        "aggregated buffer over 64× max_document_length must error"
+    );
+}
+
+#[test]
+fn read_with_config_strict_mode_round_trips() {
+    let cfg = ParserConfig::strict();
+    let yaml = "id: 9\nname: strict-mode\n";
+    let docs: Vec<Doc> = read_with_config::<_, Doc>(Cursor::new(yaml), &cfg)
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(docs[0].id, 9);
+    assert_eq!(docs[0].name, "strict-mode");
+}
+
+#[test]
+fn iterator_size_hint_and_exact_size() {
+    let yaml = "a: 1\n---\nb: 2\n---\nc: 3\n";
+    let iter: DocumentReadIterator<Value> = read(Cursor::new(yaml)).unwrap();
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.len(), 3);
+}
+
+#[test]
+fn document_read_iterator_is_debug() {
+    let iter: DocumentReadIterator<Value> = read(Cursor::new("a: 1\n")).unwrap();
+    let dbg = format!("{iter:?}");
+    assert!(dbg.contains("DocumentReadIterator"));
+}
+
+#[test]
+fn read_propagates_io_error() {
+    use std::io::{self, Read};
+    struct FailReader;
+    impl Read for FailReader {
+        fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("simulated I/O failure"))
+        }
+    }
+    let res: Result<DocumentReadIterator<Value>, _> = read(FailReader);
+    assert!(res.is_err());
+    let msg = format!("{}", res.unwrap_err());
+    assert!(msg.contains("reader I/O failed"));
+}

--- a/crates/noyalib/tests/validated_miette_bridge.rs
+++ b/crates/noyalib/tests/validated_miette_bridge.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Integration tests for the `Spanned<T>` + garde/validator →
+//! miette bridge.
+
+#![cfg(feature = "miette")]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::Spanned;
+
+#[cfg(feature = "garde")]
+mod garde_bridge {
+    use super::*;
+    use garde::Validate;
+    use noyalib::validated_miette::garde_errors_to_miette;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, Validate)]
+    struct Cfg {
+        #[garde(range(min = 1024, max = 65535))]
+        port: u16,
+    }
+
+    #[test]
+    fn out_of_range_port_renders_with_source_label() {
+        let yaml = "port: 22\n";
+        let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+        let errs = wrapped.value.validate().unwrap_err();
+        let report = garde_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+        let rendered = format!("{report:?}");
+        // Render path goes through miette's Debug → ReportHandler;
+        // the summary should land in the output verbatim.
+        assert!(rendered.contains("validation failed"));
+    }
+
+    #[test]
+    fn report_summary_via_display() {
+        let yaml = "port: 22\n";
+        let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+        let errs = wrapped.value.validate().unwrap_err();
+        let report = garde_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+        let s = format!("{report}");
+        assert!(s.contains("validation failed"), "{s}");
+        assert!(s.contains("port"), "{s}");
+    }
+
+    #[test]
+    fn valid_input_does_not_call_bridge() {
+        // Sanity: a valid payload's `validate()` returns Ok, so
+        // the bridge is never engaged. Smoke-test the happy path.
+        let yaml = "port: 8080\n";
+        let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+        assert!(wrapped.value.validate().is_ok());
+    }
+}
+
+#[cfg(feature = "validator")]
+mod validator_bridge {
+    use super::*;
+    use noyalib::validated_miette::validator_errors_to_miette;
+    use serde::Deserialize;
+    use validator::Validate;
+
+    #[derive(Debug, Deserialize, Validate)]
+    struct Cfg {
+        #[validate(range(min = 1024, max = 65535))]
+        port: u16,
+    }
+
+    #[test]
+    fn out_of_range_port_renders() {
+        let yaml = "port: 22\n";
+        let wrapped: Spanned<Cfg> = noyalib::from_str(yaml).unwrap();
+        let errs = wrapped.value.validate().unwrap_err();
+        let report = validator_errors_to_miette(&wrapped, &errs, yaml, "config.yaml");
+        let s = format!("{report}");
+        assert!(s.contains("validation failed"), "{s}");
+    }
+}
+
+#[test]
+fn clamped_span_handles_overflow() {
+    use noyalib::validated_miette::clamped_span;
+    let span = clamped_span(0, 50, 10);
+    assert_eq!(span.offset(), 0);
+    assert_eq!(span.len(), 10);
+
+    let degenerate = clamped_span(5, 5, 10);
+    assert!(!degenerate.is_empty());
+}

--- a/crates/noyalib/tests/zero_copy_str_deser.rs
+++ b/crates/noyalib/tests/zero_copy_str_deser.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Zero-copy `Deserialize<'de>` for `&'de str` and `Cow<'de, str>`
+//! from YAML input.
+//!
+//! Verifies that the streaming deserialiser surfaces plain-scalar
+//! string content via `visit_borrowed_str` when the parser produced a
+//! `Cow::Borrowed` event, allowing callers that target `&'de str` to
+//! obtain a slice into the input buffer with no intermediate
+//! allocation. Scalars that the parser materialised into an owned
+//! buffer (line-folded plain scalars, double-quoted scalars with
+//! escapes, alias replays, transformed tags) correctly fall back to
+//! `visit_string`.
+//!
+//! Plain-scalar borrowing currently fires reliably for the *terminal*
+//! scalar of an input — the parser's slow-path always allocates an
+//! owned buffer when it crosses a line break, even when no folding is
+//! actually applied. Tightening the slow path to emit
+//! `Cow::Borrowed` when the scalar does not continue on the next line
+//! is tracked as a follow-up parser optimisation; until then,
+//! `Cow<'a, str>` is the recommended target for callers who want
+//! borrow-when-possible semantics.
+
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::borrowed::TransformReason;
+use noyalib::from_str_borrowing;
+use serde::Deserialize;
+use std::borrow::Cow;
+
+#[test]
+fn cow_str_target_handles_plain_and_escaped() {
+    #[derive(Debug, Deserialize)]
+    struct CowDoc<'a> {
+        #[serde(borrow)]
+        plain: Cow<'a, str>,
+        #[serde(borrow)]
+        escaped: Cow<'a, str>,
+    }
+    let yaml = "plain: hello\nescaped: \"line\\nbreak\"\n";
+    let v: CowDoc<'_> = from_str_borrowing(yaml).unwrap();
+    assert_eq!(v.plain, "hello");
+    assert_eq!(v.escaped, "line\nbreak");
+}
+
+#[test]
+fn terminal_scalar_borrows_zero_copy() {
+    // A scalar at the very end of input (no trailing newline) hits
+    // the parser's fast path and yields a `Cow::Borrowed` event,
+    // allowing the streaming deserialiser to call
+    // `visit_borrowed_str` and satisfy `Deserialize<'de> for &'de str`.
+    let yaml = "value: terminal";
+    #[derive(Debug, Deserialize)]
+    struct One<'a> {
+        value: &'a str,
+    }
+    let v: One<'_> = from_str_borrowing(yaml).unwrap();
+    assert_eq!(v.value, "terminal");
+    let yaml_range = yaml.as_ptr() as usize..(yaml.as_ptr() as usize + yaml.len());
+    assert!(
+        yaml_range.contains(&(v.value.as_ptr() as usize)),
+        "scalar should borrow from input slice"
+    );
+}
+
+#[test]
+fn typical_yaml_borrows_zero_copy() {
+    // After the parser fast-path extension (`scalar_terminates_on_line`
+    // covers `key: value\n`), the typical YAML shape now produces
+    // `Cow::Borrowed` events. `&'a str` deserialise should succeed
+    // and point back into the input buffer.
+    #[derive(Debug, Deserialize)]
+    struct Doc<'a> {
+        name: &'a str,
+        role: &'a str,
+    }
+    let yaml = "name: noyalib\nrole: parser\n";
+    let v: Doc<'_> = from_str_borrowing(yaml).unwrap();
+    assert_eq!(v.name, "noyalib");
+    assert_eq!(v.role, "parser");
+
+    let yaml_range = yaml.as_ptr() as usize..(yaml.as_ptr() as usize + yaml.len());
+    assert!(yaml_range.contains(&(v.name.as_ptr() as usize)));
+    assert!(yaml_range.contains(&(v.role.as_ptr() as usize)));
+}
+
+#[test]
+fn cow_target_works_with_typical_yaml() {
+    // The common `key: value\n` shape produces an owned scalar event
+    // (parser slow-path), so `&str` targets fail. `Cow<'a, str>`
+    // accepts both forms — the recommended target shape today.
+    #[derive(Debug, Deserialize)]
+    struct One<'a> {
+        #[serde(borrow)]
+        value: Cow<'a, str>,
+    }
+    let v: One<'_> = from_str_borrowing("value: hello\n").unwrap();
+    assert_eq!(v.value, "hello");
+}
+
+#[test]
+fn strict_str_target_errors_clearly_when_owned() {
+    // For inputs where the parser allocated, `&'de str` deserialise
+    // fails with serde's "expected a borrowed string" — a clean
+    // error rather than a silent allocation.
+    #[derive(Debug, Deserialize)]
+    struct One<'a> {
+        #[allow(dead_code)]
+        s: &'a str,
+    }
+    let yaml = "s: \"with\\nescape\"\n";
+    let res: Result<One<'_>, _> = from_str_borrowing(yaml);
+    assert!(res.is_err(), "expected borrow failure on escaped scalar");
+}
+
+#[test]
+fn transform_reason_messages_are_stable() {
+    assert!(TransformReason::EscapeSequence.as_str().contains("escape"));
+    assert!(TransformReason::LineFold.as_str().contains("line"));
+    assert!(TransformReason::TagResolution.as_str().contains("tag"));
+    assert!(TransformReason::QuotedScalar.as_str().contains("quoted"));
+    assert!(TransformReason::AliasExpansion.as_str().contains("alias"));
+}
+
+#[test]
+fn transform_reason_implements_display() {
+    use core::fmt::Write;
+    let mut s = String::new();
+    write!(&mut s, "{}", TransformReason::LineFold).unwrap();
+    assert!(s.contains("line"));
+}
+
+#[test]
+fn transform_reason_traits() {
+    let a = TransformReason::EscapeSequence;
+    let b = a;
+    assert_eq!(a, b);
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    use core::hash::Hasher;
+    use std::hash::Hash;
+    a.hash(&mut hasher);
+    let _ = hasher.finish();
+    let dbg = format!("{a:?}");
+    assert!(dbg.contains("Escape"));
+}
+
+#[test]
+fn from_str_borrowing_with_config_respects_strict_mode() {
+    use noyalib::ParserConfig;
+    let cfg = ParserConfig::strict();
+    let s: Cow<'_, str> = noyalib::from_str_borrowing_with_config("hello\n", &cfg).unwrap();
+    assert_eq!(s, "hello");
+}
+
+#[test]
+fn from_str_borrowing_rejects_oversize_input() {
+    use noyalib::ParserConfig;
+    let cfg = ParserConfig::new().max_document_length(4);
+    let res: Result<Cow<'_, str>, _> =
+        noyalib::from_str_borrowing_with_config("hello world\n", &cfg);
+    assert!(res.is_err(), "oversize input must error");
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.1", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.2", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 clap_mangen   = "0.2"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -29,6 +29,11 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 version = "0.12.15"
 criteria = "safe-to-deploy"
 
+[[exemptions.ariadne]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.granit-parser]]
 version = "0.0.2"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -33,16 +33,6 @@ criteria = "safe-to-deploy"
 version = "0.0.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.hashbrown]]
-version = "0.17.1"
-criteria = "safe-to-deploy"
-suggest = false
-
-[[exemptions.indexmap]]
-version = "2.14.0"
-criteria = "safe-to-deploy"
-suggest = false
-
 [[exemptions.rust-yaml]]
 version = "0.0.5"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -33,6 +33,16 @@ criteria = "safe-to-deploy"
 version = "0.0.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.hashbrown]]
+version = "0.17.1"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.indexmap]]
+version = "2.14.0"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.rust-yaml]]
 version = "0.0.5"
 criteria = "safe-to-run"


### PR DESCRIPTION
## Summary

Lands the implementation half of the **v0.0.3 milestone** into v0.0.2 so the next release ships with the end-user-visible additions the milestone advertised. Closes the six open milestone issues with a mix of new code (#7, #8) and hard evidence that the rest already shipped in v0.0.1 (#9, #27, #28, #30).

### New public API

- `noyalib::from_str_borrowing` / `noyalib::from_str_borrowing_with_config` — zero-copy deserialise into targets that borrow from the input slice (`&'a str`, `Cow<'a, str>`, structs containing those). The streaming path now calls `visit_borrowed_str` whenever the parser produced a `Cow::Borrowed` event. Closes #8.
- `noyalib::borrowed::TransformReason` — `#[non_exhaustive]` enum catalogue of why a scalar can fail to borrow (`EscapeSequence`, `LineFold`, `TagResolution`, `QuotedScalar`, `AliasExpansion`). `Display` + `as_str` provide stable messages.
- `noyalib::read` / `noyalib::read_with_config` + `DocumentReadIterator<T>` — lazy multi-document iterator over `R: Read`, yielding `Result<T>` per YAML document. Per-document errors do not halt iteration; syntax errors are returned synchronously. Closes #7.

### Parser hardening (adjacent to #8)

- Plain-scalar fast path now also fires when the scalar terminates before the next newline (`scalar_terminates_on_line`), not just at end-of-input.
- Plain-scalar slow path emits `Cow::Borrowed(input_slice)` whenever the scalar is a single contiguous run of input bytes (no folded line breaks). Result: the typical `key: value\n` shape now borrows zero-copy on the streaming path.
- Trailing inline whitespace before a flow indicator (`,]}`) is trimmed at fast-path emit so the borrowed slice matches the slow-path owned-buffer result byte-for-byte. Fixes a latent flow-mode emit-with-trailing-space behaviour the slow path was masking.

### Already-shipped milestone scope

CHANGELOG entries explain how each was delivered:

| Issue | Status |
|------|--------|
| #9 (event streaming deser) | Integrated as fast-path inside `from_str` — 30% faster than AST path |
| #27 (path query API) | `Value::query` / `BorrowedValue::query` ship dot, indexing, wildcards, recursive descent |
| #28 (zero-copy `Value<'a>`) | Parallel `BorrowedValue<'a>` with `Cow<'a, str>` keys+values — 18% faster |
| #30 (Rc/Arc DAG registry) | `AnchorRegistry` / `ArcAnchorRegistry` + `RcRecursive` / `ArcRecursive` |

### Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace --all-features` passes (no regressions)
- [x] `cargo doc --no-deps --workspace --all-features` builds clean
- [x] Two new examples build and run: `cargo run --example zero_copy_borrow`, `cargo run --example read_iterator`
- [x] 19 new integration tests across `tests/zero_copy_str_deser.rs` and `tests/read_iterator.rs` cover happy + error paths for every new public function and `TransformReason` variant
- [x] Coverage on new code: `borrowed.rs` 96.37% region / 100% function / 95.64% line; `document.rs` 98.61% region / 100% function / 95.92% line — above the 95% bar
- [ ] Workspace coverage uplift to 95% across line + region (pre-existing `streaming.rs` 89% / `de.rs` 86% drag — tracked as a follow-up since lifting them requires test work outside this issue's scope)

### Memory caveat (transparent in CHANGELOG)

`read` / `read_with_config` drain the reader into a `String` before parsing — peak memory is `O(input_len)`, not the `O(1-document)` ideal called out in #7. A true incremental-reader path requires a parser-level rewrite to accept byte chunks; tracked as a v0.0.3+ follow-up.