### PR TITLE
feat(v0.0.4): `!include` directive with sandboxed file resolver (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,38 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Targeting `[v0.0.4]` — scope: `!include` directive + ecosystem
-integrations.)
+### Added — `!include` directive support (issue #10)
+
+`ParserConfig::include_resolver` + `max_include_depth`. Two
+feature gates: `include` (resolver types only, works in
+no_std-style builds) and `include_fs` (adds the bundled
+`SafeFileResolver` with root-dir sandboxing and configurable
+symlink policy).
+
+After parse, every `Value::Tagged(!include, scalar_spec)` node
+is replaced with the resolver's output. Highlights:
+
+- **In-memory resolvers** — wrap any `Fn(IncludeRequest) ->
+  Result<InputSource>` via `IncludeResolver::new`. Useful for
+  virtual filesystems, test harnesses, network-backed fetchers.
+- **`SafeFileResolver`** — filesystem-backed resolver rooted at
+  a directory. Path traversal (`../../etc/passwd`) is caught by
+  canonicalisation + root-prefix check; symlinks are governed by
+  `SymlinkPolicy::FollowWithinRoot` (default) or
+  `SymlinkPolicy::Reject`.
+- **Fragment anchors** — `!include file.yaml#key` narrows to the
+  named top-level mapping key inside the included document.
+- **Cycle detection** — per-walk visited set rejects A→B→A
+  regardless of depth.
+- **Depth ceiling** — `max_include_depth` defaults to 24 (8 in
+  `ParserConfig::strict()`). Trips
+  `Error::RecursionLimitExceeded` on overflow.
+- **Streaming fast-path** is automatically disabled when an
+  include resolver is installed so the post-parse walk runs
+  uniformly across every typed target.
+
+11 new integration tests + a 4-scenario runnable example
+(`cargo run --example include_directive --features include_fs`).
 
 ## [v0.0.3] — 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.3]` is the cut.)
+(Targeting `[v0.0.4]` — scope: `!include` directive + ecosystem
+integrations.)
 
 ## [v0.0.3] — 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "ariadne",
  "criterion",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.3", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.4", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.3", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.4", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.3" }
+noyalib = { path = "../noyalib", version = "0.0.4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.3", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.4", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -268,6 +268,11 @@ name = "validated_miette"
 path = "examples/validated_miette.rs"
 required-features = ["miette", "garde"]
 
+[[example]]
+name = "include_directive"
+path = "examples/include_directive.rs"
+required-features = ["include_fs"]
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
@@ -427,6 +432,16 @@ std = ["serde/std"]
 miette = ["dep:miette"]
 ariadne = ["dep:ariadne"]
 robotics = []
+# `!include` directive — post-parse walk that consults a
+# user-supplied `crate::include::IncludeResolver` for every
+# `Value::Tagged(!include, _)` node and substitutes the
+# resolved content in-place. Pairs with `max_include_depth`
+# for cycle bounding. Off by default so callers who never see
+# `!include` scalars pay zero compile cost.
+include = []
+# Filesystem-backed `crate::include::SafeFileResolver` (root
+# sandbox, symlink policy). Implies `include` + `std`.
+include_fs = ["include", "std"]
 garde = ["dep:garde"]
 validator = ["dep:validator"]
 wasm-opt = []

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/examples/include_directive.rs
+++ b/crates/noyalib/examples/include_directive.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `!include` directive — compose YAML documents from multiple
+//! sources via a user-supplied resolver.
+//!
+//! Two variants demonstrated:
+//!
+//! * In-memory resolver (works in any environment, including
+//!   `no_std`-style sandboxes).
+//! * `SafeFileResolver` against a temporary directory
+//!   (`include_fs` feature only).
+//!
+//! Run: `cargo run --example include_directive --features include_fs`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::include::{IncludeRequest, IncludeResolver, InputSource, SafeFileResolver};
+use noyalib::{from_str_with_config, ParserConfig, Result, Value};
+use std::collections::HashMap;
+
+fn mem_resolver(files: HashMap<&'static str, &'static str>) -> IncludeResolver {
+    let files: HashMap<String, String> = files
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    IncludeResolver::new(move |req: IncludeRequest<'_>| -> Result<InputSource> {
+        let (path, _frag) = noyalib::include::split_fragment(req.spec);
+        match files.get(path) {
+            Some(b) => Ok(InputSource::new(path, b.clone())),
+            None => Err(noyalib::Error::Custom(format!("missing `{path}`"))),
+        }
+    })
+}
+
+fn main() {
+    support::header("noyalib -- include_directive");
+
+    support::task_with_output("In-memory resolver: substitute document root", || {
+        let mut files = HashMap::new();
+        let _ = files.insert("backend.yaml", "host: db.local\nport: 5432\n");
+        let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+        let v: Value = from_str_with_config("service: !include backend.yaml\n", &cfg).unwrap();
+        vec![
+            format!("host = {}", v["service"]["host"].as_str().unwrap()),
+            format!("port = {}", v["service"]["port"].as_i64().unwrap()),
+        ]
+    });
+
+    support::task_with_output("Fragment anchor narrows to a named key", || {
+        let mut files = HashMap::new();
+        let _ = files.insert(
+            "users.yaml",
+            "admins:\n  alice: { role: root }\n  bob: { role: root }\n",
+        );
+        let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+        let v: Value = from_str_with_config("team: !include users.yaml#admins\n", &cfg).unwrap();
+        v["team"]
+            .as_mapping()
+            .unwrap()
+            .iter()
+            .map(|(k, val)| format!("{k} → {}", val["role"].as_str().unwrap()))
+            .collect()
+    });
+
+    support::task_with_output("Cycle detection aborts cleanly", || {
+        let mut files = HashMap::new();
+        let _ = files.insert("a.yaml", "next: !include b.yaml\n");
+        let _ = files.insert("b.yaml", "next: !include a.yaml\n");
+        let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+        let res: Result<Value> = from_str_with_config("root: !include a.yaml\n", &cfg);
+        vec![format!("err = {}", res.unwrap_err().to_string())]
+    });
+
+    support::task_with_output("SafeFileResolver sandboxes to a temp dir", || {
+        // Stage two files in a temp dir under examples/_temp/.
+        let dir = std::env::temp_dir().join("noyalib-include-example");
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::write(dir.join("greet.yaml"), "msg: hello from temp\n");
+        let resolver = SafeFileResolver::new(&dir).into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let v: Value = from_str_with_config("greeting: !include greet.yaml\n", &cfg).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        vec![format!(
+            "msg = {:?}  (resolved against {})",
+            v["greeting"]["msg"].as_str().unwrap(),
+            dir.display()
+        )]
+    });
+}

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -234,6 +234,26 @@ pub struct ParserConfig {
     #[cfg(feature = "std")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub strict_properties: bool,
+    /// `!include` directive resolver. When set, the post-parse
+    /// walk substitutes every `Value::Tagged(!include, spec)`
+    /// node with the result of `resolver(IncludeRequest)`. See
+    /// [`crate::include::IncludeResolver`] for the closure
+    /// signature and [`crate::include::SafeFileResolver`] for
+    /// the bundled filesystem implementation.
+    ///
+    /// `None` (default) disables include expansion; tagged
+    /// `!include` nodes flow through unchanged.
+    #[cfg(feature = "include")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "include")))]
+    pub include_resolver: Option<crate::include::IncludeResolver>,
+    /// Maximum `!include` recursion depth. Default 24. Each
+    /// nested `!include` increments the depth counter; once the
+    /// limit is reached, the parser aborts with
+    /// `Error::RecursionLimitExceeded`. Pairs with a per-walk
+    /// visited-set to catch cycles independent of depth.
+    #[cfg(feature = "include")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "include")))]
+    pub max_include_depth: usize,
 }
 
 impl Default for ParserConfig {
@@ -266,6 +286,10 @@ impl Default for ParserConfig {
             properties: None,
             #[cfg(feature = "std")]
             strict_properties: false,
+            #[cfg(feature = "include")]
+            include_resolver: None,
+            #[cfg(feature = "include")]
+            max_include_depth: 24,
         }
     }
 }
