### PR TITLE
docs: drop broken intra-doc links to feature-gated symbols

### DIFF
--- a/crates/noyalib/src/borrowed.rs
+++ b/crates/noyalib/src/borrowed.rs
@@ -3,8 +3,7 @@
 
 //! Zero-copy YAML values that borrow strings from the input.
 //!
-//! [`BorrowedValue`](crate::borrowed::BorrowedValue) is the zero-copy
-//! counterpart of [`Value`](crate::Value).
+//! [`BorrowedValue`] is the zero-copy counterpart of [`Value`](crate::Value).
 //! String scalars and mapping keys use `Cow<'a, str>`, borrowing directly from
 //! the input buffer when no escape processing was needed. This eliminates heap
 //! allocations for the majority of YAML content.

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-//! [`Spanned<T>`] + `garde` / `validator` → [`miette::Report`]
+//! [`Spanned<T>`] + `garde` / `validator` → `miette::Report`
 //! bridge.
 //!
-//! Walks a validation error tree produced by [`garde::Report`] or
-//! [`validator::ValidationErrors`] and emits a single
-//! [`miette::Report`] whose source label points at the
+//! Walks a validation error tree produced by `garde::Report` or
+//! `validator::ValidationErrors` and emits a single
+//! `miette::Report` whose source label points at the
 //! corresponding [`Spanned<T>`] range — enabling beautiful,
 //! line-and-column-precise output for declarative validation
 //! failures.
 //!
 //! Behind feature combinations:
-//! * [`garde_errors_to_miette`] requires `miette` + `garde`
-//! * [`validator_errors_to_miette`] requires `miette` + `validator`
+//! * `garde_errors_to_miette` requires `miette` + `garde`
+//! * `validator_errors_to_miette` requires `miette` + `validator`
 //!
 //! These functions are deliberately free-standing rather than
 //! impls on [`crate::Spanned`] to keep the dependency surface


### PR DESCRIPTION
Documentation workflow failed on main after v0.0.2 merge on two intra-doc link sites. Replaces gated references with backticked code so the lint passes regardless of which feature subset is active.

## Summary
- `validated_miette.rs`: `[]` / `[]` → backticked
- `borrowed.rs`: collapse `[](crate::borrowed::BorrowedValue)` redundant explicit target

## Test plan
- [x] `RUSTDOCFLAGS="-D warnings ..." cargo doc --no-deps --all-features` clean locally (matches CI command verbatim)
- [ ] CI Documentation workflow green on this branch