### PR TITLE
release(v0.0.3): widen rustc-hash cap to <3 for downstream compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.2]` is the cut.)
+(Targeting `[v0.0.3]` — scope TBD.)
 
 ## [v0.0.2] — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Targeting `[v0.0.3]` — scope TBD.)
+(Nothing yet — `[v0.0.3]` is the cut.)
+
+## [v0.0.3] — 2026-05-11
+
+### Changed — widen `rustc-hash` cap to `>=2, <3`
+
+Single-line manifest widening (`rustc-hash = ">=2, <2.1"` →
+`rustc-hash = ">=2, <3"`). The old cap was defensive, not
+load-bearing — noyalib's usage is the stable `FxHashMap` /
+`FxHashSet` / `FxBuildHasher` public surface unchanged across
+the 2.x line.
+
+The motivating downstream is `html-generator`, whose dependency
+chain pulls `scraper 0.26 → selectors 0.36 → rustc-hash
+^2.1.1`. Under the previous range the two co-resolution paths
+were incompatible.
+
+`Cargo.lock` stays pinned to `rustc-hash 2.0.0` because 2.1+
+declares `rust-version = "1.77"`, above noyalib's 1.75 MSRV
+floor. Downstream consumers on Rust ≥ 1.77 are free to
+`cargo update -p rustc-hash` to take 2.1+; consumers on 1.75
+inherit our lockfile pin via `cargo build --locked`. Same
+MSRV-preservation pattern v0.0.2 used for `indexmap 2.10 /
+hashbrown 0.15`.
 
 ## [v0.0.2] — 2026-05-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ariadne",
  "criterion",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/RELEASE-NOTES-v0.0.3.md
+++ b/RELEASE-NOTES-v0.0.3.md
@@ -1,0 +1,78 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.3 — Release Notes
+
+A surgical patch release that widens the `rustc-hash` dependency
+cap so downstream crates pulling `rustc-hash 2.1+` (notably
+`scraper`, `selectors`, and anything depending on them via
+`html-generator`) can co-resolve cleanly with noyalib.
+
+## What changed
+
+- **`rustc-hash = ">=2, <2.1"` → `rustc-hash = ">=2, <3"`** in
+  `crates/noyalib/Cargo.toml`. The original cap was defensive
+  (the version we'd tested against at v0.0.2 release time),
+  not load-bearing — noyalib's usage is the stable
+  `FxHashMap` / `FxHashSet` / `FxBuildHasher` surface,
+  unchanged across the 2.x line.
+
+That's the entire behaviour change. No public API moved. No
+private semantics moved. Nothing else.
+
+## Why now
+
+`html-generator`'s dep chain pulls
+`scraper 0.26 → selectors 0.36 → rustc-hash ^2.1.1`. Under
+v0.0.2's `<2.1` cap, a workspace pulling both `noyalib` and
+`html-generator` failed to resolve. Widening to `<3` lifts the
+block without any code or semantic change.
+
+## MSRV preservation
+
+`Cargo.lock` is pinned to `rustc-hash 2.0.0` because the 2.1+
+manifest declares `rust-version = "1.77"`, above noyalib's
+documented 1.75 MSRV floor. The same MSRV-preserving lockfile
+pattern v0.0.2 used for `indexmap 2.10 / hashbrown 0.15`:
+
+- Downstream consumers on Rust ≥ 1.77 are free to
+  `cargo update -p rustc-hash` to take 2.1+.
+- Consumers on Rust 1.75 inherit our lockfile pin via
+  `cargo build --locked`.
+
+## Lockstep version bumps
+
+All five publishable crates bump to 0.0.3 in lockstep —
+`noyalib`, `noya-cli`, `noyalib-mcp`, `noyalib-lsp`,
+`noyalib-wasm`. The release workflow's lockstep guard requires
+this. Path-dep `version` pins in the satellite manifests follow.
+
+## Compatibility
+
+- **Public API:** unchanged from v0.0.2.
+- **Wire format:** unchanged.
+- **MSRV:** Rust 1.75.0 stable (unchanged).
+- **Drop-in upgrade:** bump the version pin in your `Cargo.toml`
+  and `cargo update -p noyalib`. No code changes required.
+
+## Headline numbers
+
+Unchanged from v0.0.2: 100% strict YAML Test Suite (406/406),
+zero `unsafe`, 4 000+ workspace tests + 495+ doctests.
+
+## Verification
+
+```bash
+cargo install noya-cli --version 0.0.3
+noyafmt --version    # noyafmt 0.0.3
+noyavalidate --version
+
+# Cosign-verify any release artefact
+cosign verify-blob \
+  --certificate "noyalib-0.0.3.crate.pem" \
+  --signature   "noyalib-0.0.3.crate.sig" \
+  --certificate-identity-regexp \
+    "^https://github.com/sebastienrousseau/noyalib/" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  noyalib-0.0.3.crate
+```

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.2", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.3", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.2", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.3", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.2" }
+noyalib = { path = "../noyalib", version = "0.0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.2", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.3", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -271,7 +271,7 @@ required-features = ["miette", "garde"]
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
-rustc-hash = ">=2, <2.1"
+rustc-hash = ">=2, <3"
 itoa = { version = "1", optional = true }
 ryu = { version = "1", optional = true }
 memchr = "2.7"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.2"
+noyalib = "0.0.3"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.2", default-features = false }
+noyalib = { version = "0.0.3", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.2", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.3", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 clap_mangen   = "0.2"


### PR DESCRIPTION
## Summary

Single-file release-blocker fix: widens \`rustc-hash\` from \`>=2, <2.1\` to \`>=2, <3\`. Unblocks \`html-generator\` (whose \`scraper 0.26 → selectors 0.36\` chain requires \`rustc-hash ^2.1.1\`) and any other downstream consumer pulling \`rustc-hash\` 2.1+ transitively.

## Scope

- \`crates/noyalib/Cargo.toml\` — \`rustc-hash\` range widened
- \`Cargo.lock\` stays pinned to \`rustc-hash 2.0.0\` (2.1+ declares \`rust-version = "1.77"\`, above noyalib's 1.75 MSRV) — same MSRV-preserving pattern v0.0.2 used for \`indexmap 2.10 / hashbrown 0.15\`
- All 5 publishable crates bumped 0.0.2 → 0.0.3 in lockstep
- Crate-version README snippets refreshed

## Test plan

- [x] \`cargo check --workspace --all-features\` clean
- [x] \`cargo +1.75.0 check -p noyalib --locked\` clean (MSRV preserved)
- [ ] CI green