### PR TITLE
test+docs: cover v0.0.5 surface (i18n + ariadne + include)

### DIFF
--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -273,6 +273,14 @@ name = "include_directive"
 path = "examples/include_directive.rs"
 required-features = ["include_fs"]
 
+[[example]]
+name = "config_macros"
+path = "examples/config_macros.rs"
+
+[[example]]
+name = "i18n_formatters"
+path = "examples/i18n_formatters.rs"
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }

--- a/crates/noyalib/examples/config_macros.rs
+++ b/crates/noyalib/examples/config_macros.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `parser_config!` / `serializer_config!` — declarative
+//! field-value builders that expand to the existing chained
+//! setter calls.
+//!
+//! Zero runtime overhead: the macro expansion is byte-identical
+//! to writing the builder chain by hand. The motivating
+//! ergonomics: dense call sites stay readable when you need to
+//! flip half-a-dozen flags.
+//!
+//! Run: `cargo run --example config_macros`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::{
+    DuplicateKeyPolicy, ParserConfig, SerializerConfig, YamlVersion, parser_config,
+    serializer_config,
+};
+
+fn main() {
+    support::header("noyalib -- config_macros");
+
+    support::task_with_output(
+        "parser_config! — flip several knobs in one expression",
+        || {
+            let cfg = parser_config! {
+                max_depth: 32,
+                max_alias_expansions: 200,
+                strict_booleans: true,
+                duplicate_key_policy: DuplicateKeyPolicy::Error,
+                version: YamlVersion::V1_1,
+            };
+            vec![
+                format!("max_depth             = {}", cfg.max_depth),
+                format!("max_alias_expansions  = {}", cfg.max_alias_expansions),
+                format!("strict_booleans       = {}", cfg.strict_booleans),
+                format!("duplicate_key_policy  = {:?}", cfg.duplicate_key_policy),
+                format!("version               = {:?}", cfg.yaml_version),
+            ]
+        },
+    );
+
+    support::task_with_output("parser_config! {} — empty form == new()", || {
+        let from_macro = parser_config! {};
+        let from_new = ParserConfig::new();
+        vec![
+            format!("macro.max_depth = new.max_depth = {}", from_macro.max_depth),
+            format!("both equal? {}", from_macro.max_depth == from_new.max_depth),
+        ]
+    });
+
+    support::task_with_output("serializer_config! — same pattern for emit knobs", || {
+        let cfg = serializer_config! {
+            indent: 4,
+            quote_all: true,
+        };
+        let _ = SerializerConfig::new(); // sanity import
+        vec![
+            format!("indent     = {}", cfg.indent),
+            format!("quote_all  = {}", cfg.quote_all),
+        ]
+    });
+
+    support::task_with_output(
+        "Equivalent to chained builders — pick whichever reads cleaner",
+        || {
+            let from_macro = parser_config! {
+                max_depth: 16,
+                max_alias_expansions: 50,
+            };
+            let from_chain = ParserConfig::new().max_depth(16).max_alias_expansions(50);
+            vec![format!(
+                "max_depth match: {}, alias match: {}",
+                from_macro.max_depth == from_chain.max_depth,
+                from_macro.max_alias_expansions == from_chain.max_alias_expansions
+            )]
+        },
+    );
+}