@@ -325,6 +349,13 @@ impl ParserConfig {
             properties: None,
             #[cfg(feature = "std")]
             strict_properties: true,
+            #[cfg(feature = "include")]
+            include_resolver: None,
+            // Strict mode tightens the include recursion ceiling
+            // proportionally to its other depth caps (max_depth
+            // 128 → 64, max_alias_expansions 1024 → 100).
+            #[cfg(feature = "include")]
+            max_include_depth: 8,
         }
     }
 
@@ -388,6 +419,57 @@ impl ParserConfig {
     #[must_use]
     pub fn strict_properties(mut self, strict: bool) -> Self {
         self.strict_properties = strict;
+        self
+    }
+
+    /// Install an `!include` directive resolver.
+    ///
+    /// Each `Value::Tagged(!include, scalar_spec)` node in the
+    /// parsed tree is replaced with the resolver's output. The
+    /// resolver is consulted with an `IncludeRequest` carrying
+    /// the verbatim spec text, a stable source-id, and the
+    /// current recursion depth.
+    ///
+    /// Pair with [`Self::max_include_depth`] to bound the
+    /// recursion ceiling. Cycle detection (A includes B includes
+    /// A) runs independently using a per-walk visited set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::include::{IncludeRequest, IncludeResolver, InputSource};
+    /// use noyalib::{ParserConfig, Result};
+    ///
+    /// let resolver = IncludeResolver::new(|req: IncludeRequest<'_>| -> Result<InputSource> {
+    ///     // For an in-memory test, fabricate a YAML payload
+    ///     // keyed on the spec.
+    ///     Ok(InputSource::new(req.spec, format!("name: {}\n", req.spec)))
+    /// });
+    /// let cfg = ParserConfig::new().include_resolver(resolver);
+    /// # let _ = cfg;
+    /// ```
+    #[cfg(feature = "include")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "include")))]
+    #[must_use]
+    pub fn include_resolver(mut self, resolver: crate::include::IncludeResolver) -> Self {
+        self.include_resolver = Some(resolver);
+        self
+    }
+
+    /// Maximum `!include` recursion depth.
+    ///
+    /// Default 24 (8 in [`Self::strict()`]). Each nested
+    /// `!include` increments the depth; once the limit is
+    /// reached, the parser aborts with
+    /// `Error::RecursionLimitExceeded`. The cap is independent
+    /// of [`Self::max_depth`] (which bounds *YAML structural*
+    /// nesting) and of the per-walk cycle-detection set (which
+    /// catches A→B→A regardless of depth).
+    #[cfg(feature = "include")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "include")))]
+    #[must_use]
+    pub fn max_include_depth(mut self, depth: usize) -> Self {
+        self.max_include_depth = depth;
         self
     }
 
@@ -1292,7 +1374,8 @@ where
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
         && config.policies.is_empty()
-        && properties_inactive(config);
+        && properties_inactive(config)
+        && includes_inactive(config);
     if stream_eligible {
         if let Some(res) = crate::streaming::from_str_streaming(s, config) {
             return res;
@@ -1314,6 +1397,7 @@ where
     // verified `TypeId::of::<T>() == TypeId::of::<Value>()`.
     if is_value_target::<T>() {
         let mut value = parser::parse_one_value(s, &parse_config)?;
+        apply_includes(&mut value, config)?;
         apply_properties(&mut value, config)?;
         for p in &config.policies {
             p.check_value(&value)?;
@@ -1332,6 +1416,7 @@ where
     #[cfg(feature = "std")]
     {
         let (mut value, span_tree) = parser::parse_one(s, &parse_config)?;
+        apply_includes(&mut value, config)?;
         apply_properties(&mut value, config)?;
         for p in &config.policies {
             p.check_value(&value)?;
@@ -1402,6 +1487,175 @@ fn apply_properties(value: &mut Value, config: &ParserConfig) -> Result<()> {
 #[cfg(not(feature = "std"))]
 #[inline]
 fn apply_properties(_value: &mut Value, _config: &ParserConfig) -> Result<()> {
+    Ok(())
+}
+
+/// Returns `true` when no `!include` resolver is installed —
+/// keeps the streaming fast-path eligible.
+#[cfg(feature = "include")]
+#[inline]
+fn includes_inactive(config: &ParserConfig) -> bool {
+    config.include_resolver.is_none()
+}
+
+#[cfg(not(feature = "include"))]
+#[inline]
+fn includes_inactive(_config: &ParserConfig) -> bool {
+    true
+}
+
+/// Walk the `Value` tree, find every `Value::Tagged(!include, _)`
+/// node, and replace it with the resolver's output. Cyclic
+/// includes are detected via a per-walk visited set; depth is
+/// bounded by `config.max_include_depth`. No-op when no resolver
+/// is installed.
+#[cfg(feature = "include")]
+fn apply_includes(value: &mut Value, config: &ParserConfig) -> Result<()> {
+    if let Some(resolver) = config.include_resolver.as_ref() {
+        let parse_config = parser::ParseConfig::from(config);
+        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut next_id: usize = 1;
+        resolve_includes_recursive(
+            value,
+            resolver,
+            &parse_config,
+            config.max_include_depth,
+            0,
+            0,
+            &mut visited,
+            &mut next_id,
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "include"))]
+#[inline]
+fn apply_includes(_value: &mut Value, _config: &ParserConfig) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(feature = "include")]
+#[allow(clippy::too_many_arguments)]
+fn resolve_includes_recursive(
+    value: &mut Value,
+    resolver: &crate::include::IncludeResolver,
+    parse_config: &parser::ParseConfig,
+    max_depth: usize,
+    depth: usize,
+    from_id: usize,
+    visited: &mut std::collections::HashSet<String>,
+    next_id: &mut usize,
+) -> Result<()> {
+    if depth > max_depth {
+        return Err(Error::RecursionLimitExceeded { depth });
+    }
+    match value {
+        Value::Tagged(boxed) => {
+            if boxed.tag().as_str() == "!include" {
+                let spec = match boxed.value().as_str() {
+                    Some(s) => s.to_string(),
+                    None => {
+                        return Err(Error::Custom(
+                            "!include directive expects a scalar string spec".into(),
+                        ));
+                    }
+                };
+                if !visited.insert(spec.clone()) {
+                    return Err(Error::Custom(format!(
+                        "!include cycle detected: `{spec}` already in resolution chain"
+                    )));
+                }
+                let (path, fragment) = crate::include::split_fragment(&spec);
+                let req = crate::include::IncludeRequest {
+                    spec: &spec,
+                    from_id,
+                    depth,
+                };
+                let source = resolver.resolve(req)?;
+                let id = *next_id;
+                *next_id += 1;
+                let mut included = parser::parse_one_value(&source.bytes, parse_config)?;
+                // Recurse into the included document's own
+                // `!include` nodes — depth + 1.
+                resolve_includes_recursive(
+                    &mut included,
+                    resolver,
+                    parse_config,
+                    max_depth,
+                    depth + 1,
+                    id,
+                    visited,
+                    next_id,
+                )?;
+                // Fragment selection: if `spec` was `foo.yaml#anchor`,
+                // narrow to the named anchor inside the included
+                // document. Fragments resolve against mapping keys
+                // (the conventional YAML "anchor-as-key" pattern);
+                // see `examples/include_directive.rs`.
+                if let Some(frag) = fragment {
+                    if let Some(map) = included.as_mapping() {
+                        match map.get(frag) {
+                            Some(v) => *value = v.clone(),
+                            None => {
+                                return Err(Error::Custom(format!(
+                                    "!include fragment `#{frag}` not found in `{path}`"
+                                )));
+                            }
+                        }
+                    } else {
+                        return Err(Error::Custom(format!(
+                            "!include fragment `#{frag}` requires a mapping-shaped \
+                             included document; `{path}` is not a mapping"
+                        )));
+                    }
+                } else {
+                    *value = included;
+                }
+                let _ = visited.remove(&spec);
+            } else {
+                resolve_includes_recursive(
+                    boxed.value_mut(),
+                    resolver,
+                    parse_config,
+                    max_depth,
+                    depth,
+                    from_id,
+                    visited,
+                    next_id,
+                )?;
+            }
+        }
+        Value::Sequence(seq) => {
+            for v in seq {
+                resolve_includes_recursive(
+                    v,
+                    resolver,
+                    parse_config,
+                    max_depth,
+                    depth,
+                    from_id,
+                    visited,
+                    next_id,
+                )?;
+            }
+        }
+        Value::Mapping(map) => {
+            for v in map.values_mut() {
+                resolve_includes_recursive(
+                    v,
+                    resolver,
+                    parse_config,
+                    max_depth,
+                    depth,
+                    from_id,
+                    visited,
+                    next_id,
+                )?;
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
     Ok(())
 }
 

--- a/crates/noyalib/src/include.rs
+++ b/crates/noyalib/src/include.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `!include` directive support — compose YAML documents from
+//! multiple files via the `!include path/to/file.yaml` tag.
+//!
+//! Two layers:
+//!
+//! - **`include` feature** (this module's free-standing types) —
+//!   defines [`IncludeResolver`], [`IncludeRequest`], and
+//!   [`InputSource`]. The resolver is a `Send + Sync` closure
+//!   stored on [`crate::ParserConfig`]; users wire it up via
+//!   [`crate::ParserConfig::include_resolver`].
+//!
+//! - **`include_fs` feature** ([`SafeFileResolver`]) — a
+//!   filesystem-backed implementation with root-dir sandboxing,
+//!   symlink-policy enforcement ([`SymlinkPolicy`]), and
+//!   max-depth cycle protection.
+//!
+//! Fragment anchors (`!include file.yaml#name`) resolve the named
+//! YAML anchor inside the included document and substitute its
+//! value rather than the whole document. Plain `!include
+//! file.yaml` substitutes the document root.
+//!
+//! Cyclic includes (A includes B includes A) are rejected via a
+//! per-resolution visited set; the depth ceiling
+//! [`crate::ParserConfig::max_include_depth`] (default 24)
+//! bounds the recursion.
+
+use crate::error::{Error, Result};
+use crate::prelude::*;
+
+/// Describes one `!include` request the loader hands to the
+/// resolver.
+///
+/// The `spec` is the YAML scalar text after `!include` —
+/// typically a file path, possibly with a `#anchor` fragment.
+/// Resolvers are free to interpret the spec however they like
+/// (file path, URL, key in a virtual filesystem); the
+/// [`SafeFileResolver`] interprets it as a filesystem path.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct IncludeRequest<'a> {
+    /// The path / URL / identifier the user wrote after
+    /// `!include`. Includes the optional `#anchor` fragment.
+    pub spec: &'a str,
+    /// The source identifier of the document making this
+    /// request. The top-level document is `0`; nested includes
+    /// receive a fresh id from the parser.
+    pub from_id: usize,
+    /// Inclusion depth (0 = top-level document, 1 = first
+    /// nested include, …). Resolvers can refuse to resolve
+    /// beyond a certain depth or use this for diagnostics.
+    pub depth: usize,
+}
+
+/// What a resolver returns: the YAML text plus a stable
+/// identifier that downstream layers use for cycle detection
+/// and span-source attribution.
+///
+/// `name` is shown in diagnostic output — typically the
+/// canonicalised file path. `bytes` is the YAML text the loader
+/// will parse.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct InputSource {
+    /// Display name (file path, URL, …).
+    pub name: String,
+    /// The YAML text to parse.
+    pub bytes: String,
+}
+
+impl InputSource {
+    /// Construct a new [`InputSource`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::include::InputSource;
+    /// let s = InputSource::new("config.yaml", "k: 1\n");
+    /// assert_eq!(s.name, "config.yaml");
+    /// assert_eq!(s.bytes, "k: 1\n");
+    /// ```
+    #[must_use]
+    pub fn new(name: impl Into<String>, bytes: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            bytes: bytes.into(),
+        }
+    }
+}
+
+/// Type alias for the resolver closure stored on
+/// [`crate::ParserConfig`].
+///
+/// `Arc` (not `Box`) so configs stay cheap to clone. The
+/// closure is `Send + Sync` so the resolver can be invoked
+/// from any thread of a parallel parse.
+pub type IncludeResolver = Arc<dyn Fn(IncludeRequest<'_>) -> Result<InputSource> + Send + Sync>;
+
+/// How [`SafeFileResolver`] handles symbolic links it
+/// encounters while resolving a path.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::include::SymlinkPolicy;
+/// assert_eq!(SymlinkPolicy::default(), SymlinkPolicy::FollowWithinRoot);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SymlinkPolicy {
+    /// Follow symlinks that resolve to a path still inside the
+    /// resolver's root directory. Reject anything pointing
+    /// outside. Default.
+    FollowWithinRoot,
+    /// Reject all symbolic links regardless of target. Strictest
+    /// posture; appropriate for untrusted document graphs.
+    Reject,
+}
+
+impl Default for SymlinkPolicy {
+    fn default() -> Self {
+        Self::FollowWithinRoot
+    }
+}
+
+/// Filesystem-backed [`IncludeResolver`] with root-dir
+/// sandboxing.
+///
+/// Behind the `include_fs` Cargo feature (which implies
+/// `include` + `std`).
+///
+/// # Sandboxing
+///
+/// All resolved paths are canonicalised (via [`std::fs::canonicalize`])
+/// and verified to live inside the supplied `root` directory.
+/// Path-traversal attempts (`../../etc/passwd`) are caught at
+/// the canonicalisation step — the canonical path simply will
+/// not have `root` as a prefix, and the resolver errors.
+///
+/// # Symlinks
+///
+/// Controlled by [`SymlinkPolicy`]. The default
+/// [`SymlinkPolicy::FollowWithinRoot`] follows symlinks but
+/// re-applies the root-prefix check against the resolved
+/// target. [`SymlinkPolicy::Reject`] errors on any symlink in
+/// the path.
+///
+/// # Examples
+///
+/// ```no_run
+/// use noyalib::include::{SafeFileResolver, SymlinkPolicy};
+/// use std::sync::Arc;
+///
+/// let resolver = SafeFileResolver::new("/srv/configs")
+///     .symlink_policy(SymlinkPolicy::Reject)
+///     .into_resolver();
+/// let cfg = noyalib::ParserConfig::new().include_resolver(resolver);
+/// # let _ = cfg;
+/// ```
+#[cfg(feature = "include_fs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "include_fs")))]
+#[derive(Debug, Clone)]
+pub struct SafeFileResolver {
+    root: std::path::PathBuf,
+    symlink_policy: SymlinkPolicy,
+}
+
+#[cfg(feature = "include_fs")]
+impl SafeFileResolver {
+    /// Construct a resolver rooted at `root`. All resolved paths
+    /// must canonicalise to a descendant of `root`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::include::SafeFileResolver;
+    /// let r = SafeFileResolver::new("/srv/configs");
+    /// let _ = r;
+    /// ```
+    #[must_use]
+    pub fn new(root: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            symlink_policy: SymlinkPolicy::default(),
+        }
+    }
+
+    /// Set the [`SymlinkPolicy`].
+    #[must_use]
+    pub fn symlink_policy(mut self, policy: SymlinkPolicy) -> Self {
+        self.symlink_policy = policy;
+        self
+    }
+
+    /// Convert this configuration into a boxed [`IncludeResolver`]
+    /// suitable for [`crate::ParserConfig::include_resolver`].
+    #[must_use]
+    pub fn into_resolver(self) -> IncludeResolver {
+        let this = self.clone();
+        Arc::new(move |req: IncludeRequest<'_>| this.resolve(req))
+    }
+
+    fn resolve(&self, req: IncludeRequest<'_>) -> Result<InputSource> {
+        use std::fs;
+        // Strip the optional `#anchor` fragment — the loader
+        // handles anchor selection after parse, so the resolver
+        // only needs the path portion.
+        let (path_part, _frag) = split_fragment(req.spec);
+        let candidate = self.root.join(path_part);
+
+        // Reject paths whose canonical form jumps outside `root`.
+        let canon_root = fs::canonicalize(&self.root).map_err(|e| {
+            Error::Custom(format!("include resolver: cannot canonicalise root: {e}"))
+        })?;
+        let canon = fs::canonicalize(&candidate).map_err(|e| {
+            Error::Custom(format!(
+                "include resolver: cannot canonicalise `{}`: {e}",
+                candidate.display()
+            ))
+        })?;
+        if !canon.starts_with(&canon_root) {
+            return Err(Error::Custom(format!(
+                "include resolver: `{}` escapes sandbox root `{}`",
+                canon.display(),
+                canon_root.display()
+            )));
+        }
+
+        if self.symlink_policy == SymlinkPolicy::Reject {
+            // `fs::symlink_metadata` returns metadata of the link itself
+            // (not the target). If the original (un-canonicalised)
+            // path is a symlink the policy rejects.
+            let meta = fs::symlink_metadata(&candidate).map_err(|e| {
+                Error::Custom(format!(
+                    "include resolver: cannot stat `{}`: {e}",
+                    candidate.display()
+                ))
+            })?;
+            if meta.file_type().is_symlink() {
+                return Err(Error::Custom(format!(
+                    "include resolver: symlink rejected by policy: `{}`",
+                    candidate.display()
+                )));
+            }
+        }
+
+        let bytes = fs::read_to_string(&canon).map_err(|e| {
+            Error::Custom(format!(
+                "include resolver: cannot read `{}`: {e}",
+                canon.display()
+            ))
+        })?;
+        Ok(InputSource::new(canon.display().to_string(), bytes))
+    }
+}
+
+/// Split `path#fragment` into `(path, Some(fragment))` /
+/// `(path, None)`. Used by both the resolver and the post-parse
+/// walk so they agree on which characters are path-bytes.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::include::split_fragment;
+/// assert_eq!(split_fragment("a.yaml#anchor"), ("a.yaml", Some("anchor")));
+/// assert_eq!(split_fragment("a.yaml"), ("a.yaml", None));
+/// ```
+#[must_use]
+pub fn split_fragment(spec: &str) -> (&str, Option<&str>) {
+    match spec.split_once('#') {
+        Some((p, f)) => (p, Some(f)),
+        None => (spec, None),
+    }
+}

--- a/crates/noyalib/src/include.rs
+++ b/crates/noyalib/src/include.rs
@@ -7,14 +7,14 @@
 //! Two layers:
 //!
 //! - **`include` feature** (this module's free-standing types) —
-//!   defines [`IncludeResolver`], [`IncludeRequest`], and
-//!   [`InputSource`]. The resolver is a `Send + Sync` closure
+//!   defines `IncludeResolver`, `IncludeRequest`, and
+//!   `InputSource`. The resolver is a `Send + Sync` closure
 //!   stored on [`crate::ParserConfig`]; users wire it up via
 //!   [`crate::ParserConfig::include_resolver`].
 //!
-//! - **`include_fs` feature** ([`SafeFileResolver`]) — a
+//! - **`include_fs` feature** (`SafeFileResolver`) — a
 //!   filesystem-backed implementation with root-dir sandboxing,
-//!   symlink-policy enforcement ([`SymlinkPolicy`]), and
+//!   symlink-policy enforcement (`SymlinkPolicy`), and
 //!   max-depth cycle protection.
 //!
 //! Fragment anchors (`!include file.yaml#name`) resolve the named
@@ -27,7 +27,9 @@
 //! [`crate::ParserConfig::max_include_depth`] (default 24)
 //! bounds the recursion.
 
-use crate::error::{Error, Result};
+#[cfg(feature = "include_fs")]
+use crate::error::Error;
+use crate::error::Result;
 use crate::prelude::*;
 
 /// Describes one `!include` request the loader hands to the
@@ -90,13 +92,56 @@ impl InputSource {
     }
 }
 
-/// Type alias for the resolver closure stored on
-/// [`crate::ParserConfig`].
+/// Resolver closure stored on [`crate::ParserConfig`].
 ///
-/// `Arc` (not `Box`) so configs stay cheap to clone. The
-/// closure is `Send + Sync` so the resolver can be invoked
-/// from any thread of a parallel parse.
-pub type IncludeResolver = Arc<dyn Fn(IncludeRequest<'_>) -> Result<InputSource> + Send + Sync>;
+/// Wraps an `Arc<dyn Fn>` so the type is `Clone + Debug` (the
+/// underlying `dyn Fn` is not). Construct with
+/// [`IncludeResolver::new`].
+///
+/// `Arc` (not `Box`) keeps configs cheap to clone. The closure
+/// is `Send + Sync` so the resolver can be invoked from any
+/// thread of a parallel parse.
+#[derive(Clone)]
+pub struct IncludeResolver(Arc<dyn Fn(IncludeRequest<'_>) -> Result<InputSource> + Send + Sync>);
+
+impl IncludeResolver {
+    /// Wrap a closure as an [`IncludeResolver`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::include::{IncludeRequest, IncludeResolver, InputSource};
+    /// use noyalib::Result;
+    /// let r = IncludeResolver::new(|req: IncludeRequest<'_>| -> Result<InputSource> {
+    ///     Ok(InputSource::new(req.spec, "v: 1\n"))
+    /// });
+    /// let _ = r;
+    /// ```
+    #[must_use]
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(IncludeRequest<'_>) -> Result<InputSource> + Send + Sync + 'static,
+    {
+        Self(Arc::new(f))
+    }
+
+    /// Invoke the wrapped closure.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces whatever the underlying resolver returned.
+    pub fn resolve(&self, req: IncludeRequest<'_>) -> Result<InputSource> {
+        (self.0)(req)
+    }
+}
+
+impl core::fmt::Debug for IncludeResolver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IncludeResolver")
+            .field("ptr", &Arc::as_ptr(&self.0))
+            .finish()
+    }
+}
 
 /// How [`SafeFileResolver`] handles symbolic links it
 /// encounters while resolving a path.
@@ -107,22 +152,17 @@ pub type IncludeResolver = Arc<dyn Fn(IncludeRequest<'_>) -> Result<InputSource>
 /// use noyalib::include::SymlinkPolicy;
 /// assert_eq!(SymlinkPolicy::default(), SymlinkPolicy::FollowWithinRoot);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[non_exhaustive]
 pub enum SymlinkPolicy {
     /// Follow symlinks that resolve to a path still inside the
     /// resolver's root directory. Reject anything pointing
     /// outside. Default.
+    #[default]
     FollowWithinRoot,
     /// Reject all symbolic links regardless of target. Strictest
     /// posture; appropriate for untrusted document graphs.
     Reject,
-}
-
-impl Default for SymlinkPolicy {
-    fn default() -> Self {
-        Self::FollowWithinRoot
-    }
 }
 
 /// Filesystem-backed [`IncludeResolver`] with root-dir
@@ -199,7 +239,7 @@ impl SafeFileResolver {
     #[must_use]
     pub fn into_resolver(self) -> IncludeResolver {
         let this = self.clone();
-        Arc::new(move |req: IncludeRequest<'_>| this.resolve(req))
+        IncludeResolver::new(move |req: IncludeRequest<'_>| this.resolve(req))
     }
 
     fn resolve(&self, req: IncludeRequest<'_>) -> Result<InputSource> {

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -406,8 +406,16 @@ mod anchors;
 #[cfg(feature = "ariadne")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ariadne")))]
 pub mod ariadne_adapter;
+
 /// Internal RFC 4648 base64 codec for `!!binary` scalars.
 mod base64;
+/// `!include` directive — resolver types
+/// (`IncludeResolver`, `IncludeRequest`, `InputSource`,
+/// `SymlinkPolicy`, `SafeFileResolver`). Wired into
+/// `ParserConfig::include_resolver`.
+#[cfg(feature = "include")]
+#[cfg_attr(docsrs, doc(cfg(feature = "include")))]
+pub mod include;
 
 /// `Spanned<T>` + garde / validator → `miette::Report` bridge.
 /// Behind the `miette` Cargo feature; the actual conversion

--- a/crates/noyalib/tests/include_directive.rs
+++ b/crates/noyalib/tests/include_directive.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `!include` directive — post-parse resolution + cycle / depth /
+//! sandbox guards.
+
+#![cfg(feature = "include")]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::include::{IncludeRequest, IncludeResolver, InputSource};
+use noyalib::{from_str_with_config, ParserConfig, Result, Value};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Build a resolver backed by an in-memory map.
+fn mem_resolver(files: HashMap<&'static str, &'static str>) -> IncludeResolver {
+    let files: HashMap<String, String> = files
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    IncludeResolver::new(move |req: IncludeRequest<'_>| -> Result<InputSource> {
+        let (path, _frag) = noyalib::include::split_fragment(req.spec);
+        match files.get(path) {
+            Some(b) => Ok(InputSource::new(path, b.clone())),
+            None => Err(noyalib::Error::Custom(format!(
+                "test mem resolver: missing `{path}`"
+            ))),
+        }
+    })
+}
+
+#[test]
+fn basic_include_substitutes_document_root() {
+    let mut files = HashMap::new();
+    let _ = files.insert("frag.yaml", "name: alpha\nversion: 1\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "service: !include frag.yaml\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    assert_eq!(v["service"]["name"].as_str(), Some("alpha"));
+    assert_eq!(v["service"]["version"].as_i64(), Some(1));
+}
+
+#[test]
+fn nested_include_resolves_recursively() {
+    let mut files = HashMap::new();
+    let _ = files.insert("inner.yaml", "v: 99\n");
+    let _ = files.insert("outer.yaml", "inner: !include inner.yaml\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "wrap: !include outer.yaml\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    assert_eq!(v["wrap"]["inner"]["v"].as_i64(), Some(99));
+}
+
+#[test]
+fn fragment_anchor_narrows_to_named_key() {
+    let mut files = HashMap::new();
+    let _ = files.insert(
+        "defs.yaml",
+        "users:\n  admin: { role: root }\n  guest: { role: anon }\n",
+    );
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "u: !include defs.yaml#users\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    assert_eq!(v["u"]["admin"]["role"].as_str(), Some("root"));
+    assert_eq!(v["u"]["guest"]["role"].as_str(), Some("anon"));
+}
+
+#[test]
+fn fragment_anchor_missing_key_errors_clearly() {
+    let mut files = HashMap::new();
+    let _ = files.insert("defs.yaml", "users:\n  admin: 1\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "u: !include defs.yaml#missing\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("fragment"), "{err}");
+    assert!(err.to_string().contains("missing"), "{err}");
+}
+
+#[test]
+fn cycle_detection_aborts_with_clear_error() {
+    let mut files = HashMap::new();
+    let _ = files.insert("a.yaml", "next: !include b.yaml\n");
+    let _ = files.insert("b.yaml", "next: !include a.yaml\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "root: !include a.yaml\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("cycle"), "{err}");
+}
+
+#[test]
+fn max_include_depth_caps_recursion() {
+    // resolver always returns another !include — guaranteed
+    // depth blow-up unless capped.
+    let resolver = IncludeResolver::new(|_req: IncludeRequest<'_>| -> Result<InputSource> {
+        Ok(InputSource::new("infinite", "deeper: !include infinite\n"))
+    });
+    let cfg = ParserConfig::new()
+        .include_resolver(resolver)
+        .max_include_depth(5);
+    let yaml = "root: !include start\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    assert!(res.is_err(), "max-depth must abort: {res:?}");
+}
+
+#[test]
+fn no_resolver_set_means_no_walk() {
+    // Without a resolver installed, the !include node stays as
+    // a Tagged value in the output — the user can still inspect
+    // it but no substitution happens.
+    let cfg = ParserConfig::new();
+    let yaml = "left_alone: !include frag.yaml\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    let tag_str = v["left_alone"].as_tagged().map(|t| t.tag().as_str());
+    assert_eq!(tag_str, Some("!include"));
+}
+
+#[test]
+fn resolver_errors_propagate() {
+    let resolver = IncludeResolver::new(|_req: IncludeRequest<'_>| -> Result<InputSource> {
+        Err(noyalib::Error::Custom("synthetic resolver failure".into()))
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let yaml = "v: !include anything\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("synthetic"), "{err}");
+}
+
+#[test]
+fn non_string_spec_errors() {
+    // `!include {x: 1}` — the spec must be a scalar string, not
+    // a mapping. The walker should refuse instead of trying to
+    // resolve a mapping-as-path.
+    let resolver = IncludeResolver::new(|_req: IncludeRequest<'_>| -> Result<InputSource> {
+        Ok(InputSource::new("noop", "k: v\n"))
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let yaml = "bad: !include\n  not: a-scalar\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    assert!(res.is_err());
+}
+
+#[test]
+fn typed_target_sees_substituted_value() {
+    use serde::Deserialize;
+    #[derive(Debug, Deserialize)]
+    struct Server {
+        host: String,
+        port: u16,
+    }
+    let mut files = HashMap::new();
+    let _ = files.insert("server.yaml", "host: db.local\nport: 5432\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "server: !include server.yaml\n";
+    #[derive(Debug, Deserialize)]
+    struct Root {
+        server: Server,
+    }
+    let root: Root = from_str_with_config(yaml, &cfg).unwrap();
+    assert_eq!(root.server.host, "db.local");
+    assert_eq!(root.server.port, 5432);
+}
+
+#[test]
+fn resolver_observes_increasing_depth() {
+    // Track the depth value the resolver sees on each call. The
+    // outer document is depth 0; nested includes are depth 1, 2…
+    let depths: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+    let depths_clone = Arc::clone(&depths);
+    let resolver = IncludeResolver::new(move |req: IncludeRequest<'_>| -> Result<InputSource> {
+        depths_clone.lock().unwrap().push(req.depth);
+        match req.spec {
+            "a.yaml" => Ok(InputSource::new("a", "next: !include b.yaml\n")),
+            "b.yaml" => Ok(InputSource::new("b", "leaf: 7\n")),
+            _ => unreachable!(),
+        }
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let v: Value = from_str_with_config("r: !include a.yaml\n", &cfg).unwrap();
+    assert_eq!(v["r"]["next"]["leaf"].as_i64(), Some(7));
+    let observed = depths.lock().unwrap().clone();
+    assert_eq!(observed, vec![0, 1]);
+}

--- a/crates/noyalib/tests/include_directive.rs
+++ b/crates/noyalib/tests/include_directive.rs
@@ -164,6 +164,163 @@ fn typed_target_sees_substituted_value() {
     assert_eq!(root.server.port, 5432);
 }
 
+#[cfg(feature = "include_fs")]
+mod safe_file {
+    use super::*;
+    use noyalib::include::{SafeFileResolver, SymlinkPolicy};
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("noyalib-include-{name}"));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn file_resolver_loads_basic_path() {
+        let dir = temp_dir("basic");
+        std::fs::write(dir.join("a.yaml"), "hello: world\n").unwrap();
+        let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&dir).into_resolver());
+        let v: Value = from_str_with_config("inc: !include a.yaml\n", &cfg).unwrap();
+        assert_eq!(v["inc"]["hello"].as_str(), Some("world"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn path_traversal_outside_root_errors() {
+        // Stage a file *inside* root that legitimately resolves;
+        // then attempt `..` to escape.
+        let dir = temp_dir("traversal");
+        std::fs::write(dir.join("ok.yaml"), "k: v\n").unwrap();
+        let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&dir).into_resolver());
+        let res: Result<Value> = from_str_with_config("x: !include ../../etc/hosts\n", &cfg);
+        assert!(res.is_err(), "must reject path-traversal");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_file_errors() {
+        let dir = temp_dir("missing");
+        let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&dir).into_resolver());
+        let res: Result<Value> = from_str_with_config("x: !include nope.yaml\n", &cfg);
+        assert!(res.is_err(), "missing file must error");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reject_symlink_policy_blocks_symlinks() {
+        let dir = temp_dir("symlink");
+        std::fs::write(dir.join("real.yaml"), "v: 1\n").unwrap();
+        // Best-effort symlink creation — on platforms without
+        // privileges to symlink (Windows without dev-mode), skip.
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.join("real.yaml"), dir.join("link.yaml")).unwrap();
+        #[cfg(not(unix))]
+        return; // Windows/no-symlink path: nothing to assert.
+
+        #[cfg(unix)]
+        {
+            let resolver = SafeFileResolver::new(&dir)
+                .symlink_policy(SymlinkPolicy::Reject)
+                .into_resolver();
+            let cfg = ParserConfig::new().include_resolver(resolver);
+            let res: Result<Value> = from_str_with_config("x: !include link.yaml\n", &cfg);
+            assert!(
+                res.is_err(),
+                "SymlinkPolicy::Reject must block symlinked includes"
+            );
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    #[test]
+    fn symlink_policy_default_is_follow_within_root() {
+        assert_eq!(SymlinkPolicy::default(), SymlinkPolicy::FollowWithinRoot);
+    }
+
+    #[test]
+    fn debug_impl_renders() {
+        let r = SafeFileResolver::new("/srv/configs");
+        let s = format!("{r:?}");
+        assert!(s.contains("SafeFileResolver"));
+    }
+
+    #[test]
+    fn split_fragment_round_trip() {
+        use noyalib::include::split_fragment;
+        assert_eq!(split_fragment("a.yaml#anchor"), ("a.yaml", Some("anchor")));
+        assert_eq!(split_fragment("a.yaml"), ("a.yaml", None));
+        assert_eq!(split_fragment(""), ("", None));
+        assert_eq!(split_fragment("#anchor"), ("", Some("anchor")));
+    }
+}
+
+#[test]
+fn fragment_on_non_mapping_document_errors() {
+    let mut files = HashMap::new();
+    let _ = files.insert("scalar.yaml", "42\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let res: Result<Value> = from_str_with_config("v: !include scalar.yaml#k\n", &cfg);
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("mapping"), "{err}");
+}
+
+#[test]
+fn include_inside_sequence_is_resolved() {
+    let mut files = HashMap::new();
+    let _ = files.insert("item.yaml", "name: alpha\n");
+    let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
+    let yaml = "items:\n  - !include item.yaml\n  - !include item.yaml\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    let seq = v["items"].as_sequence().unwrap();
+    assert_eq!(seq.len(), 2);
+    assert_eq!(seq[0]["name"].as_str(), Some("alpha"));
+}
+
+#[test]
+fn non_include_tagged_values_pass_through() {
+    let resolver = IncludeResolver::new(|_req: IncludeRequest<'_>| -> Result<InputSource> {
+        unreachable!("non-!include tag must not invoke the resolver")
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let yaml = "v: !custom 42\n";
+    let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+    let tag = v["v"].as_tagged().unwrap();
+    assert_eq!(tag.tag().as_str(), "!custom");
+}
+
+#[test]
+fn input_source_constructor_and_clone() {
+    let src = InputSource::new("test.yaml", "k: v\n");
+    assert_eq!(src.name, "test.yaml");
+    assert_eq!(src.bytes, "k: v\n");
+    let cloned = src.clone();
+    assert_eq!(cloned.name, src.name);
+}
+
+#[test]
+fn include_request_debug_renders_via_resolver_invocation() {
+    use std::sync::Mutex;
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_clone = Arc::clone(&captured);
+    let resolver = IncludeResolver::new(move |req: IncludeRequest<'_>| -> Result<InputSource> {
+        *captured_clone.lock().unwrap() = Some(format!("{req:?}"));
+        Ok(InputSource::new(req.spec, "ok: 1\n"))
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let _: Value = from_str_with_config("x: !include some_spec.yaml\n", &cfg).unwrap();
+    let dbg = captured.lock().unwrap().clone().unwrap();
+    assert!(dbg.contains("IncludeRequest"));
+    assert!(dbg.contains("some_spec.yaml"));
+}
+
+#[test]
+fn resolver_debug_renders() {
+    let r = IncludeResolver::new(|_| Ok(InputSource::new("n", "v: 1\n")));
+    let s = format!("{r:?}");
+    assert!(s.contains("IncludeResolver"));
+}
+
 #[test]
 fn resolver_observes_increasing_depth() {
     // Track the depth value the resolver sees on each call. The

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.3", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.4", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 clap_mangen   = "0.2"


### PR DESCRIPTION
## Summary

Opens the **v0.0.4 cycle** with the `!include` directive (issue #10) — composable YAML documents via a user-supplied resolver, with first-party filesystem sandboxing and cycle protection.

All five publishable crates bump **0.0.3 → 0.0.4** in lockstep; `xtask` stays internal at 0.0.1.

## Highlights

### `!include` directive (issue #10)

Two new Cargo features:

| Feature | Scope |
| :--- | :--- |
| `include` | Resolver types (`IncludeResolver`, `IncludeRequest`, `InputSource`). Works in no_std-style builds. |
| `include_fs` | Adds `SafeFileResolver` + `SymlinkPolicy`. Implies `include` + `std`. |

After parse, every `Value::Tagged(!include, scalar_spec)` node is replaced with the resolver's output via a post-parse walk on the `Value` tree.

Behaviour:

* **Whole-document substitution** by default.
* **Fragment anchors** — `!include file.yaml#key` narrows to the named top-level mapping key.
* **Cycle detection** — per-walk visited set rejects A→B→A regardless of depth.
* **Depth ceiling** — `ParserConfig::max_include_depth` defaults to 24 (8 in `ParserConfig::strict()`). Trips `Error::RecursionLimitExceeded` on overflow.
* **Streaming fast-path** is automatically disabled when a resolver is installed so the walk runs uniformly across every typed target.

\`SafeFileResolver\` does the safety work:

* **Path traversal** (\`../../etc/passwd\`) is caught by canonicalisation against the configured root.
* **Symlinks** are governed by \`SymlinkPolicy::FollowWithinRoot\` (default) or \`SymlinkPolicy::Reject\`.

### Public-API additions

| API | Where | Feature gate |
| :--- | :--- | :--- |
| \`ParserConfig::include_resolver(resolver)\` | \`de.rs\` | \`include\` |
| \`ParserConfig::max_include_depth(usize)\` | \`de.rs\` | \`include\` |
| \`include::IncludeResolver\` (newtype around \`Arc<dyn Fn>\`) | \`include.rs\` | \`include\` |
| \`include::IncludeRequest<'a>\` | \`include.rs\` | \`include\` |
| \`include::InputSource\` | \`include.rs\` | \`include\` |
| \`include::SafeFileResolver\` | \`include.rs\` | \`include_fs\` |
| \`include::SymlinkPolicy\` | \`include.rs\` | \`include_fs\` |
| \`include::split_fragment\` | \`include.rs\` | \`include\` |

\`IncludeResolver\` is a newtype rather than a bare \`Arc<dyn Fn>\` so it carries \`Clone + Debug + Send + Sync\` cleanly. The dyn \`Fn\` doesn't auto-impl \`Debug\` and \`thiserror\` / derive-\`Debug\` aren't applicable; the impl is hand-rolled (matches the policy in \`error.rs\`).

## Files changed

\`\`\`
 CHANGELOG.md                                 |  33 ++-
 Cargo.lock                                   |  10 +-
 crates/noya-cli/Cargo.toml                   |   4 +-
 crates/noyalib-lsp/Cargo.toml                |   4 +-
 crates/noyalib-mcp/Cargo.toml                |   4 +-
 crates/noyalib-wasm/Cargo.toml               |   4 +-
 crates/noyalib/Cargo.toml                    |  17 +-
 crates/noyalib/examples/include_directive.rs |  91 ++++++++
 crates/noyalib/src/de.rs                     | 256 +++++++++++++++++++++-
 crates/noyalib/src/include.rs                | 316 +++++++++++++++++++++++++++
 crates/noyalib/src/lib.rs                    |   8 +
 crates/noyalib/tests/include_directive.rs    | 186 ++++++++++++++++
 crates/xtask/Cargo.toml                      |   2 +-
 13 files changed, 918 insertions(+), 17 deletions(-)
\`\`\`

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --all-features\` clean (11 new tests in \`tests/include_directive.rs\`)
- [x] \`cargo vet --locked\` — 270 fully audited / 5 exempted (unchanged)
- [x] \`RUSTDOCFLAGS='-D warnings -D rustdoc::broken_intra_doc_links …' cargo doc --no-deps --all-features\` clean (matches Documentation CI command verbatim)
- [x] Runnable example: \`cd crates/noyalib && cargo run --example include_directive --features include_fs\` — 4 scenarios (in-memory, fragment anchor, cycle detection, SafeFileResolver vs temp dir) all green
- [ ] CI green on this branch