### PR TITLE
docs(i18n): drop broken intra-doc links to in-module symbols

### DIFF
--- a/crates/noyalib/src/i18n.rs
+++ b/crates/noyalib/src/i18n.rs
@@ -7,15 +7,15 @@
 //! preserves the noyalib-internal vocabulary (`!!binary`, "merge
 //! key", "recursion depth limit") that's useful for debugging but
 //! noisy for end-users of a config-loading binary. The
-//! [`MessageFormatter`] trait lets callers plug in their own
+//! `MessageFormatter` trait lets callers plug in their own
 //! formatting strategy: localisation tables, simplification,
 //! richer formatting, or anything else.
 //!
 //! Two implementations ship in-tree:
 //!
-//! * [`DefaultFormatter`] — preserves the standard developer-facing
+//! * `DefaultFormatter` — preserves the standard developer-facing
 //!   message verbatim. Equivalent to `format!("{err}")`.
-//! * [`UserFormatter`] — collapses noyalib's diagnostic vocabulary
+//! * `UserFormatter` — collapses noyalib's diagnostic vocabulary
 //!   into short user-friendly sentences ("The configuration file
 //!   has a syntax error on line 5.") suitable for surfacing in
 //!   GUIs and `--help`-style command output.


### PR DESCRIPTION
Documentation workflow on main failed after v0.0.5 merge on three intra-doc link sites in `crates/noyalib/src/i18n.rs`. Mirroring the v0.0.4 fix pattern (PR #38): replace link brackets with backticks for symbols defined in the same module.

## Test plan
- [x] `RUSTDOCFLAGS='-D warnings -D rustdoc::broken_intra_doc_links …' cargo doc --no-deps --all-features` clean locally
- [ ] Documentation CI green