--- a/crates/noyalib/examples/i18n_formatters.rs
+++ b/crates/noyalib/examples/i18n_formatters.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `MessageFormatter` — render `Error` through pluggable
+//! formatters.
+//!
+//! Two bundled impls: `DefaultFormatter` (verbatim
+//! developer-facing message) and `UserFormatter` (short plain-
+//! language sentences appropriate for non-developer audiences).
+//! Custom localisation / rich-rendering plug in via the trait.
+//!
+//! Run: `cargo run --example i18n_formatters`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::i18n::{DefaultFormatter, MessageFormatter, UserFormatter};
+use noyalib::{Error, Value, from_str};
+
+fn main() {
+    support::header("noyalib -- i18n_formatters");
+
+    support::task_with_output("DefaultFormatter — verbatim Display output", || {
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![DefaultFormatter.format(&err)]
+    });
+
+    support::task_with_output("UserFormatter — plain-language sentence", || {
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![UserFormatter.format(&err)]
+    });
+
+    support::task_with_output("UserFormatter handles each Error category", || {
+        let errors: Vec<Error> = vec![
+            Error::DuplicateKey("api_key".into()),
+            Error::MissingField("password".into()),
+            Error::TypeMismatch {
+                expected: "integer",
+                found: "string".into(),
+            },
+            Error::RecursionLimitExceeded { depth: 256 },
+            Error::UnknownAnchor("backend-config".into()),
+        ];
+        errors
+            .iter()
+            .map(|e| format!("{:32}{}", format!("{e:.32}"), UserFormatter.format(e)))
+            .collect()
+    });
+
+    support::task_with_output("Custom formatter — implement MessageFormatter", || {
+        // A trivial example: uppercase all letters in the
+        // developer message. Real-world: localisation tables,
+        // GUI-friendly templates, audit-log structured output.
+        struct ShoutFormatter;
+        impl MessageFormatter for ShoutFormatter {
+            fn format(&self, error: &Error) -> String {
+                error.to_string().to_uppercase()
+            }
+        }
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![err.render_with_formatter(&ShoutFormatter)]
+    });
+
+    support::task_with_output(
+        "Error::render_with_formatter — dispatch entry point",
+        || {
+            let err = from_str::<Value>("a: [unclosed").unwrap_err();
+            vec![
+                format!("dev:  {}", err.render_with_formatter(&DefaultFormatter)),
+                format!("user: {}", err.render_with_formatter(&UserFormatter)),
+            ]
+        },
+    );
+}

--- a/crates/noyalib/tests/ariadne_adapter.rs
+++ b/crates/noyalib/tests/ariadne_adapter.rs
@@ -48,9 +48,6 @@ fn typed_target_error_renders() {
         .write(("config.yaml", Source::from(source)), &mut out)
         .unwrap();
     let s = String::from_utf8_lossy(&out);
-    // The deserialization error has no location (the typed-target
-    // path only carries one for parse-time errors), so the report
-    // is header-only — but the message must still render.
     assert!(
         s.contains("port") || s.contains("Error") || s.contains("error"),
         "{s}"
@@ -59,7 +56,6 @@ fn typed_target_error_renders() {
 
 #[test]
 fn report_without_location_still_renders() {
-    // Construct a custom error with no location attached.
     use noyalib::Error;
     let err = Error::Custom("synthetic".into());
     let report = error_to_ariadne_report(&err, "input.yaml", "source: value\n");
@@ -74,9 +70,7 @@ fn report_without_location_still_renders() {
 #[test]
 fn label_clamps_when_index_past_source_end() {
     use noyalib::Error;
-    // Custom error has no location, so this tests the fallback path.
     let err = Error::Custom("late".into());
-    // Even an empty source must not panic.
     let report = error_to_ariadne_report(&err, "input.yaml", "");
     let mut out = Vec::new();
     report
@@ -90,4 +84,40 @@ fn multibyte_unicode_at_label_does_not_panic() {
     let source = "name: 日本語\nbroken: [unclosed\n";
     let bytes = render(source);
     assert!(!bytes.is_empty());
+}
+
+#[test]
+fn label_span_normal_path_with_mid_source_location() {
+    // Force a parse error whose location lands mid-source so the
+    // normal `label_span` path (start < source.len(), char extract,
+    // char-width range) fires.
+    let source = "key: value\nnext: bad: scalar\nthird: value\n";
+    let err = from_str::<Value>(source).unwrap_err();
+    if let Some(loc) = err.location() {
+        assert!(
+            loc.index() < source.len(),
+            "expected mid-source location, got {}",
+            loc.index()
+        );
+    }
+    let report = error_to_ariadne_report(&err, "config.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("config.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    let rendered = String::from_utf8_lossy(&out);
+    assert!(rendered.contains("config.yaml"), "{rendered}");
+}
+
+#[test]
+fn label_span_handles_utf8_boundary() {
+    // Multi-byte UTF-8 at the label position must not panic.
+    let source = "name: 日本語の設定\nbad: [unclosed\n";
+    let err = from_str::<Value>(source).unwrap_err();
+    let report = error_to_ariadne_report(&err, "input.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("input.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    assert!(!out.is_empty());
 }

--- a/crates/noyalib/tests/i18n_formatters.rs
+++ b/crates/noyalib/tests/i18n_formatters.rs
@@ -102,6 +102,71 @@ fn message_formatter_works_through_dyn_dispatch() {
 }
 
 #[test]
+fn user_formatter_for_parse_no_location() {
+    let err = Error::Parse("synthetic parse failure".into());
+    let msg = UserFormatter.format(&err);
+    assert_eq!(msg, "The configuration file has a syntax error.");
+}
+
+#[test]
+fn user_formatter_for_deserialize() {
+    let err = Error::Deserialize("synthetic deser failure".into());
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("does not match"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_deserialize_with_location() {
+    use noyalib::Location;
+    let err = Error::DeserializeWithLocation {
+        message: "synthetic".into(),
+        location: Location::new(3, 5, 12),
+    };
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("line 3"), "{msg}");
+    assert!(msg.contains("does not match"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_io_error() {
+    let err = Error::Io(std::io::Error::other("synthetic io"));
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("Could not read"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_budget_breach() {
+    use noyalib::BudgetBreach;
+    let err = Error::Budget(BudgetBreach::MaxNodes {
+        limit: 100,
+        observed: 101,
+    });
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("large") || msg.contains("nested"), "{msg}");
+}
+
+#[test]
+fn user_formatter_catchall_for_unhandled_variants() {
+    // Custom is the catch-all path in UserFormatter — not one of
+    // the enumerated user-facing categories.
+    let err = Error::Custom("synthetic".into());
+    let msg = UserFormatter.format(&err);
+    assert_eq!(msg, "The configuration file is invalid.");
+}
+
+#[test]
+fn user_formatter_for_unknown_anchor_at() {
+    use noyalib::Location;
+    let err = Error::UnknownAnchorAt {
+        name: "anc".into(),
+        location: Location::new(2, 3, 5),
+        suggestion: None,
+    };
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("does not exist"), "{msg}");
+}
+
+#[test]
 fn custom_formatter_implementation() {
     struct UpperFormatter;
     impl MessageFormatter for UpperFormatter {

--- a/crates/noyalib/tests/include_directive.rs
+++ b/crates/noyalib/tests/include_directive.rs
@@ -253,6 +253,65 @@ mod safe_file {
         assert_eq!(split_fragment(""), ("", None));
         assert_eq!(split_fragment("#anchor"), ("", Some("anchor")));
     }
+
+    #[test]
+    fn resolver_with_nonexistent_root_errors() {
+        let dir = temp_dir("nonexistent");
+        let _ = std::fs::remove_dir_all(&dir);
+        let resolver = SafeFileResolver::new(&dir).into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include a.yaml\n", &cfg);
+        assert!(res.is_err(), "non-existent root must error");
+        let msg = res.unwrap_err().to_string();
+        assert!(
+            msg.contains("canonicalise"),
+            "expected canonicalisation error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_symlink_with_missing_file() {
+        let dir = temp_dir("rej-missing");
+        let resolver = SafeFileResolver::new(&dir)
+            .symlink_policy(SymlinkPolicy::Reject)
+            .into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include nope.yaml\n", &cfg);
+        assert!(res.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolver_reads_utf8_content() {
+        let dir = temp_dir("utf8");
+        std::fs::write(dir.join("multi.yaml"), "msg: 日本語の値\n").unwrap();
+        let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&dir).into_resolver());
+        let v: Value = from_str_with_config("inc: !include multi.yaml\n", &cfg).unwrap();
+        assert_eq!(v["inc"]["msg"].as_str(), Some("日本語の値"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_sandbox_is_rejected() {
+        // Symlink pointing outside the sandbox should be caught
+        // by the post-canonicalisation root-prefix check (under
+        // the default FollowWithinRoot policy).
+        let dir = temp_dir("escape");
+        // Stage an outside file.
+        let outside = std::env::temp_dir().join("noyalib-include-escape-outside.yaml");
+        std::fs::write(&outside, "secret: outside\n").unwrap();
+        // Symlink from inside dir → outside file.
+        std::os::unix::fs::symlink(&outside, dir.join("link.yaml")).unwrap();
+        let resolver = SafeFileResolver::new(&dir).into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include link.yaml\n", &cfg);
+        assert!(res.is_err(), "symlink target outside root must be rejected");
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("escapes"), "{msg}");
+        let _ = std::fs::remove_file(&outside);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }
 
 #[test]

--- a/crates/noyalib/tests/streaming_failsafe_tags.rs
+++ b/crates/noyalib/tests/streaming_failsafe_tags.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Streaming-path coverage for the YAML 1.2 failsafe-schema
+//! `!!`-prefixed tags (`!!int`, `!!float`, `!!str`, `!!bool`,
+//! `!!null`, `!!seq`, `!!map`). The streaming deserialiser
+//! short-circuits these to the appropriate visitor without
+//! enum-dispatch.
+
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::from_str;
+use serde::Deserialize;
+
+#[test]
+fn int_tag_resolves_to_integer() {
+    let n: i64 = from_str("!!int 42").unwrap();
+    assert_eq!(n, 42);
+}
+
+#[test]
+fn float_tag_resolves_to_float() {
+    let f: f64 = from_str("!!float 3.14").unwrap();
+    assert!((f - 3.14).abs() < 1e-9);
+}
+
+#[test]
+fn str_tag_keeps_numeric_as_string() {
+    let s: String = from_str("!!str 8080").unwrap();
+    assert_eq!(s, "8080");
+}
+
+#[test]
+fn bool_tag_resolves_to_bool() {
+    let b: bool = from_str("!!bool true").unwrap();
+    assert!(b);
+}
+
+#[test]
+fn null_tag_resolves_to_unit() {
+    #[derive(Debug, Deserialize)]
+    struct N {
+        x: Option<i64>,
+    }
+    let n: N = from_str("x: !!null ~").unwrap();
+    assert!(n.x.is_none());
+}
+
+#[test]
+fn seq_tag_resolves_to_sequence() {
+    let v: Vec<i64> = from_str("!!seq [1, 2, 3]").unwrap();
+    assert_eq!(v, vec![1, 2, 3]);
+}
+
+#[test]
+fn map_tag_resolves_to_mapping() {
+    #[derive(Debug, Deserialize)]
+    struct Doc {
+        a: i64,
+        b: i64,
+    }
+    let d: Doc = from_str("!!map {a: 1, b: 2}").unwrap();
+    assert_eq!(d.a, 1);
+    assert_eq!(d.b, 2);
+}


### PR DESCRIPTION
## Summary

Targeted tests + new examples for the v0.0.5 surface (i18n formatters, ariadne adapter, !include directive, streaming failsafe tags) whose coverage was below the workspace average.

## Coverage delta

Workspace TOTAL (\`NOYALIB_COVERAGE=1 cargo +nightly llvm-cov --workspace --all-features\` matching the CI gate command):

| Axis | Before | After | Δ |
| :--- | ---: | ---: | ---: |
| function | 96.31% | 96.42% | +0.11 |
| line     | 94.24% | 94.38% | +0.14 |
| region   | 93.34% | 93.46% | +0.12 |

The 95% target across all axes remains aspirational — the remaining gap (~1.5% region, ~0.6% line) lives in legitimately hard-to-reach paths inside \`value.rs\` (307 uncovered regions, 93.69%), \`cst/document.rs\` (108, 93.04%), \`de.rs\` (107, 86.76%), \`ser.rs\` (102, 94.34%), \`streaming.rs\` (88, 89.02%). Most are error / fallback / no_std branches that need targeted fixtures to engage. Closing those is its own multi-PR campaign.

## New tests

* \`i18n_formatters.rs\` — +7 covering every \`UserFormatter\` Error branch (Parse-no-location, Deserialize, DeserializeWithLocation, Io, BudgetBreach, catch-all Custom, UnknownAnchorAt)
* \`ariadne_adapter.rs\` — +2 covering \`label_span\` normal-path char-extract + UTF-8 boundary
* \`include_directive.rs\` — +4 covering SafeFileResolver edge cases (non-existent root, reject + missing file, UTF-8 content, symlink-escape post-canonicalisation rejection)
* \`streaming_failsafe_tags.rs\` (new) — 7 tests covering every \`!!\`-prefixed failsafe-schema tag (\`!!int\`, \`!!float\`, \`!!str\`, \`!!bool\`, \`!!null\`, \`!!seq\`, \`!!map\`)

## New examples

* \`examples/config_macros.rs\` — \`parser_config!\` / \`serializer_config!\` demonstration
* \`examples/i18n_formatters.rs\` — DefaultFormatter / UserFormatter / custom impl / dispatch

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test --workspace --all-features\` clean
- [x] \`cargo vet --locked\` succeeds (268 audited / 8 exempted)
- [x] Both new examples run cleanly (\`cargo run --example config_macros\`, \`cargo run --example i18n_formatters\`)
- [ ] CI green