### PR TITLE
feat(v0.0.6): Ecosystem Integration — recovery + sval + tokio + OIDC publish + hardening pass + #46 fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Dependabot configuration for `noyalib`.
+#
+# Three ecosystems are tracked:
+#
+# 1. `cargo` — workspace Cargo.toml + every crate manifest. Weekly
+#    runs (Monday 06:00 UTC). Grouped updates so a serde / clap
+#    bump arrives as one PR not five.
+# 2. `github-actions` — every workflow under `.github/workflows/`.
+#    Weekly runs. Updates the SHA pin alongside the version tag
+#    so the OpenSSF Scorecard `Pinned-Dependencies` check stays
+#    green.
+# 3. `npm` — the `pkg/npm-mcp-wrapper/` directory which ships the
+#    `noyalib-mcp` npm wrapper. Weekly runs.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot
+
+version: 2
+updates:
+  # ── Cargo workspace ──────────────────────────────────────────────
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps(cargo)"
+      include: scope
+    labels:
+      - dependencies
+      - rust
+    # Group related ecosystems into single PRs so reviewers don't
+    # drown in serde-version-bump churn.
+    groups:
+      serde:
+        patterns:
+          - "serde*"
+      clap:
+        patterns:
+          - "clap*"
+      miette-stack:
+        patterns:
+          - "miette*"
+          - "thiserror*"
+      tokio-stack:
+        patterns:
+          - "tokio*"
+          - "bytes"
+          - "futures*"
+      proc-macro:
+        patterns:
+          - "syn"
+          - "quote"
+          - "proc-macro2"
+      criterion:
+        patterns:
+          - "criterion*"
+          - "plotters*"
+      yaml-competitors:
+        patterns:
+          - "yaml-*"
+          - "serde_yaml*"
+          - "serde_yml*"
+          - "saphyr*"
+          - "rust-yaml"
+    # Workspace-private crates are auto-bumped via `cargo
+    # workspaces version` at release time, not by Dependabot.
+    ignore:
+      - dependency-name: "noyalib*"
+      - dependency-name: "noya-cli"
+
+  # ── GitHub Actions ──────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: scope
+    labels:
+      - dependencies
+      - github_actions
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+      sigstore:
+        patterns:
+          - "sigstore/*"
+      rust-toolchain:
+        patterns:
+          - "dtolnay/*"
+          - "Swatinem/*"
+          - "taiki-e/*"
+
+  # ── npm wrapper (`pkg/npm-mcp-wrapper`) ─────────────────────────
+  - package-ecosystem: npm
+    directory: /pkg/npm-mcp-wrapper
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps(npm)"
+      include: scope
+    labels:
+      - dependencies
+      - javascript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       # target dir. The sysroot is pinned to the nightly toolchain
       # version so the cache key includes the resolved compiler hash.
       - name: Cache Miri sysroot
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/miri

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -34,8 +34,15 @@
 #   SCOOP_BUCKET_TOKEN   → ScoopInstaller/GithubActions
 #   VSCODE_MARKETPLACE_PAT  → vsce publish
 #   OPEN_VSX_PAT         → ovsx publish
-#   NPM_TOKEN            → npm publish --provenance
 #   GITHUB_TOKEN         → provided automatically (release upload, GHCR push)
+#
+# npm publish uses Trusted Publishing (OIDC) — no long-lived
+# `NPM_TOKEN` is needed. The publish jobs declare `id-token: write`
+# and npm validates the workflow identity against per-package
+# trusted-publisher policies configured at
+# `https://www.npmjs.com/package/<name>/access`. The `npm publish
+# --provenance` flag attaches a verified-publisher badge linking
+# back to the GitHub Actions run that produced the artefact.
 
 name: Release binaries
 
@@ -689,6 +696,9 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -715,9 +725,7 @@ jobs:
               --scope noyalib \
               crates/noyalib-wasm
 
-      - name: Publish (with provenance)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish (Trusted Publishing + provenance)
         run: |
           cd crates/noyalib-wasm/pkg
           npm publish --provenance --access public
@@ -728,6 +736,9 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -743,9 +754,7 @@ jobs:
           cd pkg/npm-mcp-wrapper
           npm version "${{ needs.create-release.outputs.version }}" --no-git-tag-version --allow-same-version
 
-      - name: Publish (with provenance)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish (Trusted Publishing + provenance)
         run: |
           cd pkg/npm-mcp-wrapper
           npm publish --provenance --access public

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -58,11 +58,12 @@ on:
         type: boolean
         default: true
 
+# Least-privilege default: top-level workflow only reads.
+# The jobs that need write scope (release creation, GHCR push,
+# npm OIDC, attestation upload) declare it locally — see the
+# per-job `permissions:` blocks below.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -73,6 +74,8 @@ jobs:
   create-release:
     name: Create GitHub Release skeleton
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # creates the GitHub Release object
     outputs:
       version: ${{ steps.parse.outputs.version }}
       source_date_epoch: ${{ steps.parse.outputs.source_date_epoch }}
@@ -113,6 +116,10 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: create-release
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write       # uploads .tar.* / .zip assets to the release
+      id-token: write       # Fulcio keyless signing of release artefacts
+      attestations: write   # SLSA L3 build-provenance attestation
     strategy:
       fail-fast: false
       matrix:
@@ -307,7 +314,7 @@ jobs:
           done
 
       - name: Attest build provenance (SLSA L3)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: |
             ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.tar.gz
@@ -318,7 +325,7 @@ jobs:
             ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}-debuginfo.tar.gz
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
 
       - name: Sign artefacts (keyless)
         env:
@@ -365,6 +372,10 @@ jobs:
     name: macOS Universal Binary
     needs: [create-release, build-release]
     runs-on: macos-14
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     env:
       VERSION:      ${{ needs.create-release.outputs.version }}
       ARCHIVE_BASE: noyalib-${{ needs.create-release.outputs.version }}-universal-apple-darwin
@@ -413,12 +424,12 @@ jobs:
           shasum -a 512 "${ARCHIVE_BASE}.tar.gz" > "${ARCHIVE_BASE}.tar.gz.sha512"
 
       - name: Attest provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.tar.gz
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
 
       - name: Sign
         env:
@@ -451,6 +462,8 @@ jobs:
     name: Reproducible build
     needs: [create-release, build-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       TARGET:            x86_64-unknown-linux-gnu
       VERSION:           ${{ needs.create-release.outputs.version }}
@@ -514,6 +527,10 @@ jobs:
     needs: [create-release, build-release, lipo-universal, verify-reproducible]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # finalise GitHub Release notes
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -547,9 +564,11 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # external tap repo write via HOMEBREW_TAP_TOKEN
     steps:
       - name: Bump formula
-        uses: mislav/bump-homebrew-formula-action@v3
+        uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3
         with:
           formula-name:    noyalib
           formula-path:    Formula/noyalib.rb
@@ -568,6 +587,8 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # external AUR push via AUR_SSH_PRIVATE_KEY
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -592,7 +613,7 @@ jobs:
               pkg/arch/PKGBUILD.template > /tmp/PKGBUILD
 
       - name: Push to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v3
+        uses: KSXGitHub/github-actions-deploy-aur@a97f56a8425a7a7f3b8c58607f769c69b089cadb # v3
         with:
           pkgname:        noyalib-bin
           pkgbuild:       /tmp/PKGBUILD
@@ -607,6 +628,8 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # external bucket push via SCOOP_BUCKET_TOKEN
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -626,7 +649,7 @@ jobs:
               pkg/windows/scoop/noyalib.json > /tmp/noyalib.json
 
       - name: Push to Scoop bucket
-        uses: ScoopInstaller/GithubActions@v2
+        uses: ScoopInstaller/GithubActions@37a17b993c5ae4ae44fdc47379eb67010c800323 # v2.0.0
         with:
           token:    ${{ secrets.SCOOP_BUCKET_TOKEN }}
           bucket:   sebastienrousseau/scoop-bucket
@@ -638,6 +661,8 @@ jobs:
     needs: [create-release, build-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # uploads .vsix to the GitHub Release
     env:
       VERSION: ${{ needs.create-release.outputs.version }}
     steps:
@@ -645,7 +670,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache:        'npm'
@@ -713,7 +738,7 @@ jobs:
         with:
           version: 'latest'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -744,7 +769,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -765,6 +790,11 @@ jobs:
     needs: [create-release, github-release]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write      # push image manifest to ghcr.io
+      id-token: write      # cosign keyless signing of the image
+      attestations: write  # SLSA L3 image provenance
     strategy:
       fail-fast: false
       matrix:
@@ -777,16 +807,16 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push (multi-arch)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context:    .
           file:       ${{ matrix.image.dockerfile }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@ on:
         type: boolean
         default: true
 
+# Least-privilege default: top-level workflow only reads. The
+# jobs that need write scope (release-artifact attestation,
+# github-release upload) get it locally — see per-job
+# `permissions:` blocks below.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,6 +26,8 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -75,6 +79,15 @@ jobs:
     name: Build artifacts
     needs: validate
     runs-on: ubuntu-latest
+    # `id-token: write` — Fulcio keyless signing exchanges this OIDC
+    #   token for an ephemeral certificate that signs each `.crate`.
+    # `attestations: write` — SLSA L3 build-provenance attestation
+    #   is uploaded into the workflow's attestation store.
+    # `contents: read` — checkout / source access only.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -121,7 +134,7 @@ jobs:
       # Anyone can later verify the artefact came from this exact CI
       # workflow on this repo via `gh attestation verify`.
       - name: Attest build provenance (SLSA L3)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: |
             target/package/*.crate
@@ -135,7 +148,7 @@ jobs:
       # Verifiers run `cosign verify-blob` with the issuer / identity
       # constraints documented in SECURITY.md.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
       - name: Sign release artefacts (keyless)
         env:
           COSIGN_YES: "true"
@@ -174,6 +187,8 @@ jobs:
     name: Verify (${{ matrix.os }})
     needs: validate
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -192,6 +207,9 @@ jobs:
     needs: [artifacts, cross-verify]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # `contents: write` — required to create the GitHub Release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -245,6 +263,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     environment: crates-io
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,9 +8,11 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC
 
+# Least-privilege default: top-level workflow only reads. Jobs
+# that need write scope (CodeQL → security-events) get it
+# locally — see the per-job `permissions:` blocks below.
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   # ── Dependency review (PRs only) ───────────────────────────────────
@@ -18,6 +20,9 @@ jobs:
     name: Dependency Review
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4
@@ -91,6 +96,8 @@ jobs:
     name: Soak Miri (full suite)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 1440  # 24h ceiling
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v0.0.6 work-in-progress
+## [Unreleased]
+
+(Nothing yet — `[v0.0.6]` is the cut.)
+
+## [v0.0.6] — 2026-05-30
 
 The **Ecosystem Integration** cut. Lands the four remaining
-open issues from the v0.0.6 milestone (#22, #24, #25, #33) and
-closes out the leftover stabilisation checklist (#19).
+open issues from the v0.0.6 milestone (#22, #24, #25, #33),
+closes out the leftover stabilisation checklist (#19), the
+i18n hooks (#18), the user-reported pnpm-lock recursion bug
+(#46), and the OpenSSF Scorecard hardening pass that lifts
+the score from 6.5/10 to ~9/10.
 
 ### Fixed — streaming deserializer depth leak on empty flow mappings (issue #46)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ The **Ecosystem Integration** cut. Lands the four remaining
 open issues from the v0.0.6 milestone (#22, #24, #25, #33) and
 closes out the leftover stabilisation checklist (#19).
 
+### Fixed — streaming deserializer depth leak on empty flow mappings (issue #46)
+
+`StreamingMapAccess::next_key_seed` (and the symmetric
+`next_value_seed` / `StreamingSeqAccess::next_element_seed`)
+did not consult the access object's `finished` flag. Serde
+visitors that call `next_entry` after the previous call
+returned `Ok(None)` — `noyalib::Value`'s `ValueVisitor::visit_map`
+is the canonical one — read the **next event from the parent
+mapping** and treated it as belonging to the now-exhausted
+child. The recursive `deserialize_any` on each spilled value
+inflated `self.depth` by one per entry; on a `pnpm-lock.yaml`
+shaped input with N consecutive empty flow mappings `{}`,
+depth hit `max_depth + 1` after exactly 128 entries and
+`from_str::<Value>` failed with
+`Error::RecursionLimitExceeded { depth: 129 }` even though the
+real nesting depth was 2.
+
+Fix in `crates/noyalib/src/streaming.rs`:
+
+* Both `MapAccess::next_key_seed` and
+  `MapAccess::next_value_seed` return `Ok(None)` / a clear
+  contract-error early when `finished` is set.
+* `SeqAccess::next_element_seed` mirrors the guard.
+* `deserialize_any` / `deserialize_seq` / `deserialize_map`
+  now decrement `self.depth` on both `Ok` and `Err` so a
+  failed inner visit cannot leak depth into the outer scope
+  (the same leak path under a different trigger).
+
+Regression test: `crates/noyalib/tests/issue_46.rs` —
+50 000-package `pnpm-lock.yaml`-shaped fixture, 3 000 empty
+flow mappings at one level, complex peer-dependency keys, and
+the deterministic depth-cliff probe at every `n` in
+`[100, 128, 129, 130, 200, 500, 1000]`.
+
+Affects every typed deserialize target whose visitor calls
+`next_entry` past the end (including `BTreeMap<K, V>` and
+struct fields of optional shape). Default `from_str` users
+upgrading to this release should see only the previously-broken
+parses now succeed; no behavioural change on valid documents.
+
+
 ### Security & hardening pass on the v0.0.6 surface
 
 Post-merge deep-dive audit surfaced six DoS / correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,90 @@ The **Ecosystem Integration** cut. Lands the four remaining
 open issues from the v0.0.6 milestone (#22, #24, #25, #33) and
 closes out the leftover stabilisation checklist (#19).
 
+### Security & hardening pass on the v0.0.6 surface
+
+Post-merge deep-dive audit surfaced six DoS / correctness
+findings in the new modules; this section documents the fixes.
+
+* **Recovery `---`-spam OOM (C2).** `parse_lenient` now bounds
+  the document-marker scan by `ParserConfig::max_documents`. A
+  hostile `---\n`-only-spam input cannot drive unbounded
+  `Vec<usize>` allocation.
+* **Recovery O(n²) line-truncation (C1).** The truncation loop
+  is bounded by a new `LenientConfig::truncation_event_budget`
+  (default 1 MiB cumulative bytes across retries). Adversarial
+  10k-line malformed input no longer triggers ~10k full
+  re-parses.
+* **Async unbounded `read_to_end` (C3).** Both
+  `from_async_reader{,_with_config}` and the new
+  `from_async_reader_multi_with_config` drain through
+  `AsyncReadExt::take(max_document_length)`. Slow-drip
+  adversaries cannot grow the buffer beyond the configured
+  limit before the parser fires its own check.
+* **CRLF support (C4).** `recovery::split_documents`,
+  `tokio_async::find_doc_boundary`, and the existing
+  `parallel::split` now share **one** workspace-private scanner
+  in `crate::doc_boundary` that accepts both `\n` and `\r\n`
+  line terminators. The three previous copies disagreed on
+  CRLF — Windows-edited buffers round-trip through every entry
+  point now.
+* **BOM support (C5).** `parse_lenient` and both async readers
+  strip a leading UTF-8 BOM (`U+FEFF`) so Windows-saved buffers
+  parse identically to LF-on-Linux equivalents.
+* **Decoder recursion → loop (C6).** `YamlDecoder::decode` no
+  longer recurses on whitespace-only frames; the all-whitespace
+  preamble is consumed in a bounded `loop` instead, eliminating
+  the adversarial stack-overflow vector.
+
+Correctness fixes that landed alongside the hardening:
+
+* `parse_lenient` now collects Pass-2 / Pass-3 errors instead
+  of silently dropping them (M1).
+* Multi-document budget exhaustion no longer truncates the
+  output `Sequence` — skipped documents are emitted as
+  `Value::Null` so per-document diagnostic indices stay
+  aligned for LSP joiners (M2).
+* Line-truncation now treats the buffer end as a candidate
+  cut, so a malformed last line **without** a trailing newline
+  (the universal mid-typing case) is still recoverable (M3).
+* Pass-2 `ParserConfig` clone hoisted out of the hot path —
+  one clone per document, not one per pass (M13).
+
+Surface additions on the tokio module:
+
+* `from_async_reader_multi_with_config` — config-aware variant
+  was missing.
+* `YamlDecoder::max_frame_size(usize)` — optional inter-frame
+  buffer cap for codec users driving untrusted-network input
+  (M7). `Decoder::decode` returns
+  `Error::Io(InvalidData)` when the buffer exceeds the cap.
+* `YamlDecoder` is now `Clone`.
+
+Surface additions on the sval adapter:
+
+* `to_sval_writer_with_config` + `SvalConfig` —
+  `coerce_non_finite_to_null` toggles NaN / ±∞ → `Null` so
+  downstream consumers (e.g. `sval_json`) that reject
+  non-finites accept the stream (M10).
+* `impl sval::Value for Tag` — the public `Tag` type now has a
+  direct sval impl (M12).
+
+Documentation:
+
+* `SECURITY.md` and `doc/POLICIES.md` document the new
+  resource-limit knobs and their threat model.
+* CHANGELOG, READMEs, and `RELEASE-NOTES-v0.0.6.md` cross-reference
+  the new safe-by-default contracts.
+* MSRV inconsistency (workspace claimed 1.75 in some places,
+  Cargo.toml says 1.85 since v0.0.5) resolved on both axes.
+
+Tests: +24 unit tests across the three modules (61 total),
+covering CRLF, BOM, `---`-spam, no-trailing-newline truncation,
+budget-exhaustion index preservation, oversize-reader truncation,
+frame-size cap, NaN coercion. Plus a new
+`bench_recovery_lenient_on_invalid_input` arm exercising the
+3-pass recovery loop on realistic LSP-style half-typed input.
+
 ### Added — Error-recovering parser (`recovery` feature, issue #22)
 
 `noyalib::recovery::parse_lenient` returns a `ParseResult`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ struct fields of optional shape). Default `from_str` users
 upgrading to this release should see only the previously-broken
 parses now succeed; no behavioural change on valid documents.
 
+### Fixed — no-span loader missing depth-limit check
+
+Companion audit finding to issue #46: the no-span loader path
+(`crates/noyalib/src/parser/loader.rs`) — used by
+`from_str::<Value>`'s value-target fast path and by `no_std`
+multi-document loading — incremented `self.depth` on
+`SequenceStart` / `MappingStart` events at lines 814 / 833 but
+did **not** check against `ParserConfig::max_depth` the way
+the span-tracked loader does at lines 399-401 / 443-445.
+Adversarial deeply-nested input could consume stack without
+ever firing `RecursionLimitExceeded`. Now mirrored from the
+span loader. Regression test:
+`no_span_loader_honours_max_depth` in
+`crates/noyalib/tests/issue_46.rs`.
+
+Both findings were surfaced by the same code-pattern audit
+that confirmed every `MapAccess` / `SeqAccess` /
+`EnumAccess` / `VariantAccess` impl across `streaming.rs`,
+`de.rs`, and `value.rs` either has a `finished`-style guard
+or uses an iterator that naturally returns `None` on
+exhaustion. No further iterator-state-leak bugs in the same
+family remain.
+
 
 ### Security & hardening pass on the v0.0.6 surface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,68 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] — v0.0.6 work-in-progress
 
-(Nothing yet — `[v0.0.5]` is the cut.)
+The **Ecosystem Integration** cut. Lands the four remaining
+open issues from the v0.0.6 milestone (#22, #24, #25, #33) and
+closes out the leftover stabilisation checklist (#19).
+
+### Added — Error-recovering parser (`recovery` feature, issue #22)
+
+`noyalib::recovery::parse_lenient` returns a `ParseResult`
+carrying the best-effort tree plus the list of every error
+encountered, so LSP / IDE consumers can keep showing
+autocomplete and diagnostics on half-typed documents.
+
+```rust
+let r = noyalib::recovery::parse_lenient("a: 1\nb: [unclosed\n");
+assert!(!r.is_complete);
+assert!(!r.errors.is_empty());
+```
+
+Recovery strategies — strict pass first, then
+`DuplicateKeyPolicy::Last` retry, then line-truncation retry
+that drops trailing lines until something parses.
+Multi-document input is split on `---` and each document is
+recovered independently. Error collection is capped via
+`LenientConfig::max_errors`.
+
+Gated behind the new `recovery` Cargo feature; zero extra deps.
+
+### Added — `sval` streaming adapter (`sval` feature, issue #25)
+
+Alternative to the default serde route for callers wanting to
+skip `serde_derive`'s compile-time overhead or the binary-size
+cost of serde monomorphisation. Adds `impl sval::Value for
+Value`, `Number`, `Mapping`, `MappingAny`, and `TaggedValue`,
+plus a `noyalib::sval_adapter::to_sval_writer` entry point.
+serde remains the default; this is opt-in.
+
+### Added — Native tokio async parsing (`tokio` feature, issue #24)
+
+`noyalib::tokio_async::from_async_reader` /
+`from_async_reader_multi` parse from any
+`tokio::io::AsyncRead` without `spawn_blocking`.
+`YamlDecoder<T>` is a `tokio_util::codec::Decoder` for
+plugging streaming YAML parsing into a
+`tokio_util::codec::Framed` / tower pipeline. Per-document
+emission boundary follows the YAML 1.2.2 §9.1.2 `---` grammar.
+
+### Changed — npm publish moves to Trusted Publishing / OIDC (issue #33)
+
+`.github/workflows/release-binaries.yml` no longer reads
+`NPM_TOKEN`; both `@noyalib/noyalib-wasm` and `noyalib-mcp`
+publish jobs declare `id-token: write` and rely on the OIDC
+handshake against per-package trusted-publisher policies
+configured at `https://www.npmjs.com/package/<name>/access`.
+`pkg/PUBLISH.md` §6 documents the bootstrap + secret-retirement
+flow.
+
+Compromise window collapses from 1 year (granular access
+token) to ~10 minutes (per-run OIDC token). The
+`--provenance` flag stays attached to both publish steps so
+the npm verified-publisher badge keeps linking back to the
+exact GitHub Actions run.
 
 ## [v0.0.5] — 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,7 +362,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -640,6 +646,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1179,6 +1191,7 @@ name = "noyalib"
 version = "0.0.5"
 dependencies = [
  "ariadne",
+ "bytes",
  "criterion",
  "figment",
  "garde",
@@ -1202,6 +1215,9 @@ dependencies = [
  "serde_yaml_ng",
  "serde_yml",
  "smallvec",
+ "sval",
+ "tokio",
+ "tokio-util",
  "validator",
  "yaml-rust2",
  "yaml-spanned",
@@ -2006,6 +2022,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
+name = "sval"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb9efbae90f97301f4d25f3be63dfd99d6b7af9d088228a52ec960d649b2e7d"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2129,41 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,16 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d325b93a27b93b93b7cf4a57d681c5b6a4d8f910e695db989c055eb1e4f657df"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,7 +1203,6 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_yaml_ng",
- "serde_yml",
  "smallvec",
  "sval",
  "tokio",
@@ -1947,21 +1936,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "ariadne",
  "bytes",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ wants to *use* the library. The full reference is the
 
 ```toml
 [dependencies]
-noyalib = "0.0.1"
+noyalib = "0.0.6"
 ```
 
 `no_std` (alloc-only) and lean profiles are documented in the

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ the application needs.
 | `validator` | `validator` 0.19 | `ValidatedValidator<T>` wrapper | `examples/validation_validator.rs` |
 | `robotics` | — | `Degrees`, `Radians`, `StrictFloat` newtypes | `examples/robotics_polymorphism.rs` |
 | `parallel` | `rayon` 1.10 | `noyalib::parallel::parse<T>` for `---`-separated streams | [Benchmarks](#benchmarks) |
+| `recovery` | — | `noyalib::recovery::parse_lenient` — best-effort tree + error list for LSP / IDE half-typed documents | `examples/recovery_lenient.rs`, `benches/v006_features.rs` |
+| `sval` | `sval` 2 | `impl sval::Value` for `Value` / `Number` / `Mapping` / `MappingAny` / `TaggedValue`, `noyalib::sval_adapter::to_sval_writer` | `examples/sval_streaming.rs`, `benches/v006_features.rs` |
+| `tokio` | `tokio`, `tokio-util`, `bytes` | `noyalib::tokio_async::from_async_reader` / `from_async_reader_multi` and `YamlDecoder` codec for `tokio_util::codec::Framed` pipelines | `examples/tokio_async_reader.rs`, `benches/v006_features.rs` |
 | `simd` | — | `noyalib::simd::*` primitives + parser hot path | [Benchmarks](#benchmarks) |
 | `nightly-simd` | `simd` (nightly toolchain) | `core::simd`-backed `StructuralIter` (32-byte chunks) | [Benchmarks](#benchmarks) |
 | `compat-serde-yaml` | — | `noyalib::compat::serde_yaml` shim for migration | [When not to use noyalib](#when-not-to-use-noyalib) |

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ downstream users pinned to the core's floor.
 
 | Crate | MSRV | Why |
 |---|---|---|
-| `noyalib` (core lib) | **1.75.0** | The committed floor for `default-features = false` + the standard `std` default. Enforced by the dedicated `msrv-1-75-core` CI job. |
-| `noyalib-mcp` | 1.75.0 | Same floor; small dep tree, no edition-2024 transitives. |
+| `noyalib` (core lib) | **1.85.0** | The committed floor since v0.0.5 (edition 2024). Enforced by the dedicated MSRV CI job. |
+| `noyalib-mcp` | 1.85.0 | Same floor; small dep tree, no transitives requiring a higher edition. |
 | `noya-cli` (binaries) | 1.85.0 | `clap_builder 4.6` (a transitive of `clap = "4.5"`) ships in edition 2024. |
 | `noyalib-lsp` | 1.85.0 | LSP transport-stack transitives (`litemap`, `uuid`) require recent stables. |
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.1"
+noyalib = "0.0.6"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.1", default-features = false }
+noyalib = { version = "0.0.6", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -175,7 +175,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.1", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.6", features = ["miette", "validate-schema"] }
 ```
 
 ---
@@ -280,7 +280,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0"
++noyalib = "0.0.6"
 ```
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -488,25 +488,31 @@ Headline numbers (Apple M4 / aarch64, Rust 1.95 stable,
 `--release` with LTO=fat, codegen-units=1, panic=abort,
 criterion `--warm-up-time 2 --measurement-time 4`):
 
-| Fixture | noyalib | vs `serde_yaml_ng` | vs `yaml-rust2` | vs `serde_yml` | vs `yaml-spanned` | vs `serde-saphyr` |
-|---|---:|---:|---:|---:|---:|---:|
-| Deserialise simple (3 fields) | **1.40 µs** | **1.84×** | 1.36× | **1.96×** | 1.69× | **2.00×** |
-| Deserialise nested (20 fields) | **9.66 µs** | **1.55×** | 1.25× | **1.63×** | **1.60×** | **1.76×** |
-| Deserialise large_list (500 items) | **920 µs** | **1.42×** | 1.19× | **1.48×** | **1.38×** | **1.69×** |
-| Deserialise github_actions (deep + comments) | **46.4 µs** | **1.66×** | 1.25× | **1.72×** | **1.74×** | **1.73×** |
-| Deserialise k8s multi-document | **85.1 µs** | **1.42×** | 1.11× | — | — | — |
-| Typed deserialise simple (streaming) | **1.22 µs** | **1.72×** | — | — | — | — |
-| Typed deserialise nested (streaming) | **7.08 µs** | **1.55×** | — | — | — | — |
-| Serialise simple | **290 ns** | **4.34×** | — | — | — | — |
-| Serialise nested | **2.25 µs** | **3.00×** | — | — | — | — |
-| Round-trip nested | **12.0 µs** | **1.83×** | — | — | — | — |
-| Structural-discovery (1 MiB, nightly-SIMD) | **311 µs** | — | — | — | — | 9.2× over memchr loop |
-| SWAR decimal parse (`i64::MAX`) | **9.75 ns** | — | — | — | — | 2.5× over stdlib |
+| Fixture | noyalib | vs `serde_yaml_ng` | vs `yaml-rust2` | vs `yaml-spanned` | vs `serde-saphyr` |
+|---|---:|---:|---:|---:|---:|
+| Deserialise simple (3 fields) | **1.40 µs** | **1.84×** | 1.36× | 1.69× | **2.00×** |
+| Deserialise nested (20 fields) | **9.66 µs** | **1.55×** | 1.25× | **1.60×** | **1.76×** |
+| Deserialise large_list (500 items) | **920 µs** | **1.42×** | 1.19× | **1.38×** | **1.69×** |
+| Deserialise github_actions (deep + comments) | **46.4 µs** | **1.66×** | 1.25× | **1.74×** | **1.73×** |
+| Deserialise k8s multi-document | **85.1 µs** | **1.42×** | 1.11× | — | — |
+| Typed deserialise simple (streaming) | **1.22 µs** | **1.72×** | — | — | — |
+| Typed deserialise nested (streaming) | **7.08 µs** | **1.55×** | — | — | — |
+| Serialise simple | **290 ns** | **4.34×** | — | — | — |
+| Serialise nested | **2.25 µs** | **3.00×** | — | — | — |
+| Round-trip nested | **12.0 µs** | **1.83×** | — | — | — |
+| Structural-discovery (1 MiB, nightly-SIMD) | **311 µs** | — | — | — | 9.2× over memchr loop |
+| SWAR decimal parse (`i64::MAX`) | **9.75 ns** | — | — | — | 2.5× over stdlib |
+
+(`serde_yml` was previously a comparison column — retired in
+v0.0.6 since RUSTSEC-2025-0068 flagged it unsound + unmaintained;
+the bench arm was dropped so the OpenSSF Scorecard Vulnerabilities
+check stays clean. The headline ratios above are unchanged for
+the remaining four competitors.)
 
 `noyalib` is faster than **every other pure-Rust YAML library on
-every deserialize fixture measured**. Speedup ranges across the five
+every deserialize fixture measured**. Speedup ranges across the four
 competitors above: **1.69×–2.00×** vs `serde-saphyr`,
-**1.48×–1.96×** vs `serde_yml`, **1.42×–1.84×** vs `serde_yaml_ng`,
+**1.42×–1.84×** vs `serde_yaml_ng`,
 **1.38×–1.74×** vs `yaml-spanned`, **1.11×–1.36×** vs `yaml-rust2`.
 Serialize is **3.00×–4.34×** ahead of `serde_yaml_ng`.
 
@@ -1478,7 +1484,13 @@ value.interpolate_properties_lossy(&map);
 - `cargo vet` clean — every dependency in the graph has a local
   audit or imported coverage from Mozilla / Google / Bytecode
   Alliance / Embark / ISRG audit sets.
-- `OpenSSF Scorecard` tracked, badge in the header.
+- `OpenSSF Scorecard` tracked, badge in the header — v0.0.6
+  lifts the score from `6.5/10` to `~9/10` by demoting workflow
+  tokens to least privilege, pinning every GitHub Action by
+  SHA, wiring Dependabot, and retiring the unmaintained
+  `serde_yml` / `libyml` bench dev-deps. See
+  [`doc/POLICIES.md` § OpenSSF Scorecard posture](doc/POLICIES.md#openssf-scorecard-posture)
+  for the per-check breakdown.
 - `SLSA L3` build provenance + sigstore signing on every release.
 - `REUSE.software` 3.3 compliant — every source file carries
   SPDX headers.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://crates.io/crates/noyalib"><img src="https://img.shields.io/crates/v/noyalib.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/noyalib"><img src="https://img.shields.io/badge/docs.rs-noyalib-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://lib.rs/crates/noyalib"><img src="https://img.shields.io/badge/lib.rs-noyalib-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/RELEASE-NOTES-v0.0.6.md
+++ b/RELEASE-NOTES-v0.0.6.md
@@ -112,9 +112,10 @@ Folded into the v0.0.5 + v0.0.6 cuts:
 * `CHANGELOG.md` updated with all changes since v0.0.1 —
   present.
 * Benchmark suite — `crates/noyalib/benches/comparison.rs`
-  compares against `serde_yaml_ng`, `yaml-rust2`, `serde_yml`,
+  compares against `serde_yaml_ng`, `yaml-rust2`,
   `yaml-spanned`, with optional `serde-saphyr` via the
-  `compare-saphyr` feature.
+  `compare-saphyr` feature. (`serde_yml` was retired from the
+  comparison in v0.0.6 — see the OpenSSF Scorecard pass below.)
 
 ## Bug fixes
 

--- a/RELEASE-NOTES-v0.0.6.md
+++ b/RELEASE-NOTES-v0.0.6.md
@@ -116,6 +116,49 @@ Folded into the v0.0.5 + v0.0.6 cuts:
   `yaml-spanned`, with optional `serde-saphyr` via the
   `compare-saphyr` feature.
 
+## Bug fixes
+
+### `pnpm-lock.yaml` recursion-limit false positive (issue #46)
+
+`from_str::<Value>` on a `pnpm-lock.yaml`-shaped input failed
+with `Error::RecursionLimitExceeded { depth: 129 }` even when
+the document was only a few levels deep. Root cause:
+`StreamingMapAccess::next_key_seed` did not check the access
+object's `finished` flag, so serde visitors that call
+`next_entry` after `Ok(None)` — `ValueVisitor::visit_map` does
+this — read the next event from the **parent** mapping and
+treated it as belonging to the now-exhausted child. The
+recursive `deserialize_any` on each spilled value inflated
+`self.depth` by exactly one per empty flow `{}`, hitting
+`max_depth + 1` after 128 entries.
+
+Fix: `finished`-guard early-returns in the three
+`StreamingMapAccess` / `StreamingSeqAccess` iterators, plus
+balanced `depth` decrement on both `Ok` and `Err` in
+`deserialize_any` / `deserialize_seq` / `deserialize_map` so
+a failed inner visit can't leak depth either.
+
+Companion audit finding: the `NoSpanLoader` path
+(`crates/noyalib/src/parser/loader.rs`) — used by
+`from_str::<Value>`'s value-target fast path and by `no_std`
+multi-document loading — incremented `self.depth` on
+`SequenceStart` / `MappingStart` but **did not check**
+against `max_depth` (the span-tracked loader does).
+Adversarial deeply-nested input through that path could
+consume stack without ever firing `RecursionLimitExceeded`.
+Now mirrored from the span loader.
+
+10 regression tests in `crates/noyalib/tests/issue_46.rs`:
+50 000-package full `pnpm-lock-v9` shape, 3 000 consecutive
+empty flow mappings, deterministic depth-cliff probe at
+`n ∈ [100, 128, 129, 130, 200, 500, 1000]`, complex
+peer-dependency keys, 200-level-deep sequence for the no-span
+path.
+
+No API change. Documents that previously failed with
+`RecursionLimitExceeded` now parse cleanly; documents that
+previously parsed are unchanged.
+
 ## Compatibility
 
 * MSRV unchanged from v0.0.5 (1.85, edition 2024).
@@ -123,6 +166,8 @@ Folded into the v0.0.5 + v0.0.6 cuts:
 * All new functionality is gated behind opt-in Cargo features
   (`recovery`, `sval`, `tokio`); no impact on existing call
   sites that don't enable them.
+* Issue #46 fix + no-span depth-check fix are pure bug fixes
+  — no API change.
 
 ## Acknowledgements
 

--- a/RELEASE-NOTES-v0.0.6.md
+++ b/RELEASE-NOTES-v0.0.6.md
@@ -1,0 +1,131 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.6 — Release Notes
+
+The **Ecosystem Integration** cut. Lands the four remaining
+open issues from the v0.0.6 milestone (#22, #24, #25, #33) and
+closes out the leftover stabilisation checklist (#19).
+
+## Highlights
+
+* **Error-recovering parser.** `noyalib::recovery::parse_lenient`
+  returns a `ParseResult` carrying the best-effort tree plus the
+  list of every error encountered. LSP / IDE consumers can keep
+  showing autocomplete and diagnostics on half-typed documents.
+  New `recovery` Cargo feature; no extra deps.
+* **`sval` streaming adapter.** Alternative to the default serde
+  route for callers wanting to skip `serde_derive`'s compile-time
+  overhead. New `sval` Cargo feature.
+* **Native tokio async parsing.** `from_async_reader` /
+  `from_async_reader_multi` parse from any `tokio::io::AsyncRead`
+  without `spawn_blocking`. `YamlDecoder<T>` is a
+  `tokio_util::codec::Decoder` for plugging streaming YAML
+  parsing into a tower-middleware chain. New `tokio` Cargo
+  feature.
+* **npm Trusted Publishing.** The release pipeline drops the
+  long-lived `NPM_TOKEN` and uses OIDC to authenticate. Compromise
+  window collapses from 1 year to ~10 minutes.
+
+## What ships
+
+### `noyalib::recovery` (issue #22, P1)
+
+```rust
+use noyalib::recovery::parse_lenient;
+let r = parse_lenient("a: 1\nb: [unclosed\n");
+assert!(!r.is_complete);
+assert!(!r.errors.is_empty());
+// `r.value` is the best-effort recovered tree.
+```
+
+Recovery strategies — strict pass first, then
+`DuplicateKeyPolicy::Last` retry, then line-truncation retry
+that drops trailing lines until something parses. Multi-document
+input is split on `---` and each document is recovered
+independently. Error collection is capped via
+`LenientConfig::max_errors`.
+
+For multi-document input the result's `value` is a
+`Value::Sequence` of per-document values (recovered or `Null`);
+for single-document input it is the recovered document directly.
+
+### `noyalib::sval_adapter` (issue #25, P2)
+
+Adds `impl sval::Value for Value`, `Number`, `Mapping`,
+`MappingAny`, and `TaggedValue`, plus a
+`noyalib::sval_adapter::to_sval_writer` entry point that streams
+a noyalib value graph to any `sval::Stream` consumer.
+
+serde remains the default; `sval` is opt-in for callers who want
+to avoid the binary-size cost of serde monomorphisation or the
+~5–10s compile overhead of `serde_derive` on large projects.
+
+### `noyalib::tokio_async` (issue #24, P2)
+
+```rust
+// Single document
+let pkg: Pkg = noyalib::tokio_async::from_async_reader(&mut reader).await?;
+
+// Multi document
+let docs: Vec<Pkg> = noyalib::tokio_async::from_async_reader_multi(&mut reader).await?;
+
+// Codec — for tower middleware chains
+let framed = tokio_util::codec::FramedRead::new(
+    reader,
+    noyalib::tokio_async::YamlDecoder::<Pkg>::new(),
+);
+```
+
+The codec emits one parsed `T` per `---`-delimited document.
+Per-document boundary detection follows the YAML 1.2.2 §9.1.2
+`---` grammar — column-0 marker followed by whitespace or EOL.
+
+### npm Trusted Publishing (issue #33, security)
+
+`.github/workflows/release-binaries.yml` no longer reads
+`NPM_TOKEN`; both `@noyalib/noyalib-wasm` and `noyalib-mcp`
+publish jobs declare `id-token: write` and rely on the OIDC
+handshake against per-package trusted-publisher policies
+configured at `https://www.npmjs.com/package/<name>/access`.
+`pkg/PUBLISH.md` §6 documents the bootstrap + secret-retirement
+flow.
+
+The `--provenance` flag stays attached to both publish steps so
+the npm verified-publisher badge keeps linking back to the
+exact GitHub Actions run that produced the artefact.
+
+### API stabilisation checklist (issue #19, P1)
+
+Folded into the v0.0.5 + v0.0.6 cuts:
+
+* `#[non_exhaustive]` on all public configuration types — done
+  via v0.0.5 audit. `ParseResult` (new in v0.0.6) follows the
+  same pattern; `LenientConfig` deliberately does not, so
+  callers can use struct-literal syntax (`LenientConfig { … }`).
+* All public functions have doc-comments with examples — the
+  workspace `missing_docs = "warn"` + the strict-doc gate on
+  CI enforce it.
+* `Error` enum's variant set is comprehensive and actionable —
+  no new variants needed; `i18n::MessageFormatter` (v0.0.5)
+  surfaces a customisable user-facing rendering layer.
+* `CHANGELOG.md` updated with all changes since v0.0.1 —
+  present.
+* Benchmark suite — `crates/noyalib/benches/comparison.rs`
+  compares against `serde_yaml_ng`, `yaml-rust2`, `serde_yml`,
+  `yaml-spanned`, with optional `serde-saphyr` via the
+  `compare-saphyr` feature.
+
+## Compatibility
+
+* MSRV unchanged from v0.0.5 (1.85, edition 2024).
+* Default-features behaviour unchanged.
+* All new functionality is gated behind opt-in Cargo features
+  (`recovery`, `sval`, `tokio`); no impact on existing call
+  sites that don't enable them.
+
+## Acknowledgements
+
+Thanks to the LSP-tooling community (issue #22 reporters) and
+the npm Security team's Trusted Publishing rollout for shaping
+the API surface here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,24 @@ Configurable limits protect against denial-of-service attacks:
 
 Use `ParserConfig::strict()` for a hardened preset suitable for untrusted input.
 
+#### v0.0.6 optional surfaces
+
+The three opt-in modules added in v0.0.6 (`recovery`, `sval`,
+`tokio`) inherit every limit above and add their own DoS
+mitigations:
+
+| Surface | Guard | Knob |
+|:--------|:------|:-----|
+| `noyalib::recovery::parse_lenient` | `---`-marker count cap (defeats marker-spam OOM) | `ParserConfig::max_documents` |
+| `noyalib::recovery::parse_lenient` | Cumulative byte budget across line-truncation retries (defeats O(n²) re-parse on 10k-line malformed input) | `LenientConfig::truncation_event_budget` (default 1 MiB) |
+| `noyalib::tokio_async::from_async_reader` | Bounded `AsyncReadExt::take(max_document_length)` drain (defeats slow-drip OOM) | `ParserConfig::max_document_length` |
+| `noyalib::tokio_async::YamlDecoder` | Optional inter-frame buffer cap (defeats codec buffer pinning by adversarial producer) | `YamlDecoder::max_frame_size(usize)` |
+
+Untrusted-input deployments driving `YamlDecoder` over a network
+stream **should** call `max_frame_size(_)` to a sane upper bound;
+the default `None` matches the trust contract of a process-local
+in-memory consumer.
+
 ### Supply Chain
 
 - Runtime deps audited (`cargo-deny` in CI): license validation, advisory checks, source verification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,18 @@ stream **should** call `max_frame_size(_)` to a sane upper bound;
 the default `None` matches the trust contract of a process-local
 in-memory consumer.
 
+#### `max_depth` guard correctness (issue #46)
+
+The `max_depth` guard above relies on balanced increment /
+decrement of the parser's internal depth counter on every
+code path. Two correctness bugs were patched in v0.0.6 — one
+that made `from_str::<Value>` falsely report
+`RecursionLimitExceeded` on shallow `pnpm-lock.yaml` inputs,
+and one in the no-span loader path that incremented depth
+without ever checking the limit. See
+[`doc/POLICIES.md` § Resource-limit gates](doc/POLICIES.md#resource-limit-gates)
+for the full treatment.
+
 ### Supply Chain
 
 - Runtime deps audited (`cargo-deny` in CI): license validation, advisory checks, source verification.

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.5", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.6", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noya-cli/README.md
+++ b/crates/noya-cli/README.md
@@ -17,7 +17,7 @@
   <a href="https://crates.io/crates/noyalib"><img src="https://img.shields.io/crates/v/noyalib.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/noyalib"><img src="https://img.shields.io/badge/docs.rs-noyalib-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://github.com/sebastienrousseau/noyalib/releases"><img src="https://img.shields.io/github/v/release/sebastienrousseau/noyalib?style=for-the-badge&label=release&color=blueviolet" alt="GitHub Release" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.5", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.6", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-lsp/README.md
+++ b/crates/noyalib-lsp/README.md
@@ -17,7 +17,7 @@
   <a href="https://crates.io/crates/noyalib-lsp"><img src="https://img.shields.io/crates/v/noyalib-lsp.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/noyalib-lsp"><img src="https://img.shields.io/badge/docs.rs-noyalib--lsp-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://lib.rs/crates/noyalib-lsp"><img src="https://img.shields.io/badge/lib.rs-noyalib-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.5" }
+noyalib = { path = "../noyalib", version = "0.0.6" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/README.md
+++ b/crates/noyalib-mcp/README.md
@@ -17,7 +17,7 @@
   <a href="https://crates.io/crates/noyalib-mcp"><img src="https://img.shields.io/crates/v/noyalib-mcp.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/noyalib-mcp"><img src="https://img.shields.io/badge/docs.rs-noyalib--mcp-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://lib.rs/crates/noyalib-mcp"><img src="https://img.shields.io/badge/lib.rs-noyalib-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/crates/noyalib-mcp/tests/protocol.rs
+++ b/crates/noyalib-mcp/tests/protocol.rs
@@ -50,14 +50,26 @@ fn round_trip(messages: &[Value]) -> Vec<Value> {
 }
 
 fn tempfile(contents: &str) -> std::path::PathBuf {
+    // `process::id() + SystemTime::now().as_nanos()` is normally
+    // unique per call — but on Windows-nightly under cargo-test's
+    // parallel scheduler two calls have been observed landing in
+    // the same nanosecond, leading to a path collision that
+    // silently shared a fixture between concurrent tests. Append
+    // a monotonically-increasing process-local counter so the
+    // path is guaranteed unique even under nano collisions.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+
     let dir = std::env::temp_dir();
     let path = dir.join(format!(
-        "noyalib-mcp-test-{}-{}.yaml",
+        "noyalib-mcp-test-{}-{}-{}.yaml",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_nanos()
+            .as_nanos(),
+        seq,
     ));
     std::fs::write(&path, contents).unwrap();
     path

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.5", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.6", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib-wasm/README.md
+++ b/crates/noyalib-wasm/README.md
@@ -18,7 +18,7 @@
   <a href="https://www.npmjs.com/package/@noyalib/noyalib-wasm"><img src="https://img.shields.io/npm/v/@noyalib/noyalib-wasm?style=for-the-badge&color=fc8d62&logo=npm" alt="npm" /></a>
   <a href="https://docs.rs/noyalib-wasm"><img src="https://img.shields.io/badge/docs.rs-noyalib--wasm-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://bundlephobia.com/package/@noyalib/noyalib-wasm"><img src="https://img.shields.io/bundlephobia/minzip/@noyalib/noyalib-wasm?style=for-the-badge&color=informational" alt="Bundle size" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -376,10 +376,12 @@ rust-yaml = "0.0.5"
 # `crates/noyalib/benches/comparison.rs` for head-to-head Rust
 # YAML benchmarks. See `doc/BENCHMARKS.md` for measured numbers.
 #
-# `serde_yml` is the maintainer's prior crate (a `serde_yaml` 0.9
-# fork). `yaml-spanned` is the closest other span-tracking parser
-# in the ecosystem.
-serde_yml = "0.0"
+# `yaml-spanned` is the closest other span-tracking parser
+# in the ecosystem. (`serde_yml` — the maintainer's prior crate
+# — was previously benched here; it was retired in v0.0.6 after
+# RUSTSEC-2025-0068 flagged it unsound + unmaintained so the
+# OpenSSF Scorecard Vulnerabilities check stays clean. The
+# `serde_yaml_ng` comparison row covers the same axis.)
 yaml-spanned = "0.0"
 # Ecosystem interop verification — proves noyalib's
 # `Deserializer<'de>` works with the standard serde wrappers

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -281,6 +281,11 @@ path = "examples/config_macros.rs"
 name = "i18n_formatters"
 path = "examples/i18n_formatters.rs"
 
+[[example]]
+name = "recovery_lenient"
+path = "examples/recovery_lenient.rs"
+required-features = ["recovery"]
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
@@ -337,6 +342,16 @@ rayon = { version = "1.10", optional = true }
 # profile (and FIPS / embedded users with strict dep policies) can
 # turn it off.
 serde_ignored = { version = "0.1", optional = true }
+# Zero-allocation streaming serialization framework — alternative
+# to serde for the `sval` feature. Pulled in only when the
+# `sval` feature is enabled.
+sval = { version = "2", optional = true, default-features = false }
+# `tokio` async runtime — required by the `tokio` feature for
+# native `AsyncRead` parsing and the `YamlDecoder` codec. Default
+# features off; we only need the I/O bits.
+tokio = { version = "1", optional = true, default-features = false, features = ["io-util"] }
+tokio-util = { version = "0.7", optional = true, default-features = false, features = ["codec"] }
+bytes = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -365,6 +380,10 @@ serde_path_to_error = "0.1"
 # `serde_ecosystem` interop test compiling under
 # `--no-default-features` builds.
 serde_ignored = "0.1"
+# Test-only tokio runtime — the `tokio` feature in `[features]`
+# only enables `io-util`; tests need `macros` and the
+# `current-thread` runtime to execute `#[tokio::test]` cases.
+tokio = { version = "1", features = ["macros", "rt", "io-util"] }
 
 [[bench]]
 name = "benchmarks"
@@ -493,6 +512,26 @@ simd = []
 # 2024 edition (Cargo 1.85+). Enabling this feature pulls saphyr in
 # as a dev-dep and gates the comparison bench arms on its presence.
 compare-saphyr = ["dep:serde-saphyr"]
+# Native async stream parsing on top of `tokio::io::AsyncRead`.
+# Adds `noyalib::tokio_async` with `from_async_reader`,
+# `from_async_reader_multi`, and a `YamlDecoder` codec for
+# `tokio_util::codec::Framed` pipelines. Off by default to keep
+# the dep list lean for sync-only callers.
+tokio = ["dep:tokio", "dep:tokio-util", "dep:bytes", "std"]
+# `sval` zero-allocation streaming serialization framework
+# adapter. Adds `impl sval::Value for Value` (and the other
+# in-tree value types) plus a `noyalib::sval_adapter::to_sval_writer`
+# entry point. serde remains the default; this is opt-in for
+# callers that want to skip serde monomorphisation overhead.
+sval = ["dep:sval"]
+# Error-recovering parser for LSP / IDE partial parsing. Adds
+# the `noyalib::recovery` module with `parse_lenient` /
+# `parse_lenient_with` entry points returning a `ParseResult`
+# carrying the best-effort tree plus the collected error list.
+# Pure Rust, no extra deps — turns existing strict-parse retries
+# into a recovery pipeline. Off by default because the strict
+# path is what most callers want.
+recovery = ["std"]
 # Parallel multi-document deserialisation via Rayon. Adds the
 # `noyalib::parallel` module:
 #   - `parallel::parse<T>(&str) -> Result<Vec<T>>` — typed deserialise.

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -286,6 +286,16 @@ name = "recovery_lenient"
 path = "examples/recovery_lenient.rs"
 required-features = ["recovery"]
 
+[[example]]
+name = "sval_streaming"
+path = "examples/sval_streaming.rs"
+required-features = ["sval"]
+
+[[example]]
+name = "tokio_async_reader"
+path = "examples/tokio_async_reader.rs"
+required-features = ["tokio"]
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
@@ -425,6 +435,11 @@ harness = false
 [[bench]]
 name = "numeric_parse"
 harness = false
+
+[[bench]]
+name = "v006_features"
+harness = false
+required-features = ["recovery", "sval", "tokio"]
 
 [features]
 default = ["std", "fast-int", "fast-float", "strict-deserialise"]

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -273,6 +273,14 @@ name = "include_directive"
 path = "examples/include_directive.rs"
 required-features = ["include_fs"]
 
+[[example]]
+name = "config_macros"
+path = "examples/config_macros.rs"
+
+[[example]]
+name = "i18n_formatters"
+path = "examples/i18n_formatters.rs"
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -206,6 +206,9 @@ the application needs.
 | `validator` | `validator` 0.19 | `ValidatedValidator<T>` wrapper |
 | `robotics` | — | `Degrees` / `Radians` / `StrictFloat` newtypes |
 | `parallel` | `rayon` 1.10 | `noyalib::parallel::parse<T>` |
+| `recovery` | — | `noyalib::recovery::parse_lenient` — best-effort parsing for LSP / IDE half-typed documents |
+| `sval` | `sval` 2 | `impl sval::Value` for `Value` / `Number` / `Mapping` / `MappingAny` / `TaggedValue`, `noyalib::sval_adapter::to_sval_writer` |
+| `tokio` | `tokio`, `tokio-util`, `bytes` | `noyalib::tokio_async::from_async_reader` / `from_async_reader_multi` and `YamlDecoder` codec for `tokio_util::codec::Framed` |
 | `simd` | — | `noyalib::simd::*` primitives + parser hot path |
 | `nightly-simd` | `simd` (nightly) | `core::simd`-backed 32-byte structural-bitmask scanner |
 | `compat-serde-yaml` | — | `noyalib::compat::serde_yaml` shim for migration |
@@ -292,6 +295,9 @@ cargo run --example schema_validation --features validate-schema
 cargo run --example figment      --features figment
 cargo run --example validation_garde --features garde
 cargo run --example robotics_polymorphism --features robotics
+cargo run --example recovery_lenient --features recovery
+cargo run --example sval_streaming   --features sval
+cargo run --example tokio_async_reader --features tokio
 ```
 
 Categories (full list in

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -17,7 +17,7 @@
   <a href="https://crates.io/crates/noyalib"><img src="https://img.shields.io/crates/v/noyalib.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/noyalib"><img src="https://img.shields.io/badge/docs.rs-noyalib-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://lib.rs/crates/noyalib"><img src="https://img.shields.io/badge/lib.rs-noyalib-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
-  <a href="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib"><img src="https://api.securityscorecards.dev/projects/github.com/sebastienrousseau/noyalib/badge" alt="OpenSSF Scorecard" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/noyalib?style=for-the-badge&label=OpenSSF%20Scorecard&logo=openssf" alt="OpenSSF Scorecard" /></a>
 </p>
 
 ---

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.3"
+noyalib = "0.0.6"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.3", default-features = false }
+noyalib = { version = "0.0.6", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/benches/comparison.rs
+++ b/crates/noyalib/benches/comparison.rs
@@ -110,13 +110,12 @@ fn bench_deserialize(c: &mut Criterion) {
             });
         });
 
-        // `serde_yml` — the maintainer's prior crate (a `serde_yaml` 0.9
-        // fork). Apples-to-apples Value comparison.
-        group.bench_with_input(BenchmarkId::new("serde_yml", name), yaml, |b, input| {
-            b.iter(|| {
-                let _: serde_yml::Value = serde_yml::from_str(black_box(input)).unwrap();
-            });
-        });
+        // (`serde_yml` was previously benched here as the maintainer's
+        // prior crate. RUSTSEC-2025-0068 marked it unsound +
+        // unmaintained; the comparison row was retired so it no
+        // longer appears in `Cargo.lock` and the OpenSSF Scorecard
+        // Vulnerabilities check is clean. `serde_yaml_ng` above
+        // covers the equivalent comparison axis.)
 
         // `yaml-spanned` — the closest other span-tracking parser in
         // the ecosystem. Returns a sequence of spanned values.

--- a/crates/noyalib/benches/v006_features.rs
+++ b/crates/noyalib/benches/v006_features.rs
@@ -49,6 +49,25 @@ items:
 // ───────────────────────── recovery ─────────────────────────
 
 #[cfg(feature = "recovery")]
+const INVALID: &str = "\
+name: noyalib
+version: 0.0.6
+features:
+  - recovery
+  - sval
+  - tokio
+nested:
+  a: 1
+  b: 2.5
+  c: true
+  d: null
+items:
+  - one
+  - two
+  - [unclosed-flow
+";
+
+#[cfg(feature = "recovery")]
 fn bench_recovery_strict_vs_lenient(c: &mut Criterion) {
     use noyalib::recovery::parse_lenient;
     use noyalib::{Value, from_str};
@@ -60,9 +79,18 @@ fn bench_recovery_strict_vs_lenient(c: &mut Criterion) {
             black_box(v);
         });
     });
-    g.bench_function("lenient_parse_lenient", |b| {
+    g.bench_function("lenient_parse_lenient_valid", |b| {
         b.iter(|| {
             let r = parse_lenient(black_box(SMALL));
+            black_box(r);
+        });
+    });
+    // The recovery surface's actual value proposition is on
+    // malformed input. This arm benches the 3-pass recovery loop
+    // on a realistic LSP-style half-typed buffer.
+    g.bench_function("lenient_parse_lenient_invalid", |b| {
+        b.iter(|| {
+            let r = parse_lenient(black_box(INVALID));
             black_box(r);
         });
     });

--- a/crates/noyalib/benches/v006_features.rs
+++ b/crates/noyalib/benches/v006_features.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! v0.0.6 feature benchmarks — `recovery`, `sval`, `tokio`.
+//!
+//! Three bench groups:
+//!
+//! 1. **recovery_strict_vs_lenient** — `from_str` vs
+//!    `recovery::parse_lenient` on valid input. The lenient
+//!    path is a thin wrapper around `from_str_with_config` for
+//!    valid inputs; the bench asserts the wrapper does not
+//!    regress the strict throughput by more than rounding noise.
+//! 2. **sval_vs_serde_value** — full deserialise into
+//!    `noyalib::Value` (the serde route) vs streaming the same
+//!    pre-built `Value` through a no-op `sval::Stream`. Shows
+//!    the relative cost of the two reflection surfaces.
+//! 3. **tokio_async_drain** — `tokio_async::from_async_reader`
+//!    against an in-memory `BufReader` source vs the sync
+//!    `from_slice` baseline. Quantifies the async-fixed-overhead
+//!    cost when the I/O source has zero latency.
+//!
+//! Run with all three features:
+//!     `cargo bench --bench v006_features --features recovery,sval,tokio`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+// ───────────────────────── Fixture ──────────────────────────
+
+const SMALL: &str = "\
+name: noyalib
+version: 0.0.6
+features:
+  - recovery
+  - sval
+  - tokio
+nested:
+  a: 1
+  b: 2.5
+  c: true
+  d: null
+items:
+  - one
+  - two
+  - three
+";
+
+// ───────────────────────── recovery ─────────────────────────
+
+#[cfg(feature = "recovery")]
+fn bench_recovery_strict_vs_lenient(c: &mut Criterion) {
+    use noyalib::recovery::parse_lenient;
+    use noyalib::{Value, from_str};
+
+    let mut g = c.benchmark_group("recovery_strict_vs_lenient");
+    g.bench_function("strict_from_str", |b| {
+        b.iter(|| {
+            let v: Value = from_str(black_box(SMALL)).unwrap();
+            black_box(v);
+        });
+    });
+    g.bench_function("lenient_parse_lenient", |b| {
+        b.iter(|| {
+            let r = parse_lenient(black_box(SMALL));
+            black_box(r);
+        });
+    });
+    g.finish();
+}
+
+#[cfg(not(feature = "recovery"))]
+fn bench_recovery_strict_vs_lenient(_c: &mut Criterion) {}
+
+// ────────────────────────── sval ────────────────────────────
+
+#[cfg(feature = "sval")]
+fn bench_sval_vs_serde_value(c: &mut Criterion) {
+    use noyalib::{Value, from_str};
+
+    let value: Value = from_str(SMALL).unwrap();
+
+    let mut g = c.benchmark_group("sval_vs_serde_value");
+    g.bench_function("serde_from_str_to_value", |b| {
+        b.iter(|| {
+            let v: Value = from_str(black_box(SMALL)).unwrap();
+            black_box(v);
+        });
+    });
+    g.bench_function("sval_stream_prebuilt_value", |b| {
+        let mut sink = NullStream::default();
+        b.iter(|| {
+            sval::Value::stream(black_box(&value), &mut sink).unwrap();
+            sink.count = 0;
+        });
+    });
+    g.finish();
+}
+
+#[cfg(not(feature = "sval"))]
+fn bench_sval_vs_serde_value(_c: &mut Criterion) {}
+
+#[cfg(feature = "sval")]
+#[derive(Default)]
+struct NullStream {
+    count: u64,
+}
+
+#[cfg(feature = "sval")]
+impl sval::Stream<'_> for NullStream {
+    fn null(&mut self) -> sval::Result {
+        self.count += 1;
+        Ok(())
+    }
+    fn bool(&mut self, _: bool) -> sval::Result {
+        self.count += 1;
+        Ok(())
+    }
+    fn i64(&mut self, _: i64) -> sval::Result {
+        self.count += 1;
+        Ok(())
+    }
+    fn f64(&mut self, _: f64) -> sval::Result {
+        self.count += 1;
+        Ok(())
+    }
+    fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+        Ok(())
+    }
+    fn text_fragment_computed(&mut self, _: &str) -> sval::Result {
+        self.count += 1;
+        Ok(())
+    }
+    fn text_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn map_begin(&mut self, _: Option<usize>) -> sval::Result {
+        Ok(())
+    }
+    fn map_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn map_key_begin(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn map_key_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn map_value_begin(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn map_value_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+        Ok(())
+    }
+    fn seq_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn seq_value_begin(&mut self) -> sval::Result {
+        Ok(())
+    }
+    fn seq_value_end(&mut self) -> sval::Result {
+        Ok(())
+    }
+}
+
+// ────────────────────────── tokio ───────────────────────────
+
+#[cfg(feature = "tokio")]
+fn bench_tokio_async_drain(c: &mut Criterion) {
+    use noyalib::Value;
+    use tokio::runtime::Builder;
+
+    let rt = Builder::new_current_thread().build().unwrap();
+
+    let mut g = c.benchmark_group("tokio_async_drain");
+    g.bench_function("sync_from_slice", |b| {
+        b.iter(|| {
+            let v: Value = noyalib::from_slice(black_box(SMALL.as_bytes())).unwrap();
+            black_box(v);
+        });
+    });
+    g.bench_function("async_from_async_reader", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut reader = tokio::io::BufReader::new(SMALL.as_bytes());
+                let v: Value = noyalib::tokio_async::from_async_reader(&mut reader)
+                    .await
+                    .unwrap();
+                black_box(v);
+            });
+        });
+    });
+    g.finish();
+}
+
+#[cfg(not(feature = "tokio"))]
+fn bench_tokio_async_drain(_c: &mut Criterion) {}
+
+criterion_group!(
+    benches,
+    bench_recovery_strict_vs_lenient,
+    bench_sval_vs_serde_value,
+    bench_tokio_async_drain
+);
+criterion_main!(benches);

--- a/crates/noyalib/examples/all.rs
+++ b/crates/noyalib/examples/all.rs
@@ -63,9 +63,28 @@ const EXAMPLES: &[&str] = &[
     // Final
     "async_io",
     "recursive",
+    // v0.0.5 — pluggable error formatting + declarative config macros
+    "i18n_formatters",
+    "config_macros",
     // Bench (last — longest)
     "bench",
 ];
+
+// Feature-gated examples that aren't run by this umbrella because
+// each one needs its own `--features X` flag. Listed here as a
+// pointer for anyone reading this file:
+//
+//   cargo run --example schema_validation     --features validate-schema
+//   cargo run --example figment               --features figment
+//   cargo run --example validation_garde      --features garde
+//   cargo run --example validation_validator  --features validator
+//   cargo run --example robotics_polymorphism --features robotics
+//   cargo run --example ariadne_diagnostic    --features ariadne
+//   cargo run --example validated_miette      --features miette,garde
+//   cargo run --example include_directive     --features include_fs
+//   cargo run --example recovery_lenient      --features recovery
+//   cargo run --example sval_streaming        --features sval
+//   cargo run --example tokio_async_reader    --features tokio
 
 fn main() {
     println!("\n  \x1b[1mnoyalib examples\x1b[0m\n");

--- a/crates/noyalib/examples/config_macros.rs
+++ b/crates/noyalib/examples/config_macros.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `parser_config!` / `serializer_config!` — declarative
+//! field-value builders that expand to the existing chained
+//! setter calls.
+//!
+//! Zero runtime overhead: the macro expansion is byte-identical
+//! to writing the builder chain by hand. The motivating
+//! ergonomics: dense call sites stay readable when you need to
+//! flip half-a-dozen flags.
+//!
+//! Run: `cargo run --example config_macros`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::{
+    DuplicateKeyPolicy, ParserConfig, SerializerConfig, YamlVersion, parser_config,
+    serializer_config,
+};
+
+fn main() {
+    support::header("noyalib -- config_macros");
+
+    support::task_with_output(
+        "parser_config! — flip several knobs in one expression",
+        || {
+            let cfg = parser_config! {
+                max_depth: 32,
+                max_alias_expansions: 200,
+                strict_booleans: true,
+                duplicate_key_policy: DuplicateKeyPolicy::Error,
+                version: YamlVersion::V1_1,
+            };
+            vec![
+                format!("max_depth             = {}", cfg.max_depth),
+                format!("max_alias_expansions  = {}", cfg.max_alias_expansions),
+                format!("strict_booleans       = {}", cfg.strict_booleans),
+                format!("duplicate_key_policy  = {:?}", cfg.duplicate_key_policy),
+                format!("version               = {:?}", cfg.yaml_version),
+            ]
+        },
+    );
+
+    support::task_with_output("parser_config! {} — empty form == new()", || {
+        let from_macro = parser_config! {};
+        let from_new = ParserConfig::new();
+        vec![
+            format!("macro.max_depth = new.max_depth = {}", from_macro.max_depth),
+            format!("both equal? {}", from_macro.max_depth == from_new.max_depth),
+        ]
+    });
+
+    support::task_with_output("serializer_config! — same pattern for emit knobs", || {
+        let cfg = serializer_config! {
+            indent: 4,
+            quote_all: true,
+        };
+        let _ = SerializerConfig::new(); // sanity import
+        vec![
+            format!("indent     = {}", cfg.indent),
+            format!("quote_all  = {}", cfg.quote_all),
+        ]
+    });
+
+    support::task_with_output(
+        "Equivalent to chained builders — pick whichever reads cleaner",
+        || {
+            let from_macro = parser_config! {
+                max_depth: 16,
+                max_alias_expansions: 50,
+            };
+            let from_chain = ParserConfig::new().max_depth(16).max_alias_expansions(50);
+            vec![format!(
+                "max_depth match: {}, alias match: {}",
+                from_macro.max_depth == from_chain.max_depth,
+                from_macro.max_alias_expansions == from_chain.max_alias_expansions
+            )]
+        },
+    );
+}

--- a/crates/noyalib/examples/i18n_formatters.rs
+++ b/crates/noyalib/examples/i18n_formatters.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `MessageFormatter` — render `Error` through pluggable
+//! formatters.
+//!
+//! Two bundled impls: `DefaultFormatter` (verbatim
+//! developer-facing message) and `UserFormatter` (short plain-
+//! language sentences appropriate for non-developer audiences).
+//! Custom localisation / rich-rendering plug in via the trait.
+//!
+//! Run: `cargo run --example i18n_formatters`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::i18n::{DefaultFormatter, MessageFormatter, UserFormatter};
+use noyalib::{Error, Value, from_str};
+
+fn main() {
+    support::header("noyalib -- i18n_formatters");
+
+    support::task_with_output("DefaultFormatter — verbatim Display output", || {
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![DefaultFormatter.format(&err)]
+    });
+
+    support::task_with_output("UserFormatter — plain-language sentence", || {
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![UserFormatter.format(&err)]
+    });
+
+    support::task_with_output("UserFormatter handles each Error category", || {
+        let errors: Vec<Error> = vec![
+            Error::DuplicateKey("api_key".into()),
+            Error::MissingField("password".into()),
+            Error::TypeMismatch {
+                expected: "integer",
+                found: "string".into(),
+            },
+            Error::RecursionLimitExceeded { depth: 256 },
+            Error::UnknownAnchor("backend-config".into()),
+        ];
+        errors
+            .iter()
+            .map(|e| format!("{:32}{}", format!("{e:.32}"), UserFormatter.format(e)))
+            .collect()
+    });
+
+    support::task_with_output("Custom formatter — implement MessageFormatter", || {
+        // A trivial example: uppercase all letters in the
+        // developer message. Real-world: localisation tables,
+        // GUI-friendly templates, audit-log structured output.
+        struct ShoutFormatter;
+        impl MessageFormatter for ShoutFormatter {
+            fn format(&self, error: &Error) -> String {
+                error.to_string().to_uppercase()
+            }
+        }
+        let err = from_str::<Value>("a: [unclosed").unwrap_err();
+        vec![err.render_with_formatter(&ShoutFormatter)]
+    });
+
+    support::task_with_output(
+        "Error::render_with_formatter — dispatch entry point",
+        || {
+            let err = from_str::<Value>("a: [unclosed").unwrap_err();
+            vec![
+                format!("dev:  {}", err.render_with_formatter(&DefaultFormatter)),
+                format!("user: {}", err.render_with_formatter(&UserFormatter)),
+            ]
+        },
+    );
+}

--- a/crates/noyalib/examples/recovery_lenient.rs
+++ b/crates/noyalib/examples/recovery_lenient.rs
@@ -8,8 +8,9 @@
 
 #[cfg(feature = "recovery")]
 fn main() {
-    use noyalib::recovery::parse_lenient;
+    use noyalib::recovery::{LenientConfig, parse_lenient, parse_lenient_with};
 
+    // ── Pattern 1: default knobs on a half-typed buffer ──
     let half_typed = "\
 config:
   name: noyalib
@@ -20,12 +21,53 @@ config:
 
     let result = parse_lenient(half_typed);
 
-    println!("is_complete: {}", result.is_complete);
-    println!("errors:      {}", result.errors.len());
+    println!("Pattern 1 — parse_lenient(default):");
+    println!("  is_complete: {}", result.is_complete);
+    println!("  errors:      {}", result.errors.len());
     for (i, err) in result.errors.iter().enumerate() {
-        println!("  [{i}] {err}");
+        println!("    [{i}] {err}");
     }
-    println!("recovered tree: {:?}", result.value);
+
+    // ── Pattern 2: tighten the budget for an adversarial input ──
+    //
+    // `truncation_event_budget` caps the cumulative byte cost of
+    // line-truncation retries on malformed input. The default
+    // (1 MiB) is suited to LSP-edit buffers; lower it for hostile
+    // input where every retry costs CPU.
+    let cfg = LenientConfig {
+        truncation_event_budget: 1024, // 1 KiB cap
+        ..LenientConfig::default()
+    };
+    let mut adversarial = String::from("a: 1\n");
+    for _ in 0..500 {
+        adversarial.push_str("[malformed-flow\n");
+    }
+    let bounded = parse_lenient_with(&adversarial, &cfg);
+    println!("\nPattern 2 — parse_lenient_with(truncation_event_budget = 1 KiB):");
+    println!(
+        "  is_complete: {} (expected false — 500 broken lines)",
+        bounded.is_complete
+    );
+    println!("  errors:      {}", bounded.errors.len());
+
+    // ── Pattern 3: pnpm-lock.yaml shape (issue #46 fix verifies) ──
+    //
+    // Wide-but-shallow `pnpm-lock`-shaped input with N empty flow
+    // mappings used to fail `from_str::<Value>` with
+    // RecursionLimitExceeded at exactly N = max_depth. v0.0.6
+    // closes that bug; recovery now parses it cleanly too.
+    let mut lockfile = String::from("packages:\n");
+    for i in 0..300 {
+        let _ =
+            std::fmt::Write::write_fmt(&mut lockfile, format_args!("  pkg-{i}@1.0.{i}: {{}}\n"));
+    }
+    let pnpm = parse_lenient(&lockfile);
+    println!("\nPattern 3 — 300-package pnpm-lock-shaped input:");
+    println!(
+        "  is_complete: {} (was: RecursionLimitExceeded pre-v0.0.6)",
+        pnpm.is_complete
+    );
+    println!("  errors:      {}", pnpm.errors.len());
 }
 
 #[cfg(not(feature = "recovery"))]

--- a/crates/noyalib/examples/recovery_lenient.rs
+++ b/crates/noyalib/examples/recovery_lenient.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `recovery::parse_lenient` — best-effort parsing for LSP / IDE
+//! partial-document scenarios.
+//!
+//! Run with: `cargo run --example recovery_lenient --features recovery`
+
+#[cfg(feature = "recovery")]
+fn main() {
+    use noyalib::recovery::parse_lenient;
+
+    let half_typed = "\
+config:
+  name: noyalib
+  version: 0.0.6
+  features: [recovery, std
+  # ^^ user is mid-typing — the flow sequence is unclosed
+";
+
+    let result = parse_lenient(half_typed);
+
+    println!("is_complete: {}", result.is_complete);
+    println!("errors:      {}", result.errors.len());
+    for (i, err) in result.errors.iter().enumerate() {
+        println!("  [{i}] {err}");
+    }
+    println!("recovered tree: {:?}", result.value);
+}
+
+#[cfg(not(feature = "recovery"))]
+fn main() {
+    eprintln!("This example requires the `recovery` feature.");
+    eprintln!("Run with: cargo run --example recovery_lenient --features recovery");
+}

--- a/crates/noyalib/examples/sval_streaming.rs
+++ b/crates/noyalib/examples/sval_streaming.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `sval_adapter` — stream a `noyalib::Value` graph through any
+//! `sval::Stream` consumer.
+//!
+//! The bundled `Recorder` is a minimal `sval::Stream` impl that
+//! captures every event as a human-readable line so you can see
+//! the shape of the stream sval consumers receive.
+//!
+//! Run: `cargo run --example sval_streaming --features sval`
+
+#[cfg(feature = "sval")]
+fn main() {
+    use noyalib::{Value, from_str};
+
+    let yaml = "\
+name: noyalib
+version: 0.0.6
+features:
+  - recovery
+  - sval
+  - tokio
+nested:
+  a: 1
+  b: 2.5
+  c: true
+  d: null
+";
+
+    let value: Value = from_str(yaml).expect("parse");
+
+    let mut recorder = Recorder::default();
+    sval::Value::stream(&value, &mut recorder).expect("stream");
+
+    println!("sval event stream (one per line):");
+    for line in &recorder.events {
+        println!("  {line}");
+    }
+    println!("\ntotal events: {}", recorder.events.len());
+}
+
+#[cfg(feature = "sval")]
+#[derive(Default)]
+struct Recorder {
+    events: Vec<String>,
+}
+
+#[cfg(feature = "sval")]
+impl sval::Stream<'_> for Recorder {
+    fn null(&mut self) -> sval::Result {
+        self.events.push("null".into());
+        Ok(())
+    }
+    fn bool(&mut self, v: bool) -> sval::Result {
+        self.events.push(format!("bool({v})"));
+        Ok(())
+    }
+    fn i64(&mut self, v: i64) -> sval::Result {
+        self.events.push(format!("i64({v})"));
+        Ok(())
+    }
+    fn f64(&mut self, v: f64) -> sval::Result {
+        self.events.push(format!("f64({v})"));
+        Ok(())
+    }
+    fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+        self.events.push("text_begin".into());
+        Ok(())
+    }
+    fn text_fragment_computed(&mut self, fragment: &str) -> sval::Result {
+        self.events.push(format!("text({fragment:?})"));
+        Ok(())
+    }
+    fn text_end(&mut self) -> sval::Result {
+        self.events.push("text_end".into());
+        Ok(())
+    }
+    fn map_begin(&mut self, n: Option<usize>) -> sval::Result {
+        self.events.push(format!("map_begin({n:?})"));
+        Ok(())
+    }
+    fn map_end(&mut self) -> sval::Result {
+        self.events.push("map_end".into());
+        Ok(())
+    }
+    fn map_key_begin(&mut self) -> sval::Result {
+        self.events.push("map_key_begin".into());
+        Ok(())
+    }
+    fn map_key_end(&mut self) -> sval::Result {
+        self.events.push("map_key_end".into());
+        Ok(())
+    }
+    fn map_value_begin(&mut self) -> sval::Result {
+        self.events.push("map_value_begin".into());
+        Ok(())
+    }
+    fn map_value_end(&mut self) -> sval::Result {
+        self.events.push("map_value_end".into());
+        Ok(())
+    }
+    fn seq_begin(&mut self, n: Option<usize>) -> sval::Result {
+        self.events.push(format!("seq_begin({n:?})"));
+        Ok(())
+    }
+    fn seq_end(&mut self) -> sval::Result {
+        self.events.push("seq_end".into());
+        Ok(())
+    }
+    fn seq_value_begin(&mut self) -> sval::Result {
+        self.events.push("seq_value_begin".into());
+        Ok(())
+    }
+    fn seq_value_end(&mut self) -> sval::Result {
+        self.events.push("seq_value_end".into());
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "sval"))]
+fn main() {
+    eprintln!("This example requires the `sval` feature.");
+    eprintln!("Run with: cargo run --example sval_streaming --features sval");
+}

--- a/crates/noyalib/examples/sval_streaming.rs
+++ b/crates/noyalib/examples/sval_streaming.rs
@@ -38,6 +38,27 @@ nested:
         println!("  {line}");
     }
     println!("\ntotal events: {}", recorder.events.len());
+
+    // ── Pattern: non-finite float coercion ──────────────────────
+    //
+    // `.nan` / `.inf` literals are valid YAML floats but `sval_json`
+    // and similar JSON-bound consumers reject non-finites. Use
+    // `SvalConfig::coerce_non_finite_to_null` to emit `Null`
+    // instead — required for round-tripping into JSON.
+    use noyalib::Number;
+    use noyalib::sval_adapter::{SvalConfig, to_sval_writer_with_config};
+
+    let nan_value = Value::Number(Number::Float(f64::NAN));
+    let cfg = SvalConfig {
+        coerce_non_finite_to_null: true,
+    };
+
+    let mut nan_recorder = Recorder::default();
+    to_sval_writer_with_config(&mut nan_recorder, &nan_value, &cfg).expect("stream NaN");
+    println!("\nNaN with coerce_non_finite_to_null = true:");
+    for line in &nan_recorder.events {
+        println!("  {line}");
+    }
 }
 
 #[cfg(feature = "sval")]

--- a/crates/noyalib/examples/tokio_async_reader.rs
+++ b/crates/noyalib/examples/tokio_async_reader.rs
@@ -62,6 +62,24 @@ version: 0.0.6
     if let Some(pkg) = decoder.decode_eof(&mut buf).expect("decode_eof") {
         println!("  [{i}] {} {}", pkg.name, pkg.version);
     }
+
+    // ── Pattern 3: untrusted-network frame-size cap (v0.0.6) ──
+    //
+    // Production services driving `YamlDecoder` over a network
+    // stream MUST cap inter-frame buffer growth or an adversarial
+    // producer that streams without `---` can pin arbitrary memory.
+    // Set the cap with `max_frame_size(usize)` — when the buffer
+    // exceeds it, the next `decode` call returns `Error::Io`.
+    let mut guarded = YamlDecoder::<Pkg>::new().max_frame_size(64);
+    // Stream a single doc whose first line is longer than 64 bytes
+    // and no `---` boundary lands inside the cap.
+    let oversize =
+        b"name: a-very-long-package-name-that-definitely-exceeds-sixty-four-bytes\nversion: '1'\n";
+    let mut buf = BytesMut::from(&oversize[..]);
+    match guarded.decode(&mut buf) {
+        Err(e) => println!("\nmax_frame_size(64) rejected the oversize frame: {e}"),
+        Ok(_) => println!("\nunexpected: oversize frame should have been rejected"),
+    }
 }
 
 #[cfg(not(feature = "tokio"))]

--- a/crates/noyalib/examples/tokio_async_reader.rs
+++ b/crates/noyalib/examples/tokio_async_reader.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `tokio_async` — parse a YAML stream from a tokio `AsyncRead`
+//! source without `spawn_blocking`, and from a
+//! `tokio_util::codec::Framed` pipeline.
+//!
+//! Run: `cargo run --example tokio_async_reader --features tokio`
+
+#[cfg(feature = "tokio")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    use bytes::BytesMut;
+    use noyalib::tokio_async::{YamlDecoder, from_async_reader_multi};
+    use serde::Deserialize;
+    use tokio::io::BufReader;
+    use tokio_util::codec::Decoder;
+
+    #[derive(Debug, Deserialize)]
+    struct Pkg {
+        name: String,
+        version: String,
+    }
+
+    let stream = b"\
+---
+name: noyalib
+version: 0.0.6
+---
+name: noya-cli
+version: 0.0.6
+---
+name: noyalib-lsp
+version: 0.0.6
+";
+
+    // ── Pattern 1: drain-and-parse via from_async_reader_multi ──
+    let mut buf_reader = BufReader::new(&stream[..]);
+    let docs: Vec<Pkg> = from_async_reader_multi(&mut buf_reader)
+        .await
+        .expect("parse multi");
+    println!("from_async_reader_multi:");
+    for (i, pkg) in docs.iter().enumerate() {
+        println!("  [{i}] {} {}", pkg.name, pkg.version);
+    }
+
+    // ── Pattern 2: streaming codec via YamlDecoder directly ──
+    //
+    // For brevity the example feeds the whole buffer in one shot
+    // and drives `decode` / `decode_eof` by hand. In a real
+    // server you'd wrap the codec in `tokio_util::codec::FramedRead`
+    // and pull items via `futures::StreamExt::next` — that pulls
+    // in `futures-util`, which is intentionally not a noyalib dep.
+    let mut decoder = YamlDecoder::<Pkg>::new();
+    let mut buf = BytesMut::from(&stream[..]);
+    println!("\nYamlDecoder (manual drive):");
+    let mut i = 0;
+    while let Some(pkg) = decoder.decode(&mut buf).expect("decode") {
+        println!("  [{i}] {} {}", pkg.name, pkg.version);
+        i += 1;
+    }
+    if let Some(pkg) = decoder.decode_eof(&mut buf).expect("decode_eof") {
+        println!("  [{i}] {} {}", pkg.name, pkg.version);
+    }
+}
+
+#[cfg(not(feature = "tokio"))]
+fn main() {
+    eprintln!("This example requires the `tokio` feature.");
+    eprintln!("Run with: cargo run --example tokio_async_reader --features tokio");
+}

--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -48,7 +48,7 @@
 //! # Cargo.toml — before
 //! serde_yaml = "0.9"
 //! # Cargo.toml — after
-//! noyalib = { version = "0.0.1", features = ["compat-serde-yaml"] }
+//! noyalib = { version = "0.0.6", features = ["compat-serde-yaml"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/crates/noyalib/src/doc_boundary.rs
+++ b/crates/noyalib/src/doc_boundary.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Workspace-private `---` document-boundary scanner.
+//!
+//! Three modules used to ship their own copy of this routine
+//! ([`crate::parallel::split`], `crate::recovery::split_documents`,
+//! `crate::tokio_async::find_doc_boundary`). They had subtly
+//! different CRLF / leading-marker / trailing-marker semantics —
+//! Windows-edited inputs round-tripped via one and not the other.
+//!
+//! This module centralises the scanner so the CRLF, BOM, and
+//! `---`-spam DoS guards live in exactly one place.
+//!
+//! The scanner recognises a `---` document-start marker if and
+//! only if all of:
+//!
+//! * the three bytes are at the start of input, or follow a
+//!   `\n` or `\r\n` line break;
+//! * the byte after the marker (if any) is whitespace
+//!   (`\n`, `\r`, ` `, `\t`) or end-of-input.
+//!
+//! This matches the YAML 1.2.2 §9.1.2 `c-directives-end` grammar
+//! and the strict-parser's own boundary detection.
+
+#![allow(dead_code)]
+
+/// UTF-8 BOM byte sequence (`U+FEFF`).
+pub(crate) const BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
+
+/// Strip a leading UTF-8 BOM if present and return the remaining
+/// byte offset. The offset is `0` when the BOM was absent and
+/// `3` when it was present — never any other value.
+#[inline]
+#[must_use]
+pub(crate) fn strip_bom(bytes: &[u8]) -> usize {
+    if bytes.starts_with(&BOM) { 3 } else { 0 }
+}
+
+/// `true` if the byte at `i` opens a column-0 `---` directive-end
+/// marker — i.e. the run `bytes[i..i+3]` is exactly `b"---"`
+/// **and** the preceding byte (if any) is `\n` or `\r`
+/// **and** the following byte (if any) is whitespace or end of
+/// input.
+///
+/// Returns `false` for out-of-range `i` so callers can use it
+/// unchecked inside scan loops.
+#[inline]
+#[must_use]
+pub(crate) fn is_doc_marker_at(bytes: &[u8], i: usize) -> bool {
+    if i + 3 > bytes.len() {
+        return false;
+    }
+    if &bytes[i..i + 3] != b"---" {
+        return false;
+    }
+    let preceded_by_break = i == 0 || matches!(bytes[i - 1], b'\n' | b'\r');
+    if !preceded_by_break {
+        return false;
+    }
+    if i + 3 == bytes.len() {
+        return true;
+    }
+    matches!(bytes[i + 3], b'\n' | b'\r' | b' ' | b'\t')
+}
+
+/// Collect every column-0 `---` marker offset in `bytes`, bounded
+/// by `max_markers` so a hostile `---`-spam input cannot drive
+/// unbounded `Vec` growth.
+///
+/// On overflow the scan stops at `max_markers` markers and the
+/// returned `Vec` has exactly that length. Callers that want a
+/// hard error on overflow should compare `out.len() == max_markers`
+/// and decide whether the input is suspicious.
+///
+/// `max_markers == 0` yields an empty `Vec` without scanning.
+#[must_use]
+pub(crate) fn scan_markers(bytes: &[u8], max_markers: usize) -> Vec<usize> {
+    let mut out = Vec::new();
+    if max_markers == 0 {
+        return out;
+    }
+    let mut i = 0;
+    while i + 3 <= bytes.len() {
+        if is_doc_marker_at(bytes, i) {
+            out.push(i);
+            if out.len() >= max_markers {
+                break;
+            }
+            i += 3;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Search `bytes` for the **next** column-0 `---` marker starting
+/// at offset `start`. Returns the offset of the first byte of the
+/// marker, or `None` when no marker is present.
+///
+/// `start == 0` does **not** match a leading `---` — that's the
+/// start of the first document, not a boundary between two of
+/// them. Use [`is_doc_marker_at`] directly if a leading marker
+/// must be considered.
+#[must_use]
+pub(crate) fn next_marker_after(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start.max(1);
+    while i + 3 <= bytes.len() {
+        if is_doc_marker_at(bytes, i) {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split `input` into per-document `&str` slices on column-0
+/// `---` markers, bounded by `max_markers` to defeat `---`-spam
+/// inputs. Empty trailing slices are omitted.
+///
+/// A leading implicit document (content before the first `---`)
+/// becomes the first slice; each subsequent slice starts at its
+/// `---` marker (asymmetric trimming made the previous copies
+/// disagree on offsets — keeping the marker is the convention
+/// that round-trips cleanly through `from_str_with_config`).
+#[must_use]
+pub(crate) fn split_documents(input: &str, max_markers: usize) -> Vec<&str> {
+    let bytes = input.as_bytes();
+    let markers = scan_markers(bytes, max_markers);
+
+    if markers.is_empty() {
+        return if input.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![input]
+        };
+    }
+
+    let mut docs: Vec<&str> = Vec::with_capacity(markers.len() + 1);
+    if markers[0] > 0 {
+        let pre = input[..markers[0]].trim();
+        if !pre.is_empty() {
+            docs.push(&input[..markers[0]]);
+        }
+    }
+    for window in markers.windows(2) {
+        docs.push(&input[window[0]..window[1]]);
+    }
+    let last = *markers.last().unwrap();
+    if last < input.len() {
+        let trailing = &input[last..];
+        if !trailing.trim_end().is_empty() {
+            docs.push(trailing);
+        }
+    }
+    docs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bom_strip_round_trip() {
+        assert_eq!(strip_bom(b""), 0);
+        assert_eq!(strip_bom(b"a: 1\n"), 0);
+        assert_eq!(strip_bom(b"\xEF\xBB\xBFa: 1\n"), 3);
+    }
+
+    #[test]
+    fn lf_terminated_markers() {
+        let m = scan_markers(b"---\na: 1\n---\nb: 2\n", 16);
+        assert_eq!(m, vec![0, 9]);
+    }
+
+    #[test]
+    fn crlf_terminated_markers_are_recognised() {
+        // The previous copies in recovery/parallel/tokio_async
+        // each missed at least one of these.
+        let m = scan_markers(b"---\r\na: 1\r\n---\r\nb: 2\r\n", 16);
+        assert_eq!(m, vec![0, 11]);
+    }
+
+    #[test]
+    fn mid_line_dashes_are_not_markers() {
+        let m = scan_markers(b"a: ---\nb: 2\n", 16);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn marker_at_eof_is_recognised() {
+        // `---` as the very last bytes — no terminator after.
+        let m = scan_markers(b"a: 1\n---", 16);
+        assert_eq!(m, vec![5]);
+    }
+
+    #[test]
+    fn marker_cap_truncates() {
+        let input = b"---\n---\n---\n---\n---\n";
+        let m = scan_markers(input, 2);
+        assert_eq!(m.len(), 2);
+    }
+
+    #[test]
+    fn next_marker_skips_leading() {
+        assert_eq!(next_marker_after(b"---\na: 1\n", 0), None);
+        assert_eq!(next_marker_after(b"---\na: 1\n---\nb: 2\n", 0), Some(9));
+    }
+
+    #[test]
+    fn marker_cap_zero_yields_empty() {
+        assert!(scan_markers(b"---\n---\n", 0).is_empty());
+    }
+}

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -475,26 +475,15 @@ pub mod interner;
 #[cfg(feature = "parallel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub mod parallel;
+mod parser;
+mod path;
+/// Pluggable parser policies for "Safe YAML" enforcement.
+pub mod policy;
 /// Error-recovering parser for LSP / IDE partial parsing. Gated
 /// by the `recovery` feature.
 #[cfg(feature = "recovery")]
 #[cfg_attr(docsrs, doc(cfg(feature = "recovery")))]
 pub mod recovery;
-/// `sval` zero-allocation streaming serialization adapter.
-/// Gated by the `sval` feature.
-#[cfg(feature = "sval")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sval")))]
-pub mod sval_adapter;
-/// Native async YAML parsing for tokio runtimes —
-/// `from_async_reader` plus a `tokio_util::codec::Decoder`.
-/// Gated by the `tokio` feature.
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-pub mod tokio_async;
-mod parser;
-mod path;
-/// Pluggable parser policies for "Safe YAML" enforcement.
-pub mod policy;
 /// Robotics and scientific numeric types (requires `robotics` feature).
 #[cfg(feature = "robotics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "robotics")))]
@@ -514,6 +503,17 @@ mod schema_codegen;
 #[cfg_attr(docsrs, doc(cfg(feature = "validate-schema")))]
 mod schema_validate;
 mod ser;
+/// `sval` zero-allocation streaming serialization adapter.
+/// Gated by the `sval` feature.
+#[cfg(feature = "sval")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sval")))]
+pub mod sval_adapter;
+/// Native async YAML parsing for tokio runtimes —
+/// `from_async_reader` plus a `tokio_util::codec::Decoder`.
+/// Gated by the `tokio` feature.
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+pub mod tokio_async;
 
 /// SIMD-friendly multi-byte search primitives.
 ///

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -159,21 +159,20 @@
 //!
 //! ## MSRV policy
 //!
-//! - **Core library (`noyalib`)** — Rust **1.75.0** stable. CI's
-//!   `msrv-1-75-core` job builds the `default-features = false`
-//!   and the standard `default` set on `rustc 1.75.0` for every
-//!   PR. The MSRV is treated as part of the public contract: a
-//!   bump within `0.0.x` is a breaking change and ships a major
-//!   version.
+//! - **Core library (`noyalib`)** — Rust **1.85.0** stable
+//!   (edition 2024, raised in v0.0.5). CI's MSRV gate builds
+//!   the `default-features = false` and the standard `default`
+//!   set on `rustc 1.85.0` for every PR. The MSRV is treated as
+//!   part of the public contract: a bump within `0.0.x` is a
+//!   breaking change and ships a major version.
 //! - **Optional features** that pull a dep with a higher floor
 //!   (`miette`, `garde`, `validate-schema`, `figment`,
-//!   `parallel`, `validator`) inherit that dep's MSRV — currently
-//!   `1.80`–`1.86` depending on the feature. The CI matrix runs
-//!   each one against the dep's declared `rust-version`.
+//!   `parallel`, `validator`, `tokio`) inherit that dep's MSRV
+//!   — typically `1.85`–`1.86` depending on the feature. The
+//!   CI matrix runs each one against the dep's declared
+//!   `rust-version`.
 //! - **Companion crates** ([`noya-cli`], [`noyalib-lsp`]) carry
-//!   their own higher MSRVs because their dep tree includes
-//!   edition-2024 transitives — `1.85.0` for both at time of
-//!   writing.
+//!   the same `1.85.0` floor.
 //! - **`nightly-simd`** is the only feature that requires nightly
 //!   rustc (`#![feature(portable_simd)]`); a `build.rs` cfg-detect
 //!   probe means stable builds with `--all-features` still
@@ -457,6 +456,11 @@ mod de;
 #[cfg(feature = "miette")]
 #[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
 pub mod diagnostic;
+/// Workspace-private `---` document-boundary scanner shared by
+/// `parallel::split`, `recovery::split_documents`, and
+/// `tokio_async::find_doc_boundary` — one CRLF/BOM-aware scanner,
+/// one DoS cap.
+pub(crate) mod doc_boundary;
 /// Multi-document loading and iteration.
 pub mod document;
 mod error;

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -475,6 +475,22 @@ pub mod interner;
 #[cfg(feature = "parallel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "parallel")))]
 pub mod parallel;
+/// Error-recovering parser for LSP / IDE partial parsing. Gated
+/// by the `recovery` feature.
+#[cfg(feature = "recovery")]
+#[cfg_attr(docsrs, doc(cfg(feature = "recovery")))]
+pub mod recovery;
+/// `sval` zero-allocation streaming serialization adapter.
+/// Gated by the `sval` feature.
+#[cfg(feature = "sval")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sval")))]
+pub mod sval_adapter;
+/// Native async YAML parsing for tokio runtimes —
+/// `from_async_reader` plus a `tokio_util::codec::Decoder`.
+/// Gated by the `tokio` feature.
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+pub mod tokio_async;
 mod parser;
 mod path;
 /// Pluggable parser policies for "Safe YAML" enforcement.

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -812,6 +812,9 @@ impl<'a> NoSpanLoader<'a> {
             }
             Event::SequenceStart { anchor, tag, .. } => {
                 self.depth += 1;
+                if self.depth > self.config.max_depth {
+                    return Err(Error::RecursionLimitExceeded { depth: self.depth });
+                }
                 self.stack.push(NoSpanFrame::Sequence {
                     items: Vec::new(),
                     anchor,
@@ -831,6 +834,9 @@ impl<'a> NoSpanLoader<'a> {
             }
             Event::MappingStart { anchor, tag, .. } => {
                 self.depth += 1;
+                if self.depth > self.config.max_depth {
+                    return Err(Error::RecursionLimitExceeded { depth: self.depth });
+                }
                 self.stack.push(NoSpanFrame::MappingKey {
                     map: Mapping::new(),
                     anchor,

--- a/crates/noyalib/src/recovery.rs
+++ b/crates/noyalib/src/recovery.rs
@@ -383,4 +383,61 @@ mod tests {
         assert!(split_documents("").is_empty());
         assert!(split_documents("   \n").is_empty());
     }
+
+    #[test]
+    fn recover_disabled_passes_just_collect_errors() {
+        // With both recovery passes disabled, an invalid input
+        // should still produce Null + the strict error — exercises
+        // the "fall through every pass" branch in recover_one.
+        let cfg = LenientConfig {
+            recover_duplicate_keys: false,
+            line_truncation: false,
+            ..LenientConfig::default()
+        };
+        let r = parse_lenient_with("[unclosed", &cfg);
+        assert!(!r.is_complete);
+        assert_eq!(r.errors.len(), 1);
+        assert!(matches!(r.value, Value::Null));
+    }
+
+    #[test]
+    fn line_truncation_disabled_skips_third_pass() {
+        let cfg = LenientConfig {
+            line_truncation: false,
+            ..LenientConfig::default()
+        };
+        let r = parse_lenient_with("a: 1\nb: [bad\n", &cfg);
+        assert!(!r.is_complete);
+        // With truncation off, no salvage attempt — value stays Null.
+        assert!(matches!(r.value, Value::Null));
+    }
+
+    #[test]
+    fn config_is_debug_and_clone() {
+        // Cheap reflection — keeps Debug + Clone derives covered.
+        let cfg = LenientConfig::default();
+        let _printed = format!("{cfg:?}");
+        let cloned = cfg.clone();
+        assert_eq!(cloned.max_errors, cfg.max_errors);
+    }
+
+    #[test]
+    fn parse_result_is_debug() {
+        let r = parse_lenient("a: 1\n");
+        let _printed = format!("{r:?}");
+    }
+
+    #[test]
+    fn split_documents_handles_implicit_first_doc() {
+        // Content before the first `---` is an implicit doc.
+        let d = split_documents("name: pre\n---\nname: post\n");
+        assert_eq!(d.len(), 2);
+    }
+
+    #[test]
+    fn split_documents_ignores_mid_line_dashes() {
+        // `---` mid-line is not a document marker.
+        let d = split_documents("a: ---\nb: 2\n");
+        assert_eq!(d.len(), 1);
+    }
 }

--- a/crates/noyalib/src/recovery.rs
+++ b/crates/noyalib/src/recovery.rs
@@ -103,6 +103,14 @@ pub struct LenientConfig {
     /// Base parser configuration. Defaults to
     /// [`ParserConfig::default`].
     pub base_config: ParserConfig,
+    /// Cumulative byte budget for line-truncation retries
+    /// across one document. Each retry costs `prefix.len()`
+    /// from this budget; when the next candidate prefix would
+    /// exceed it, the recoverer stops salvaging and returns
+    /// `Null`. Defaults to `1 MiB`, enough to retry a few
+    /// hundred candidates on a typical LSP-edit buffer while
+    /// bounding worst-case CPU on adversarial input.
+    pub truncation_event_budget: usize,
 }
 
 impl Default for LenientConfig {
@@ -112,6 +120,7 @@ impl Default for LenientConfig {
             recover_duplicate_keys: true,
             line_truncation: true,
             base_config: ParserConfig::default(),
+            truncation_event_budget: 1024 * 1024,
         }
     }
 }
@@ -128,9 +137,25 @@ pub fn parse_lenient(input: &str) -> ParseResult {
 /// Parse `input` with caller-supplied recovery knobs.
 ///
 /// See the [module docs](self) for the recovery strategy.
+///
+/// Strips a leading UTF-8 BOM (`U+FEFF`) — Windows editors emit
+/// one by default and recovery is the one entry point callers
+/// expect to absorb it.
+///
+/// Hostile `---`-spam inputs are bounded by
+/// [`ParserConfig::max_documents`]: the underlying boundary
+/// scanner stops collecting markers once the cap is reached.
+/// Per-document parsing then re-enforces every other
+/// `ParserConfig` limit (`max_depth`, `max_events`,
+/// `max_document_length`, …).
 #[must_use]
 pub fn parse_lenient_with(input: &str, config: &LenientConfig) -> ParseResult {
-    let docs = split_documents(input);
+    // C5 — strip a leading BOM so Windows-saved buffers parse
+    //      identically to the LF-on-Linux equivalent.
+    let bom_skip = crate::doc_boundary::strip_bom(input.as_bytes());
+    let input = &input[bom_skip..];
+
+    let docs = split_documents(input, &config.base_config);
 
     if docs.is_empty() {
         return ParseResult {
@@ -153,13 +178,21 @@ pub fn parse_lenient_with(input: &str, config: &LenientConfig) -> ParseResult {
     let mut values: Vec<Value> = Vec::with_capacity(docs.len());
     let mut errors: Vec<Error> = Vec::new();
     let mut budget = config.max_errors;
+    // M2 — preserve per-document index alignment for LSP
+    //      diagnostic joiners by pushing `Null` for every
+    //      document we skip after the budget runs out.
+    let mut budget_exhausted = false;
     for doc in docs {
+        if budget_exhausted {
+            values.push(Value::Null);
+            continue;
+        }
         let (value, doc_errors) = recover_one(doc, config, budget);
         budget = budget.saturating_sub(doc_errors.len());
         errors.extend(doc_errors);
         values.push(value);
         if budget == 0 {
-            break;
+            budget_exhausted = true;
         }
     }
     let is_complete = errors.is_empty();
@@ -173,8 +206,9 @@ pub fn parse_lenient_with(input: &str, config: &LenientConfig) -> ParseResult {
 /// Recover a single document.
 ///
 /// Returns the best-effort `Value` and the list of errors
-/// encountered. Bounded by `budget` — once exhausted, the
-/// recoverer returns whatever it has and stops.
+/// encountered (every pass that emitted an `Err` contributes one
+/// entry). Bounded by `budget` — once exhausted, the recoverer
+/// returns whatever it has and stops.
 fn recover_one(input: &str, config: &LenientConfig, budget: usize) -> (Value, Vec<Error>) {
     if budget == 0 {
         return (Value::Null, Vec::new());
@@ -185,103 +219,120 @@ fn recover_one(input: &str, config: &LenientConfig, budget: usize) -> (Value, Ve
         Ok(v) => return (v, Vec::new()),
         Err(e) => e,
     };
-    let errors = vec![strict_err];
+    let mut errors = vec![strict_err];
 
     // Pass 2: duplicate-key recovery via DuplicateKeyPolicy::Last.
-    if config.recover_duplicate_keys && errors.len() < budget {
-        let mut cfg2 = config.base_config.clone();
-        cfg2.duplicate_key_policy = DuplicateKeyPolicy::Last;
-        if let Ok(v) = from_str_with_config::<Value>(input, &cfg2) {
-            // The original strict error is still surfaced as a
-            // diagnostic so the editor flags the duplicate.
-            return (v, errors);
+    //
+    // M13 — clone the base config exactly once per `recover_one`
+    //       so per-document hot paths on LSP keystrokes don't pay
+    //       the per-pass clone tax.
+    let mut tweaked_cfg: Option<ParserConfig> = None;
+    if config.recover_duplicate_keys
+        && config.base_config.duplicate_key_policy != DuplicateKeyPolicy::Last
+        && errors.len() < budget
+    {
+        let cfg2 = tweaked_cfg.insert({
+            let mut c = config.base_config.clone();
+            c.duplicate_key_policy = DuplicateKeyPolicy::Last;
+            c
+        });
+        match from_str_with_config::<Value>(input, cfg2) {
+            Ok(v) => return (v, errors),
+            // M1 — collect the Pass-2 error too so the editor
+            //      sees every diagnostic, not just the first.
+            Err(e) => errors.push(e),
         }
     }
 
-    // Pass 3: line-truncation recovery.
+    // Pass 3: line-truncation recovery, bounded by the per-document
+    // event budget so an adversarial 10k-line input cannot drive
+    // O(N×max_events) re-parses (security finding C1).
     if config.line_truncation && errors.len() < budget {
-        if let Some(v) = try_line_truncation(input, &config.base_config) {
-            return (v, errors);
+        let pass3_cfg = tweaked_cfg.as_ref().unwrap_or(&config.base_config);
+        match try_line_truncation(input, pass3_cfg, config.truncation_event_budget) {
+            TruncationOutcome::Recovered(v) => return (v, errors),
+            // M1 — collect the final truncation-failure error so
+            //      the editor can show what went wrong after
+            //      every salvage attempt was exhausted.
+            TruncationOutcome::Exhausted(Some(e)) if errors.len() < budget => errors.push(e),
+            TruncationOutcome::Exhausted(_) => {}
         }
     }
 
     (Value::Null, errors)
 }
 
+/// Result of the line-truncation pass.
+enum TruncationOutcome {
+    /// A truncated prefix parsed cleanly.
+    Recovered(Value),
+    /// No prefix parsed; the final attempt's error is carried back
+    /// so [`recover_one`] can surface it as a diagnostic.
+    Exhausted(Option<Error>),
+}
+
 /// Drop trailing lines one at a time, retrying the parse, until
-/// a parse succeeds or only one line remains.
-fn try_line_truncation(input: &str, config: &ParserConfig) -> Option<Value> {
-    // Collect line boundaries so we can truncate by slice rather
-    // than by re-string-building.
+/// a prefix succeeds, the cumulative parser-event budget is
+/// exhausted, or no candidate prefixes remain.
+///
+/// `event_budget` caps how many bytes the recovery loop may
+/// re-feed into the parser **in total**. Each attempted prefix
+/// costs `prefix.len()` from the budget; this turns a hostile
+/// 10k-line input from O(N×input_len) into bounded work without
+/// regressing recovery quality on realistic LSP-edit inputs.
+///
+/// Honours M3 — the buffer end itself is a candidate cut so a
+/// malformed last line without a trailing newline (the universal
+/// mid-typing case) is still tried.
+fn try_line_truncation(
+    input: &str,
+    config: &ParserConfig,
+    event_budget: usize,
+) -> TruncationOutcome {
+    // Collect line boundaries; the buffer end is a synthetic
+    // candidate so the no-trailing-newline case is exercised.
     let mut boundaries: Vec<usize> = Vec::new();
     for (i, b) in input.as_bytes().iter().enumerate() {
         if *b == b'\n' {
             boundaries.push(i);
         }
     }
-    // Iterate from the last line backwards.
+    if boundaries.last().copied() != Some(input.len()) {
+        boundaries.push(input.len());
+    }
+
+    let mut budget_remaining = event_budget;
+    let mut last_err: Option<Error> = None;
     for &cut in boundaries.iter().rev() {
         let candidate = &input[..cut];
         if candidate.trim().is_empty() {
             continue;
         }
-        if let Ok(v) = from_str_with_config::<Value>(candidate, config) {
-            return Some(v);
+        // Budget gate: re-parsing `candidate.len()` bytes costs
+        // proportionally; saturating-sub avoids panic on overflow.
+        let cost = candidate.len();
+        if cost > budget_remaining {
+            break;
+        }
+        budget_remaining = budget_remaining.saturating_sub(cost);
+        match from_str_with_config::<Value>(candidate, config) {
+            Ok(v) => return TruncationOutcome::Recovered(v),
+            Err(e) => last_err = Some(e),
         }
     }
-    None
+    TruncationOutcome::Exhausted(last_err)
 }
 
 /// Split `input` on top-level YAML `---` document markers.
 ///
-/// Inline mirror of the document-boundary scanner in
-/// [`crate::parallel::split`] — duplicated here so the
-/// `recovery` feature does not require the heavyweight
-/// `parallel` feature (which pulls in Rayon).
-fn split_documents(input: &str) -> Vec<&str> {
-    let bytes = input.as_bytes();
-    let mut markers: Vec<usize> = Vec::new();
-    let mut i = 0;
-    while i + 3 <= bytes.len() {
-        let at_line_start = i == 0 || bytes[i - 1] == b'\n' || bytes[i - 1] == b'\r';
-        if at_line_start && &bytes[i..i + 3] == b"---" {
-            let next_ok =
-                i + 3 >= bytes.len() || matches!(bytes[i + 3], b'\n' | b'\r' | b' ' | b'\t');
-            if next_ok {
-                markers.push(i);
-                i += 3;
-                continue;
-            }
-        }
-        i += 1;
-    }
-
-    if markers.is_empty() {
-        return if input.trim().is_empty() {
-            Vec::new()
-        } else {
-            vec![input]
-        };
-    }
-
-    let mut docs: Vec<&str> = Vec::with_capacity(markers.len() + 1);
-    if markers[0] > 0 {
-        let pre = input[..markers[0]].trim();
-        if !pre.is_empty() {
-            docs.push(&input[..markers[0]]);
-        }
-    }
-    for window in markers.windows(2) {
-        docs.push(&input[window[0]..window[1]]);
-    }
-    let last = *markers.last().unwrap();
-    if last < input.len() {
-        let trailing = &input[last..];
-        if !trailing.trim_end().is_empty() {
-            docs.push(trailing);
-        }
-    }
-    docs
+/// Thin wrapper around [`crate::doc_boundary::split_documents`]
+/// that bounds the marker cap by [`crate::de::ParserConfig::max_documents`].
+///
+/// Hostile `---`-spam inputs cannot drive unbounded `Vec`
+/// growth because the underlying scanner stops after
+/// `max_markers` boundaries.
+fn split_documents<'a>(input: &'a str, config: &ParserConfig) -> Vec<&'a str> {
+    crate::doc_boundary::split_documents(input, config.max_documents)
 }
 
 #[cfg(test)]
@@ -374,14 +425,15 @@ mod tests {
 
     #[test]
     fn split_documents_handles_single() {
-        let d = split_documents("a: 1\n");
+        let d = split_documents("a: 1\n", &ParserConfig::default());
         assert_eq!(d.len(), 1);
     }
 
     #[test]
     fn split_documents_handles_empty() {
-        assert!(split_documents("").is_empty());
-        assert!(split_documents("   \n").is_empty());
+        let cfg = ParserConfig::default();
+        assert!(split_documents("", &cfg).is_empty());
+        assert!(split_documents("   \n", &cfg).is_empty());
     }
 
     #[test]
@@ -430,14 +482,100 @@ mod tests {
     #[test]
     fn split_documents_handles_implicit_first_doc() {
         // Content before the first `---` is an implicit doc.
-        let d = split_documents("name: pre\n---\nname: post\n");
+        let d = split_documents("name: pre\n---\nname: post\n", &ParserConfig::default());
         assert_eq!(d.len(), 2);
     }
 
     #[test]
     fn split_documents_ignores_mid_line_dashes() {
         // `---` mid-line is not a document marker.
-        let d = split_documents("a: ---\nb: 2\n");
+        let d = split_documents("a: ---\nb: 2\n", &ParserConfig::default());
         assert_eq!(d.len(), 1);
+    }
+
+    #[test]
+    fn crlf_input_recovers_cleanly() {
+        // Windows-saved buffer with `\r\n` line endings.
+        let r = parse_lenient("a: 1\r\nb: 2\r\n");
+        assert!(r.is_complete);
+        if let Value::Mapping(m) = &r.value {
+            assert!(m.contains_key("a"));
+            assert!(m.contains_key("b"));
+        } else {
+            panic!("expected mapping for CRLF input, got {:?}", r.value);
+        }
+    }
+
+    #[test]
+    fn bom_prefix_is_stripped() {
+        let r = parse_lenient("\u{FEFF}a: 1\nb: 2\n");
+        assert!(r.is_complete);
+        if let Value::Mapping(m) = &r.value {
+            assert!(m.contains_key("a"));
+        } else {
+            panic!("BOM-prefixed input should parse cleanly");
+        }
+    }
+
+    #[test]
+    fn marker_spam_is_bounded() {
+        // 10k `---\n` markers in a row. Without the C2 cap this
+        // would build a 10k-entry `Vec<usize>` and try to parse
+        // each marker as a doc. With the cap it returns whatever
+        // `max_documents` permits (default 1000).
+        let yaml = "---\n".repeat(10_000);
+        let r = parse_lenient(&yaml);
+        if let Value::Sequence(s) = &r.value {
+            assert!(s.len() <= 1000);
+        } else {
+            // All-Null acceptable; we just must not OOM/hang.
+        }
+    }
+
+    #[test]
+    fn truncation_handles_no_trailing_newline() {
+        // M3 — the prefix `"a: 1\nb: ["` ends without `\n`; the
+        //      fix treats the buffer end as a truncation
+        //      candidate so the prefix `"a: 1\n"` is salvaged.
+        let r = parse_lenient("a: 1\nb: [bad");
+        if let Value::Mapping(m) = &r.value {
+            assert_eq!(m.get("a").and_then(|v| v.as_i64()), Some(1));
+        }
+    }
+
+    #[test]
+    fn budget_exhaustion_preserves_indices() {
+        // M2 — when the budget runs out mid-stream, remaining
+        //      docs become Null (not dropped) so per-doc
+        //      diagnostic indices still line up.
+        let cfg = LenientConfig {
+            max_errors: 1,
+            ..LenientConfig::default()
+        };
+        let yaml = "---\na: [bad\n---\nb: [bad\n---\nc: [bad\n";
+        let r = parse_lenient_with(yaml, &cfg);
+        if let Value::Sequence(s) = &r.value {
+            assert_eq!(s.len(), 3);
+        } else {
+            panic!("expected sequence with all 3 indices preserved");
+        }
+    }
+
+    #[test]
+    fn truncation_budget_caps_retries() {
+        // C1 — adversarial 10k-line input cannot drive unbounded
+        //      re-parses. With a tiny truncation budget the
+        //      recoverer gives up early but does not hang.
+        let cfg = LenientConfig {
+            truncation_event_budget: 64,
+            ..LenientConfig::default()
+        };
+        // 10k malformed lines after one valid line.
+        let mut yaml = String::from("a: 1\n");
+        for _ in 0..10_000 {
+            yaml.push_str("[bad\n");
+        }
+        let _r = parse_lenient_with(&yaml, &cfg);
+        // No panic, no hang.
     }
 }

--- a/crates/noyalib/src/recovery.rs
+++ b/crates/noyalib/src/recovery.rs
@@ -312,8 +312,7 @@ mod tests {
         // is strict about duplicate keys; the workspace default
         // (DuplicateKeyPolicy::Last) silently accepts them.
         let cfg = LenientConfig {
-            base_config: ParserConfig::default()
-                .duplicate_key_policy(DuplicateKeyPolicy::Error),
+            base_config: ParserConfig::default().duplicate_key_policy(DuplicateKeyPolicy::Error),
             ..LenientConfig::default()
         };
         let r = parse_lenient_with("a: 1\na: 2\n", &cfg);

--- a/crates/noyalib/src/recovery.rs
+++ b/crates/noyalib/src/recovery.rs
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Error-recovering YAML parser for LSP / IDE partial parsing.
+//!
+//! The default `from_str` family returns `Err` at the first
+//! syntax violation. Language Server Protocol implementations
+//! need the opposite contract: keep going past errors, build a
+//! best-effort partial tree, and collect every error encountered
+//! so the editor can show a complete diagnostics list and offer
+//! autocomplete on the recoverable subtrees.
+//!
+//! [`parse_lenient`] is that contract:
+//!
+//! * Top-level `---` document boundaries are scanned first; each
+//!   document is parsed independently so one broken document
+//!   never prevents the others from being recovered.
+//! * Within a single document, if the strict pass fails, the
+//!   recoverer retries with [`DuplicateKeyPolicy::Last`] — the
+//!   most common LSP-time error mode (a user typing a new key
+//!   while an old one is still on screen). Successful recovery
+//!   yields the post-retry value plus the original error in the
+//!   error list, so the editor still flags the duplicate.
+//! * If that retry also fails, the recoverer performs **line
+//!   truncation recovery**: drop trailing lines one by one and
+//!   re-parse until either a parse succeeds or the input is
+//!   exhausted. The successful prefix becomes the recovered
+//!   value; everything past the truncation point is summarised
+//!   as a synthetic [`Value::Null`].
+//! * A configurable error cap ([`LenientConfig::max_errors`])
+//!   stops further recovery once enough diagnostics have been
+//!   collected — useful when the document is so malformed that
+//!   every line errors.
+//!
+//! Gated behind the `recovery` Cargo feature.
+//!
+//! # Output shape
+//!
+//! For multi-document input the result's [`ParseResult::value`]
+//! is a [`Value::Sequence`] of per-document values (recovered or
+//! `Null`) — this matches what an LSP would walk to label
+//! per-document diagnostics. For single-document input the
+//! result's `value` is the recovered document directly (not
+//! wrapped in a sequence).
+//!
+//! # Example
+//!
+//! ```
+//! # #[cfg(feature = "recovery")] {
+//! let yaml = "a: 1\nb: [unclosed\nc: 3\n";
+//! let result = noyalib::recovery::parse_lenient(yaml);
+//! assert!(!result.is_complete);
+//! assert!(!result.errors.is_empty());
+//! // `value` is the best-effort tree the recoverer salvaged.
+//! # }
+//! ```
+
+use crate::de::{DuplicateKeyPolicy, ParserConfig, from_str_with_config};
+use crate::error::Error;
+use crate::value::Value;
+
+/// Result of an error-recovering parse pass.
+///
+/// `value` is the best-effort tree the recoverer was able to
+/// salvage from the input. `errors` lists every error the
+/// recoverer encountered, in the order it found them.
+/// `is_complete` is `true` when no errors were collected — the
+/// input parsed cleanly on the first attempt.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ParseResult {
+    /// Best-effort recovered value. For multi-document input
+    /// this is a [`Value::Sequence`] of per-document values
+    /// (recovered or [`Value::Null`]); for single-document input
+    /// it is the recovered document directly.
+    pub value: Value,
+    /// Every error the recoverer encountered, in source order.
+    pub errors: Vec<Error>,
+    /// `true` when no errors were collected.
+    pub is_complete: bool,
+}
+
+/// Knobs for the recovery passes.
+///
+/// Constructed via [`LenientConfig::default`]; tweak fields
+/// inline. The struct is intentionally not marked
+/// `#[non_exhaustive]` so callers can use struct-literal syntax
+/// like `LenientConfig { max_errors: 50, ..Default::default() }`.
+/// Adding a field is a semver-minor breaking change pre-1.0.
+#[derive(Debug, Clone)]
+pub struct LenientConfig {
+    /// Stop collecting diagnostics once this many errors have
+    /// been recorded. Defaults to `100`.
+    pub max_errors: usize,
+    /// When the strict parse fails, retry with
+    /// [`DuplicateKeyPolicy::Last`] before giving up. Defaults to
+    /// `true`.
+    pub recover_duplicate_keys: bool,
+    /// When both the strict and duplicate-key retries fail,
+    /// drop trailing lines one by one and re-parse. Defaults to
+    /// `true`.
+    pub line_truncation: bool,
+    /// Base parser configuration. Defaults to
+    /// [`ParserConfig::default`].
+    pub base_config: ParserConfig,
+}
+
+impl Default for LenientConfig {
+    fn default() -> Self {
+        Self {
+            max_errors: 100,
+            recover_duplicate_keys: true,
+            line_truncation: true,
+            base_config: ParserConfig::default(),
+        }
+    }
+}
+
+/// Parse `input` with full error recovery.
+///
+/// Equivalent to [`parse_lenient_with`] with
+/// [`LenientConfig::default`].
+#[must_use]
+pub fn parse_lenient(input: &str) -> ParseResult {
+    parse_lenient_with(input, &LenientConfig::default())
+}
+
+/// Parse `input` with caller-supplied recovery knobs.
+///
+/// See the [module docs](self) for the recovery strategy.
+#[must_use]
+pub fn parse_lenient_with(input: &str, config: &LenientConfig) -> ParseResult {
+    let docs = split_documents(input);
+
+    if docs.is_empty() {
+        return ParseResult {
+            value: Value::Null,
+            errors: Vec::new(),
+            is_complete: true,
+        };
+    }
+
+    if docs.len() == 1 {
+        let (value, errors) = recover_one(docs[0], config, config.max_errors);
+        let is_complete = errors.is_empty();
+        return ParseResult {
+            value,
+            errors,
+            is_complete,
+        };
+    }
+
+    let mut values: Vec<Value> = Vec::with_capacity(docs.len());
+    let mut errors: Vec<Error> = Vec::new();
+    let mut budget = config.max_errors;
+    for doc in docs {
+        let (value, doc_errors) = recover_one(doc, config, budget);
+        budget = budget.saturating_sub(doc_errors.len());
+        errors.extend(doc_errors);
+        values.push(value);
+        if budget == 0 {
+            break;
+        }
+    }
+    let is_complete = errors.is_empty();
+    ParseResult {
+        value: Value::Sequence(values),
+        errors,
+        is_complete,
+    }
+}
+
+/// Recover a single document.
+///
+/// Returns the best-effort `Value` and the list of errors
+/// encountered. Bounded by `budget` — once exhausted, the
+/// recoverer returns whatever it has and stops.
+fn recover_one(input: &str, config: &LenientConfig, budget: usize) -> (Value, Vec<Error>) {
+    if budget == 0 {
+        return (Value::Null, Vec::new());
+    }
+
+    // Pass 1: strict.
+    let strict_err = match from_str_with_config::<Value>(input, &config.base_config) {
+        Ok(v) => return (v, Vec::new()),
+        Err(e) => e,
+    };
+    let errors = vec![strict_err];
+
+    // Pass 2: duplicate-key recovery via DuplicateKeyPolicy::Last.
+    if config.recover_duplicate_keys && errors.len() < budget {
+        let mut cfg2 = config.base_config.clone();
+        cfg2.duplicate_key_policy = DuplicateKeyPolicy::Last;
+        if let Ok(v) = from_str_with_config::<Value>(input, &cfg2) {
+            // The original strict error is still surfaced as a
+            // diagnostic so the editor flags the duplicate.
+            return (v, errors);
+        }
+    }
+
+    // Pass 3: line-truncation recovery.
+    if config.line_truncation && errors.len() < budget {
+        if let Some(v) = try_line_truncation(input, &config.base_config) {
+            return (v, errors);
+        }
+    }
+
+    (Value::Null, errors)
+}
+
+/// Drop trailing lines one at a time, retrying the parse, until
+/// a parse succeeds or only one line remains.
+fn try_line_truncation(input: &str, config: &ParserConfig) -> Option<Value> {
+    // Collect line boundaries so we can truncate by slice rather
+    // than by re-string-building.
+    let mut boundaries: Vec<usize> = Vec::new();
+    for (i, b) in input.as_bytes().iter().enumerate() {
+        if *b == b'\n' {
+            boundaries.push(i);
+        }
+    }
+    // Iterate from the last line backwards.
+    for &cut in boundaries.iter().rev() {
+        let candidate = &input[..cut];
+        if candidate.trim().is_empty() {
+            continue;
+        }
+        if let Ok(v) = from_str_with_config::<Value>(candidate, config) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Split `input` on top-level YAML `---` document markers.
+///
+/// Inline mirror of the document-boundary scanner in
+/// [`crate::parallel::split`] — duplicated here so the
+/// `recovery` feature does not require the heavyweight
+/// `parallel` feature (which pulls in Rayon).
+fn split_documents(input: &str) -> Vec<&str> {
+    let bytes = input.as_bytes();
+    let mut markers: Vec<usize> = Vec::new();
+    let mut i = 0;
+    while i + 3 <= bytes.len() {
+        let at_line_start = i == 0 || bytes[i - 1] == b'\n' || bytes[i - 1] == b'\r';
+        if at_line_start && &bytes[i..i + 3] == b"---" {
+            let next_ok =
+                i + 3 >= bytes.len() || matches!(bytes[i + 3], b'\n' | b'\r' | b' ' | b'\t');
+            if next_ok {
+                markers.push(i);
+                i += 3;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    if markers.is_empty() {
+        return if input.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![input]
+        };
+    }
+
+    let mut docs: Vec<&str> = Vec::with_capacity(markers.len() + 1);
+    if markers[0] > 0 {
+        let pre = input[..markers[0]].trim();
+        if !pre.is_empty() {
+            docs.push(&input[..markers[0]]);
+        }
+    }
+    for window in markers.windows(2) {
+        docs.push(&input[window[0]..window[1]]);
+    }
+    let last = *markers.last().unwrap();
+    if last < input.len() {
+        let trailing = &input[last..];
+        if !trailing.trim_end().is_empty() {
+            docs.push(trailing);
+        }
+    }
+    docs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_input_is_complete() {
+        let r = parse_lenient("a: 1\nb: 2\n");
+        assert!(r.is_complete);
+        assert!(r.errors.is_empty());
+        let m = r.value.as_mapping().unwrap();
+        assert!(m.contains_key("a"));
+        assert!(m.contains_key("b"));
+    }
+
+    #[test]
+    fn empty_input_is_complete() {
+        let r = parse_lenient("");
+        assert!(r.is_complete);
+        assert!(r.errors.is_empty());
+        assert!(matches!(r.value, Value::Null));
+    }
+
+    #[test]
+    fn duplicate_key_is_recovered() {
+        // The recovery pass kicks in only when the base config
+        // is strict about duplicate keys; the workspace default
+        // (DuplicateKeyPolicy::Last) silently accepts them.
+        let cfg = LenientConfig {
+            base_config: ParserConfig::default()
+                .duplicate_key_policy(DuplicateKeyPolicy::Error),
+            ..LenientConfig::default()
+        };
+        let r = parse_lenient_with("a: 1\na: 2\n", &cfg);
+        assert!(!r.is_complete);
+        assert_eq!(r.errors.len(), 1);
+        let m = r.value.as_mapping().unwrap();
+        let v = m.get("a").unwrap();
+        assert_eq!(v.as_i64(), Some(2));
+    }
+
+    #[test]
+    fn unrecoverable_input_yields_null_with_errors() {
+        // `[` opens a flow sequence that never closes — no
+        // truncation makes this valid.
+        let r = parse_lenient("[\n");
+        assert!(!r.is_complete);
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn line_truncation_recovers_trailing_garbage() {
+        // First two lines parse; third line is malformed flow.
+        let r = parse_lenient("a: 1\nb: 2\nc: [unclosed\n");
+        assert!(!r.is_complete);
+        // The recoverer should salvage at least the strict-error
+        // for the malformed third line.
+        assert!(!r.errors.is_empty());
+        // Best-effort tree: should contain `a` (and may contain `b`).
+        if let Value::Mapping(m) = &r.value {
+            assert!(m.contains_key("a"));
+        }
+    }
+
+    #[test]
+    fn multi_doc_recovers_each_independently() {
+        let yaml = "---\na: 1\n---\nb: [unclosed\n---\nc: 3\n";
+        let r = parse_lenient(yaml);
+        assert!(!r.is_complete);
+        let seq = match &r.value {
+            Value::Sequence(s) => s,
+            _ => panic!("expected sequence for multi-doc input"),
+        };
+        assert_eq!(seq.len(), 3);
+        // Docs 0 and 2 should recover; doc 1 is the bad one.
+        assert!(matches!(&seq[0], Value::Mapping(_)));
+        assert!(matches!(&seq[2], Value::Mapping(_)));
+    }
+
+    #[test]
+    fn max_errors_caps_collection() {
+        let cfg = LenientConfig {
+            max_errors: 1,
+            ..LenientConfig::default()
+        };
+        let yaml = "---\na: [bad\n---\nb: [bad\n---\nc: [bad\n";
+        let r = parse_lenient_with(yaml, &cfg);
+        assert!(r.errors.len() <= 1);
+    }
+
+    #[test]
+    fn split_documents_handles_single() {
+        let d = split_documents("a: 1\n");
+        assert_eq!(d.len(), 1);
+    }
+
+    #[test]
+    fn split_documents_handles_empty() {
+        assert!(split_documents("").is_empty());
+        assert!(split_documents("   \n").is_empty());
+    }
+}

--- a/crates/noyalib/src/recovery.rs
+++ b/crates/noyalib/src/recovery.rs
@@ -10,7 +10,7 @@
 //! so the editor can show a complete diagnostics list and offer
 //! autocomplete on the recoverable subtrees.
 //!
-//! [`parse_lenient`] is that contract:
+//! `parse_lenient` is that contract:
 //!
 //! * Top-level `---` document boundaries are scanned first; each
 //!   document is parsed independently so one broken document
@@ -27,7 +27,7 @@
 //!   exhausted. The successful prefix becomes the recovered
 //!   value; everything past the truncation point is summarised
 //!   as a synthetic [`Value::Null`].
-//! * A configurable error cap ([`LenientConfig::max_errors`])
+//! * A configurable error cap (`LenientConfig::max_errors`)
 //!   stops further recovery once enough diagnostics have been
 //!   collected — useful when the document is so malformed that
 //!   every line errors.
@@ -36,8 +36,8 @@
 //!
 //! # Output shape
 //!
-//! For multi-document input the result's [`ParseResult::value`]
-//! is a [`Value::Sequence`] of per-document values (recovered or
+//! For multi-document input the result's `ParseResult::value`
+//! is a `Value::Sequence` of per-document values (recovered or
 //! `Null`) — this matches what an LSP would walk to label
 //! per-document diagnostics. For single-document input the
 //! result's `value` is the recovered document directly (not

--- a/crates/noyalib/src/schema_codegen.rs
+++ b/crates/noyalib/src/schema_codegen.rs
@@ -61,7 +61,7 @@ use crate::value::Value;
 ///
 /// ```toml
 /// [dependencies]
-/// noyalib = { version = "0.0.1", features = ["schema"] }
+/// noyalib = { version = "0.0.6", features = ["schema"] }
 /// schemars = "1.2"
 /// ```
 ///

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -651,9 +651,11 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     de: self,
                     finished: false,
                     count: 0,
-                })?;
+                });
+                // Decrement on both Ok and Err so a failed inner
+                // visit_seq doesn't leak depth (issue #46).
                 self.depth = self.depth.saturating_sub(1);
-                Ok(res)
+                res
             }
             Event::MappingStart { .. } => {
                 self.depth += 1;
@@ -666,9 +668,12 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     has_emitted_key: false,
                     key_count: 0,
                     seen_keys: FxHashSet::default(),
-                })?;
+                });
+                // Decrement on both Ok and Err so a failed inner
+                // visit_map doesn't leak a depth count into the
+                // outer scope (issue #46).
                 self.depth = self.depth.saturating_sub(1);
-                Ok(res)
+                res
             }
             _ => Err(self.fallback()),
         }
@@ -922,9 +927,10 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                 de: self,
                 finished: false,
                 count: 0,
-            })?;
+            });
+            // Decrement on Ok and Err (issue #46).
             self.depth = self.depth.saturating_sub(1);
-            Ok(res)
+            res
         } else {
             Err(Error::TypeMismatch {
                 expected: "sequence",
@@ -958,9 +964,10 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                 has_emitted_key: false,
                 key_count: 0,
                 seen_keys: FxHashSet::default(),
-            })?;
+            });
+            // Decrement on Ok and Err (issue #46).
             self.depth = self.depth.saturating_sub(1);
-            Ok(res)
+            res
         } else {
             Err(Error::TypeMismatch {
                 expected: "mapping",
@@ -1154,6 +1161,14 @@ impl<'de> SeqAccess<'de> for StreamingSeqAccess<'_, 'de> {
     where
         T: DeserializeSeed<'de>,
     {
+        // Symmetric guard with `StreamingMapAccess::next_key_seed`
+        // — callers that re-invoke `next_element` after the
+        // sequence is exhausted must not consume events from the
+        // parent context. See issue #46 for the matching map-side
+        // failure mode.
+        if self.finished {
+            return Ok(None);
+        }
         if matches!(self.de.peek_event()?, Event::SequenceEnd { .. }) {
             self.de.skip_event()?;
             self.finished = true;
@@ -1208,6 +1223,18 @@ impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
     where
         K: DeserializeSeed<'de>,
     {
+        // Guard against serde visitors (e.g. `noyalib::Value`'s
+        // `ValueVisitor::visit_map`) that call `next_key` again
+        // after the previous call returned `Ok(None)`. Without
+        // this guard the loop reads events from the *parent*
+        // mapping and treats them as belonging to the now-empty
+        // child — the recursive `deserialize_any` on each spilled
+        // value inflates `self.depth` by one per entry and
+        // triggers `RecursionLimitExceeded` on otherwise-shallow
+        // documents (issue #46).
+        if self.finished {
+            return Ok(None);
+        }
         loop {
             // Use `peek_event` so we see events queued on the replay stack
             // by a prior merge expansion — `peek_parser_event` bypasses it
@@ -1313,6 +1340,16 @@ impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
     where
         V: DeserializeSeed<'de>,
     {
+        // Symmetric guard with `next_key_seed`. Callers that
+        // misuse the MapAccess contract (e.g. invoking
+        // `next_value` after the keys are exhausted) would
+        // otherwise read into the parent mapping's value events
+        // — the same `depth` leak documented in issue #46.
+        if self.finished {
+            return Err(Error::Custom(
+                "next_value_seed called after MapAccess exhausted".into(),
+            ));
+        }
         seed.deserialize(&mut *self.de)
     }
 }

--- a/crates/noyalib/src/sval_adapter.rs
+++ b/crates/noyalib/src/sval_adapter.rs
@@ -20,7 +20,7 @@
 //!   value graph to any [`sval::Stream`].
 //! * `impl sval::Value for [crate::Number]` — stream a single
 //!   number.
-//! * [`to_sval_writer`] — high-level helper that streams a
+//! * `to_sval_writer` — high-level helper that streams a
 //!   noyalib [`crate::Value`] to a writer that implements
 //!   [`sval::Stream`].
 //!

--- a/crates/noyalib/src/sval_adapter.rs
+++ b/crates/noyalib/src/sval_adapter.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! `sval` adapter — stream noyalib values through any
+//! [`sval::Stream`] consumer.
+//!
+//! Provides an alternative to the default serde route for callers
+//! who want to avoid `serde_derive`'s compile-time overhead or the
+//! binary-size cost of serde monomorphisation. `sval` is a small,
+//! streaming serialization framework: instead of materialising a
+//! data graph, the producer walks the source and emits events on
+//! a [`sval::Stream`] (similar in spirit to YAML's own event-driven
+//! parser).
+//!
+//! Gated behind the `sval` Cargo feature.
+//!
+//! # API surface
+//!
+//! * `impl sval::Value for [crate::Value]` — stream a noyalib
+//!   value graph to any [`sval::Stream`].
+//! * `impl sval::Value for [crate::Number]` — stream a single
+//!   number.
+//! * [`to_sval_writer`] — high-level helper that streams a
+//!   noyalib [`crate::Value`] to a writer that implements
+//!   [`sval::Stream`].
+//!
+//! serde remains the default route for typed deserialise; `sval`
+//! is an additive, opt-in surface for callers that prefer the
+//! streaming framework. The two routes share `Value`, so a
+//! roundtrip-via-`Value` works as expected.
+//!
+//! # Example
+//!
+//! ```
+//! use noyalib::Value;
+//! let v: Value = noyalib::from_str("name: noyalib").unwrap();
+//! // The `impl sval::Value for Value` lets you hand any
+//! // noyalib-parsed graph to any `sval::Stream` consumer.
+//! // Concrete stream impls are supplied by ecosystem crates
+//! // such as `sval_fmt`, `sval_json`, or your own — noyalib
+//! // does not pull those in.
+//! assert!(matches!(v, Value::Mapping(_)));
+//! ```
+
+use crate::value::{Mapping, MappingAny, Number, TaggedValue, Value};
+
+impl sval::Value for Value {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        match self {
+            Value::Null => stream.null(),
+            Value::Bool(b) => stream.bool(*b),
+            Value::Number(n) => n.stream(stream),
+            Value::String(s) => stream.value(s.as_str()),
+            Value::Sequence(items) => stream_seq(items, stream),
+            Value::Mapping(m) => m.stream(stream),
+            Value::Tagged(t) => t.stream(stream),
+        }
+    }
+}
+
+impl sval::Value for Number {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        match self {
+            Number::Integer(i) => stream.i64(*i),
+            Number::Float(f) => stream.f64(*f),
+        }
+    }
+}
+
+impl sval::Value for Mapping {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.map_begin(Some(self.len()))?;
+        for (k, v) in self.iter() {
+            stream.map_key_begin()?;
+            stream.value(k.as_str())?;
+            stream.map_key_end()?;
+            stream.map_value_begin()?;
+            stream.value(v)?;
+            stream.map_value_end()?;
+        }
+        stream.map_end()
+    }
+}
+
+impl sval::Value for MappingAny {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.map_begin(Some(self.len()))?;
+        for (k, v) in self.iter() {
+            stream.map_key_begin()?;
+            stream.value(k)?;
+            stream.map_key_end()?;
+            stream.map_value_begin()?;
+            stream.value(v)?;
+            stream.map_value_end()?;
+        }
+        stream.map_end()
+    }
+}
+
+impl sval::Value for TaggedValue {
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        // sval has no first-class "YAML tag" concept; surface the
+        // tag as a sval `tag` annotation around the inner value
+        // so consumers that care can introspect it, then stream
+        // the inner value normally.
+        let label = sval::Label::new_computed(self.tag().as_str());
+        stream.tagged_begin(None, Some(&label), None)?;
+        stream.value(self.value())?;
+        stream.tagged_end(None, Some(&label), None)
+    }
+}
+
+fn stream_seq<'sval, S: sval::Stream<'sval> + ?Sized>(
+    items: &'sval [Value],
+    stream: &mut S,
+) -> sval::Result {
+    stream.seq_begin(Some(items.len()))?;
+    for item in items {
+        stream.seq_value_begin()?;
+        stream.value(item)?;
+        stream.seq_value_end()?;
+    }
+    stream.seq_end()
+}
+
+/// Stream a [`Value`] into a writer that implements
+/// [`sval::Stream`].
+///
+/// Convenience wrapper around the [`sval::Value`] impl on
+/// [`Value`]: just calls `value.stream(stream)`. Useful as a
+/// named entry point so call sites read as
+/// `noyalib::sval_adapter::to_sval_writer(&mut stream, &value)`.
+///
+/// # Errors
+///
+/// Returns the underlying [`sval::Error`] from the stream
+/// implementation.
+pub fn to_sval_writer<'sval, S: sval::Stream<'sval> + ?Sized>(
+    stream: &mut S,
+    value: &'sval Value,
+) -> sval::Result {
+    sval::Value::stream(value, stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::{Mapping, Number, Sequence};
+
+    /// Minimal `sval::Stream` that just records the event
+    /// sequence as strings — enough to assert structure.
+    #[derive(Default)]
+    struct Recorder(Vec<String>);
+
+    impl sval::Stream<'_> for Recorder {
+        fn null(&mut self) -> sval::Result {
+            self.0.push("null".into());
+            Ok(())
+        }
+        fn bool(&mut self, v: bool) -> sval::Result {
+            self.0.push(format!("bool({v})"));
+            Ok(())
+        }
+        fn i64(&mut self, v: i64) -> sval::Result {
+            self.0.push(format!("i64({v})"));
+            Ok(())
+        }
+        fn f64(&mut self, v: f64) -> sval::Result {
+            self.0.push(format!("f64({v})"));
+            Ok(())
+        }
+        fn text_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.0.push("text_begin".into());
+            Ok(())
+        }
+        fn text_fragment_computed(&mut self, fragment: &str) -> sval::Result {
+            self.0.push(format!("text({fragment})"));
+            Ok(())
+        }
+        fn text_end(&mut self) -> sval::Result {
+            self.0.push("text_end".into());
+            Ok(())
+        }
+        fn map_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.0.push("map_begin".into());
+            Ok(())
+        }
+        fn map_end(&mut self) -> sval::Result {
+            self.0.push("map_end".into());
+            Ok(())
+        }
+        fn map_key_begin(&mut self) -> sval::Result {
+            self.0.push("map_key_begin".into());
+            Ok(())
+        }
+        fn map_key_end(&mut self) -> sval::Result {
+            self.0.push("map_key_end".into());
+            Ok(())
+        }
+        fn map_value_begin(&mut self) -> sval::Result {
+            self.0.push("map_value_begin".into());
+            Ok(())
+        }
+        fn map_value_end(&mut self) -> sval::Result {
+            self.0.push("map_value_end".into());
+            Ok(())
+        }
+        fn seq_begin(&mut self, _: Option<usize>) -> sval::Result {
+            self.0.push("seq_begin".into());
+            Ok(())
+        }
+        fn seq_end(&mut self) -> sval::Result {
+            self.0.push("seq_end".into());
+            Ok(())
+        }
+        fn seq_value_begin(&mut self) -> sval::Result {
+            self.0.push("seq_value_begin".into());
+            Ok(())
+        }
+        fn seq_value_end(&mut self) -> sval::Result {
+            self.0.push("seq_value_end".into());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn null_streams_null_event() {
+        let mut r = Recorder::default();
+        sval::Value::stream(&Value::Null, &mut r).unwrap();
+        assert_eq!(r.0, vec!["null".to_string()]);
+    }
+
+    #[test]
+    fn bool_streams_bool_event() {
+        let mut r = Recorder::default();
+        sval::Value::stream(&Value::Bool(true), &mut r).unwrap();
+        assert_eq!(r.0, vec!["bool(true)".to_string()]);
+    }
+
+    #[test]
+    fn integer_streams_i64_event() {
+        let mut r = Recorder::default();
+        sval::Value::stream(&Value::Number(Number::Integer(42)), &mut r).unwrap();
+        assert_eq!(r.0, vec!["i64(42)".to_string()]);
+    }
+
+    #[test]
+    fn float_streams_f64_event() {
+        let mut r = Recorder::default();
+        sval::Value::stream(&Value::Number(Number::Float(2.5)), &mut r).unwrap();
+        assert_eq!(r.0, vec!["f64(2.5)".to_string()]);
+    }
+
+    #[test]
+    fn sequence_streams_seq_events() {
+        let mut r = Recorder::default();
+        let v: Sequence = vec![Value::Bool(true), Value::Bool(false)];
+        sval::Value::stream(&Value::Sequence(v), &mut r).unwrap();
+        let s = r.0.join(",");
+        assert!(s.contains("seq_begin"));
+        assert!(s.contains("bool(true)"));
+        assert!(s.contains("bool(false)"));
+        assert!(s.contains("seq_end"));
+    }
+
+    #[test]
+    fn mapping_streams_map_events() {
+        let mut r = Recorder::default();
+        let mut m = Mapping::new();
+        let _ = m.insert("k".to_string(), Value::Bool(true));
+        sval::Value::stream(&Value::Mapping(m), &mut r).unwrap();
+        let s = r.0.join(",");
+        assert!(s.contains("map_begin"));
+        assert!(s.contains("map_key_begin"));
+        assert!(s.contains("text(k)"));
+        assert!(s.contains("map_value_begin"));
+        assert!(s.contains("bool(true)"));
+        assert!(s.contains("map_end"));
+    }
+}

--- a/crates/noyalib/src/sval_adapter.rs
+++ b/crates/noyalib/src/sval_adapter.rs
@@ -264,6 +264,57 @@ mod tests {
     }
 
     #[test]
+    fn tagged_value_wraps_inner() {
+        use crate::value::{Tag, TaggedValue};
+        let mut r = Recorder::default();
+        let tv = TaggedValue::new(Tag::new("!timestamp"), Value::String("2026".into()));
+        sval::Value::stream(&Value::Tagged(Box::new(tv)), &mut r).unwrap();
+        // The tagged_begin/tagged_end events use Label::new_computed
+        // and don't surface through the Recorder's matched callbacks,
+        // but the inner value's text events must still appear.
+        let s = r.0.join(",");
+        assert!(s.contains("text(2026)"));
+    }
+
+    #[test]
+    fn mapping_any_streams_value_keyed_events() {
+        use crate::value::{MappingAny, Number};
+        let mut r = Recorder::default();
+        let mut m = MappingAny::new();
+        let _ = m.insert(Value::Number(Number::Integer(7)), Value::Bool(true));
+        sval::Value::stream(&m, &mut r).unwrap();
+        let s = r.0.join(",");
+        assert!(s.contains("map_begin"));
+        assert!(s.contains("i64(7)"));
+        assert!(s.contains("bool(true)"));
+        assert!(s.contains("map_end"));
+    }
+
+    #[test]
+    fn number_impl_streams_directly() {
+        let mut r = Recorder::default();
+        sval::Value::stream(&Number::Integer(99), &mut r).unwrap();
+        assert_eq!(r.0, vec!["i64(99)".to_string()]);
+    }
+
+    #[test]
+    fn to_sval_writer_helper_streams() {
+        let mut r = Recorder::default();
+        let v = Value::Bool(false);
+        to_sval_writer(&mut r, &v).unwrap();
+        assert_eq!(r.0, vec!["bool(false)".to_string()]);
+    }
+
+    #[test]
+    fn null_string_streams_via_value_route() {
+        // Exercises the Value::String branch of the dispatcher.
+        let mut r = Recorder::default();
+        sval::Value::stream(&Value::String("hello".into()), &mut r).unwrap();
+        let s = r.0.join(",");
+        assert!(s.contains("text(hello)"));
+    }
+
+    #[test]
     fn mapping_streams_map_events() {
         let mut r = Recorder::default();
         let mut m = Mapping::new();

--- a/crates/noyalib/src/sval_adapter.rs
+++ b/crates/noyalib/src/sval_adapter.rs
@@ -29,6 +29,28 @@
 //! streaming framework. The two routes share `Value`, so a
 //! roundtrip-via-`Value` works as expected.
 //!
+//! # Non-finite floats
+//!
+//! YAML's `.nan` / `.inf` / `-.inf` literals deserialise into
+//! `Value::Number(Number::Float(f64::NAN | INFINITY | NEG_INFINITY))`.
+//! The default streaming behaviour forwards them verbatim to
+//! `sval::Stream::f64`. **Some sval consumers — notably
+//! `sval_json` — reject non-finite floats at runtime.** Callers
+//! whose downstream cannot tolerate that should either filter
+//! out non-finites before streaming, or wrap their `sval::Stream`
+//! impl with a finite-coercion shim. The
+//! `to_sval_writer_with_config` entry point exposes a
+//! `coerce_non_finite_to_null` knob for top-level non-finite
+//! scalars; nested non-finites land in a follow-up cut.
+//!
+//! # Inverse direction
+//!
+//! v0.0.6 ships the noyalib → sval direction only. A
+//! sval → noyalib adapter (built on `sval_buffer::Value`) is
+//! tracked for a follow-up cut; for now, callers that need to
+//! ingest sval graphs into noyalib should go through serde or
+//! the `Value` AST.
+//!
 //! # Example
 //!
 //! ```
@@ -42,7 +64,7 @@
 //! assert!(matches!(v, Value::Mapping(_)));
 //! ```
 
-use crate::value::{Mapping, MappingAny, Number, TaggedValue, Value};
+use crate::value::{Mapping, MappingAny, Number, Tag, TaggedValue, Value};
 
 impl sval::Value for Value {
     fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
@@ -97,6 +119,15 @@ impl sval::Value for MappingAny {
     }
 }
 
+impl sval::Value for Tag {
+    /// A `Tag` on its own streams as plain text (the tag string).
+    /// The richer "tag-around-value" shape is in
+    /// [`impl sval::Value for TaggedValue`].
+    fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
+        stream.value(self.as_str())
+    }
+}
+
 impl sval::Value for TaggedValue {
     fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
         // sval has no first-class "YAML tag" concept; surface the
@@ -131,6 +162,11 @@ fn stream_seq<'sval, S: sval::Stream<'sval> + ?Sized>(
 /// named entry point so call sites read as
 /// `noyalib::sval_adapter::to_sval_writer(&mut stream, &value)`.
 ///
+/// Pair with [`to_sval_writer_with_config`] to coerce non-finite
+/// floats (NaN, ±∞) into `Null` before emission — required for
+/// downstream sval consumers that reject non-finites
+/// (`sval_json` is the canonical example).
+///
 /// # Errors
 ///
 /// Returns the underlying [`sval::Error`] from the stream
@@ -139,6 +175,48 @@ pub fn to_sval_writer<'sval, S: sval::Stream<'sval> + ?Sized>(
     stream: &mut S,
     value: &'sval Value,
 ) -> sval::Result {
+    sval::Value::stream(value, stream)
+}
+
+/// Knobs for [`to_sval_writer_with_config`].
+///
+/// Constructed via [`Self::default`]; tweak fields inline.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SvalConfig {
+    /// When `true`, non-finite floats (`f64::NAN`, `INFINITY`,
+    /// `NEG_INFINITY`) are emitted as `stream.null()` instead of
+    /// `stream.f64(_)`. Downstream sval consumers that reject
+    /// non-finites (notably `sval_json`) will accept the
+    /// resulting stream. Defaults to `false` — verbatim
+    /// forwarding matches the trait-impl behaviour.
+    pub coerce_non_finite_to_null: bool,
+}
+
+/// [`to_sval_writer`] with caller-supplied knobs.
+///
+/// The configured coercions are applied as a thin wrapper on top
+/// of the raw `sval::Value` impl — every non-`Value::Number` event
+/// is forwarded unchanged.
+///
+/// # Errors
+///
+/// Returns the underlying [`sval::Error`] from the stream
+/// implementation.
+pub fn to_sval_writer_with_config<'sval, S: sval::Stream<'sval> + ?Sized>(
+    stream: &mut S,
+    value: &'sval Value,
+    config: &SvalConfig,
+) -> sval::Result {
+    if config.coerce_non_finite_to_null
+        && let Value::Number(Number::Float(f)) = value
+        && !f.is_finite()
+    {
+        return stream.null();
+    }
+    // Numbers are forwarded as-is via the per-type impl when no
+    // coercion is requested or the float is finite. For
+    // composite shapes we'd need a full walking wrapper; that
+    // arrives in a follow-up cut once the API shape settles.
     sval::Value::stream(value, stream)
 }
 
@@ -303,6 +381,37 @@ mod tests {
         let v = Value::Bool(false);
         to_sval_writer(&mut r, &v).unwrap();
         assert_eq!(r.0, vec!["bool(false)".to_string()]);
+    }
+
+    #[test]
+    fn tag_streams_as_text() {
+        let mut r = Recorder::default();
+        let t = Tag::new("!timestamp");
+        sval::Value::stream(&t, &mut r).unwrap();
+        let s = r.0.join(",");
+        assert!(s.contains("text(!timestamp)"));
+    }
+
+    #[test]
+    fn nan_coerced_to_null_via_config() {
+        let mut r = Recorder::default();
+        let v = Value::Number(Number::Float(f64::NAN));
+        let cfg = SvalConfig {
+            coerce_non_finite_to_null: true,
+        };
+        to_sval_writer_with_config(&mut r, &v, &cfg).unwrap();
+        assert_eq!(r.0, vec!["null".to_string()]);
+    }
+
+    #[test]
+    fn finite_float_passes_through_config() {
+        let mut r = Recorder::default();
+        let v = Value::Number(Number::Float(2.5));
+        let cfg = SvalConfig {
+            coerce_non_finite_to_null: true,
+        };
+        to_sval_writer_with_config(&mut r, &v, &cfg).unwrap();
+        assert_eq!(r.0, vec!["f64(2.5)".to_string()]);
     }
 
     #[test]

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -335,6 +335,15 @@ mod tests {
         assert_eq!(p.name, "r");
     }
 
+    #[tokio::test]
+    async fn reader_multi_handles_invalid_utf8() {
+        // 0xFF is invalid UTF-8 — exercises the from_utf8 branch
+        // in from_async_reader_multi.
+        let mut r = BufReader::new(&[0xFFu8, 0xFE, 0xFD][..]);
+        let res: Result<Vec<Pkg>> = from_async_reader_multi(&mut r).await;
+        assert!(res.is_err());
+    }
+
     #[test]
     fn find_doc_boundary_handles_short_input() {
         assert!(find_doc_boundary(b"").is_none());

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -6,30 +6,30 @@
 //!
 //! Bridges noyalib's strict-parser entry points
 //! ([`crate::from_str`], [`crate::from_slice`]) onto
-//! [`tokio::io::AsyncRead`] sources without forcing the caller
-//! through [`tokio::task::spawn_blocking`]. Two surface shapes
+//! `tokio::io::AsyncRead` sources without forcing the caller
+//! through `tokio::task::spawn_blocking`. Two surface shapes
 //! are provided so callers can pick the right ergonomics for
 //! their workload:
 //!
-//! * [`from_async_reader`] — drain a single document out of any
-//!   [`tokio::io::AsyncRead`] into the caller's `T`.
-//! * [`from_async_reader_multi`] — drain every `---`-separated
+//! * `from_async_reader` — drain a single document out of any
+//!   `tokio::io::AsyncRead` into the caller's `T`.
+//! * `from_async_reader_multi` — drain every `---`-separated
 //!   document and return `Vec<T>`.
-//! * [`YamlDecoder<T>`] — [`tokio_util::codec::Decoder`]
+//! * `YamlDecoder<T>` — `tokio_util::codec::Decoder`
 //!   implementation for plugging YAML parsing into a
-//!   [`tokio_util::codec::Framed`] pipeline (web-services /
+//!   `tokio_util::codec::Framed` pipeline (web-services /
 //!   tower-middleware integration).
 //!
 //! # Backpressure
 //!
-//! The [`from_async_reader`] entry points buffer the full payload
+//! The `from_async_reader` entry points buffer the full payload
 //! into a `Vec<u8>` before parsing because the underlying parser
 //! is synchronous. The codec surface is the streaming choice:
 //! it emits one document per `decode` call as soon as a complete
 //! `---` boundary is in the buffer.
 //!
 //! Gated behind the `tokio` Cargo feature (which transitively
-//! enables [`tokio-util`] and [`bytes`] for the codec API).
+//! enables `tokio-util` and `bytes` for the codec API).
 //!
 //! # Example
 //!

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -493,13 +493,14 @@ mod tests {
         //      configured limit; the parser then surfaces a
         //      parse error rather than OOM.
         let yaml = "a: ".to_string() + &"x".repeat(10_000);
-        let mut cfg = ParserConfig::default();
-        cfg.max_document_length = 64;
+        let cfg = ParserConfig {
+            max_document_length: 64,
+            ..ParserConfig::default()
+        };
         let mut r = BufReader::new(yaml.as_bytes());
         let _ = from_async_reader_with_config::<_, Pkg>(&mut r, &cfg)
             .await
-            .err()
-            .expect("expected parse error after truncation");
+            .expect_err("expected parse error after truncation");
     }
 
     #[test]

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -55,7 +55,6 @@ use tokio_util::codec::Decoder;
 
 use crate::de::{ParserConfig, from_slice, from_slice_with_config};
 use crate::error::{Error, Result};
-use serde::de::Error as _;
 
 /// Drain the supplied reader to end-of-stream, then parse the
 /// buffered bytes as a single YAML document into `T`.
@@ -65,11 +64,16 @@ use serde::de::Error as _;
 ///
 /// # Errors
 ///
-/// Returns the underlying [`Error`] from either the I/O drain or
-/// the parse step.
+/// Returns the underlying [`Error`] from either the I/O drain
+/// (including reads that exceed [`ParserConfig::max_document_length`])
+/// or the parse step.
 pub async fn from_async_reader<R, T>(reader: &mut R) -> Result<T>
 where
     R: AsyncRead + Unpin,
+    // `'static` is inherited from `from_slice_with_config` and
+    // `from_str_with_config` — async I/O cannot generally hand
+    // out a borrowed `&[u8]` that outlives the await point, so
+    // dropping the bound here would only paper over the issue.
     T: DeserializeOwned + 'static,
 {
     from_async_reader_with_config(reader, &ParserConfig::default()).await
@@ -77,26 +81,38 @@ where
 
 /// [`from_async_reader`] with a caller-supplied [`ParserConfig`].
 ///
+/// The reader is capped at [`ParserConfig::max_document_length`]
+/// bytes via [`tokio::io::AsyncReadExt::take`] so a slow-drip
+/// adversary cannot drive the in-memory buffer beyond the
+/// configured limit (security finding C3).
+///
 /// # Errors
 ///
 /// Returns the underlying [`Error`] from either the I/O drain or
-/// the parse step.
+/// the parse step. An input larger than `max_document_length`
+/// surfaces as [`Error::Io`] with the trailing bytes truncated;
+/// the parser then enforces every other limit on the buffered
+/// prefix.
 pub async fn from_async_reader_with_config<R, T>(reader: &mut R, config: &ParserConfig) -> Result<T>
 where
     R: AsyncRead + Unpin,
+    // `'static` is inherited from `from_slice_with_config` and
+    // `from_str_with_config` — async I/O cannot generally hand
+    // out a borrowed `&[u8]` that outlives the await point, so
+    // dropping the bound here would only paper over the issue.
     T: DeserializeOwned + 'static,
 {
-    let mut buf = Vec::new();
-    let _ = reader.read_to_end(&mut buf).await.map_err(Error::from)?;
+    let buf = drain_bounded(reader, config.max_document_length).await?;
+    let buf = strip_bom_owned(buf);
     from_slice_with_config(&buf, config)
 }
 
 /// Drain the reader and parse every `---`-separated document
-/// into `Vec<T>`.
+/// into `Vec<T>` using the default [`ParserConfig`].
 ///
-/// Falls through to the workspace's standard multi-document
-/// loader so the per-document semantics (limits, duplicate-key
-/// policy, etc.) match [`crate::load_all_as`].
+/// Pair with [`from_async_reader_multi_with_config`] when the
+/// caller needs custom limits (it is the version most production
+/// services should pick).
 ///
 /// # Errors
 ///
@@ -105,12 +121,84 @@ where
 pub async fn from_async_reader_multi<R, T>(reader: &mut R) -> Result<Vec<T>>
 where
     R: AsyncRead + Unpin,
+    // `'static` is inherited from `from_slice_with_config` and
+    // `from_str_with_config` — async I/O cannot generally hand
+    // out a borrowed `&[u8]` that outlives the await point, so
+    // dropping the bound here would only paper over the issue.
     T: DeserializeOwned + 'static,
 {
+    from_async_reader_multi_with_config(reader, &ParserConfig::default()).await
+}
+
+/// [`from_async_reader_multi`] with a caller-supplied
+/// [`ParserConfig`]. The reader is bounded by
+/// [`ParserConfig::max_document_length`] in exactly the same way
+/// as [`from_async_reader_with_config`].
+///
+/// Uses [`crate::from_slice_with_config`] on the buffered bytes
+/// when only one document is present; otherwise routes through
+/// the standard multi-document loader so all per-document
+/// semantics (duplicate-key policy, anchor budgets, …) match
+/// [`crate::load_all_with_config`].
+///
+/// # Errors
+///
+/// Returns the underlying [`Error`] from either the I/O drain
+/// (including bounded-read overflow and UTF-8 invalidity) or the
+/// parse step.
+pub async fn from_async_reader_multi_with_config<R, T>(
+    reader: &mut R,
+    config: &ParserConfig,
+) -> Result<Vec<T>>
+where
+    R: AsyncRead + Unpin,
+    // `'static` is inherited from `from_slice_with_config` and
+    // `from_str_with_config` — async I/O cannot generally hand
+    // out a borrowed `&[u8]` that outlives the await point, so
+    // dropping the bound here would only paper over the issue.
+    T: DeserializeOwned + 'static,
+{
+    let buf = drain_bounded(reader, config.max_document_length).await?;
+    let buf = strip_bom_owned(buf);
+    // Route UTF-8 invalidity through Error::Io (InvalidData)
+    // rather than `Error::custom`, which is serde-flavoured and
+    // would mislead callers matching on error kind (M9).
+    let text = core::str::from_utf8(&buf)
+        .map_err(|e| Error::from(std::io::Error::new(std::io::ErrorKind::InvalidData, e)))?;
+    // Split on `---` with the marker cap honoured (security
+    // finding C2), then deserialise each document under the
+    // caller's config so every per-document limit fires.
+    let docs = crate::doc_boundary::split_documents(text, config.max_documents);
+    let mut results = Vec::with_capacity(docs.len());
+    for doc in docs {
+        results.push(crate::from_str_with_config::<T>(doc, config)?);
+    }
+    Ok(results)
+}
+
+/// Read at most `max_bytes` from `reader` into a fresh `Vec<u8>`.
+/// `max_bytes == 0` is treated as "unbounded" only when the
+/// caller has explicitly set `ParserConfig::max_document_length`
+/// to zero — by default this maps to a 64 MiB cap.
+async fn drain_bounded<R>(reader: &mut R, max_bytes: usize) -> Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
     let mut buf = Vec::new();
-    let _ = reader.read_to_end(&mut buf).await.map_err(Error::from)?;
-    let text = core::str::from_utf8(&buf).map_err(|e| Error::custom(e.to_string()))?;
-    crate::document::load_all_as::<T>(text)
+    let take = u64::try_from(max_bytes).unwrap_or(u64::MAX);
+    let mut limited = reader.take(take);
+    let _ = limited.read_to_end(&mut buf).await.map_err(Error::from)?;
+    Ok(buf)
+}
+
+/// Strip a leading UTF-8 BOM in-place. The owned `Vec` form
+/// keeps the buffer's allocation; we just elide the three BOM
+/// bytes at the front.
+fn strip_bom_owned(mut buf: Vec<u8>) -> Vec<u8> {
+    if crate::doc_boundary::strip_bom(&buf) == 3 {
+        let _ = buf.drain(..3);
+    }
+    buf
 }
 
 /// [`tokio_util::codec::Decoder`] that emits one parsed `T` per
@@ -128,9 +216,16 @@ where
 /// The decoder treats `---` at column 0 followed by whitespace
 /// or end-of-line as the document terminator, matching the YAML
 /// 1.2.2 §9.1.2 directive-end grammar.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct YamlDecoder<T> {
     config: ParserConfig,
+    /// Hard cap on the `BytesMut` buffer size between `decode`
+    /// calls. `None` means "no cap, trust the input source".
+    /// Production services driving `YamlDecoder` over an
+    /// untrusted network should set this to a sane upper bound
+    /// — when exceeded, `decode` returns an `Error::Io` with
+    /// `InvalidData`.
+    max_frame_size: Option<usize>,
     _marker: PhantomData<fn() -> T>,
 }
 
@@ -141,53 +236,87 @@ impl<T> Default for YamlDecoder<T> {
 }
 
 impl<T> YamlDecoder<T> {
-    /// Create a decoder with default [`ParserConfig`] limits.
+    /// Create a decoder with default [`ParserConfig`] limits and
+    /// no frame-size cap.
     #[must_use]
     pub fn new() -> Self {
         Self {
             config: ParserConfig::default(),
+            max_frame_size: None,
             _marker: PhantomData,
         }
     }
 
-    /// Create a decoder with caller-supplied [`ParserConfig`].
+    /// Create a decoder with a caller-supplied [`ParserConfig`].
     #[must_use]
     pub fn with_config(config: ParserConfig) -> Self {
         Self {
             config,
+            max_frame_size: None,
             _marker: PhantomData,
         }
+    }
+
+    /// Set a hard cap on the inter-frame buffer size. When the
+    /// `BytesMut` passed to `decode` exceeds `max`, the next
+    /// `decode` call returns an `Error::Io` with `InvalidData`
+    /// rather than letting the buffer grow without bound.
+    #[must_use]
+    pub fn max_frame_size(mut self, max: usize) -> Self {
+        self.max_frame_size = Some(max);
+        self
     }
 }
 
 impl<T> Decoder for YamlDecoder<T>
 where
+    // `'static` is inherited from `from_slice_with_config` and
+    // `from_str_with_config` — async I/O cannot generally hand
+    // out a borrowed `&[u8]` that outlives the await point, so
+    // dropping the bound here would only paper over the issue.
     T: DeserializeOwned + 'static,
 {
     type Item = T;
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> core::result::Result<Option<T>, Error> {
-        // Find the next document boundary at column 0 (`\n---` +
-        // whitespace / EOL). The first document starts at index 0.
-        let bytes: &[u8] = src.as_ref();
-        let split_at = find_doc_boundary(bytes);
-
-        let Some(end) = split_at else {
-            // No complete document in the buffer yet.
-            return Ok(None);
-        };
-
-        // Split off everything up to (but not including) the next
-        // `---` marker.
-        let doc = src.split_to(end);
-        if doc.iter().all(u8::is_ascii_whitespace) {
-            // Skip an all-whitespace preamble silently — common
-            // when a stream starts with `---`.
-            return self.decode(src);
+        // Frame-size guard (M7) — defended before any scanning
+        // work so adversarial slow-drip producers cannot pin
+        // arbitrary memory by streaming without `---`.
+        if let Some(max) = self.max_frame_size {
+            if src.len() > max {
+                return Err(Error::from(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "noyalib YamlDecoder: buffer {} > max_frame_size {}",
+                        src.len(),
+                        max
+                    ),
+                )));
+            }
         }
-        let parsed = from_slice_with_config::<T>(&doc, &self.config)?;
-        Ok(Some(parsed))
+
+        // C6 — iterate rather than recurse so an all-whitespace
+        //      preamble (or repeated `---` markers preceding the
+        //      first real document) cannot blow the stack.
+        loop {
+            let bytes: &[u8] = src.as_ref();
+            let Some(end) = find_doc_boundary(bytes) else {
+                return Ok(None);
+            };
+
+            // Split off everything up to (but not including) the
+            // next `---` marker; the marker stays in `src` to be
+            // picked up by the following call.
+            let doc = src.split_to(end);
+            if doc.iter().all(u8::is_ascii_whitespace) {
+                // Skip an all-whitespace preamble silently and
+                // retry from the new buffer head; no recursion.
+                continue;
+            }
+            let parsed = from_slice_with_config::<T>(&doc, &self.config)?;
+            return Ok(Some(parsed));
+        }
     }
 
     fn decode_eof(&mut self, src: &mut BytesMut) -> core::result::Result<Option<T>, Error> {
@@ -211,29 +340,17 @@ where
 }
 
 /// Find the byte offset of the next column-0 `---` document
-/// boundary (returns the offset of the newline preceding the
-/// `---`, so callers can split there and still see the marker
-/// in the next frame).
+/// boundary, accepting both `\n` and `\r\n` line terminators
+/// (security/correctness finding C4 — the previous copy missed
+/// CRLF inputs, so Windows-saved files would never frame).
 ///
 /// Returns `None` if no boundary is present in the buffer.
+/// The returned offset is the **first byte of the marker** so
+/// callers may use [`bytes::BytesMut::split_to`] to consume the
+/// preceding document while leaving the marker available for the
+/// next frame.
 fn find_doc_boundary(bytes: &[u8]) -> Option<usize> {
-    if bytes.len() < 4 {
-        return None;
-    }
-    // Search after byte 0 — a leading `---` is the start of the
-    // first document, not a boundary.
-    let mut i = 1;
-    while i + 3 <= bytes.len() {
-        if bytes[i - 1] == b'\n' && &bytes[i..i + 3] == b"---" {
-            let next_ok =
-                i + 3 >= bytes.len() || matches!(bytes[i + 3], b'\n' | b'\r' | b' ' | b'\t');
-            if next_ok {
-                return Some(i);
-            }
-        }
-        i += 1;
-    }
-    None
+    crate::doc_boundary::next_marker_after(bytes, 0)
 }
 
 #[cfg(test)]
@@ -348,6 +465,72 @@ mod tests {
     fn find_doc_boundary_handles_short_input() {
         assert!(find_doc_boundary(b"").is_none());
         assert!(find_doc_boundary(b"abc").is_none());
+    }
+
+    #[tokio::test]
+    async fn reader_strips_leading_bom() {
+        // C5 — BOM-prefixed payload must parse identically to
+        //      the LF-on-Linux equivalent.
+        let mut r = BufReader::new(&b"\xEF\xBB\xBFname: x\nversion: '1'\n"[..]);
+        let p: Pkg = from_async_reader(&mut r).await.unwrap();
+        assert_eq!(p.name, "x");
+    }
+
+    #[tokio::test]
+    async fn reader_multi_accepts_crlf() {
+        // C4 — Windows-saved YAML round-trips the multi path.
+        let yaml = b"---\r\nname: a\r\nversion: '1'\r\n---\r\nname: b\r\nversion: '2'\r\n";
+        let mut r = BufReader::new(&yaml[..]);
+        let docs: Vec<Pkg> = from_async_reader_multi(&mut r).await.unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].name, "a");
+        assert_eq!(docs[1].name, "b");
+    }
+
+    #[tokio::test]
+    async fn reader_caps_at_max_document_length() {
+        // C3 — slow-drip oversize input is truncated at the
+        //      configured limit; the parser then surfaces a
+        //      parse error rather than OOM.
+        let yaml = "a: ".to_string() + &"x".repeat(10_000);
+        let mut cfg = ParserConfig::default();
+        cfg.max_document_length = 64;
+        let mut r = BufReader::new(yaml.as_bytes());
+        let _ = from_async_reader_with_config::<_, Pkg>(&mut r, &cfg)
+            .await
+            .err()
+            .expect("expected parse error after truncation");
+    }
+
+    #[test]
+    fn decoder_rejects_oversize_frame() {
+        // M7 — frame-size cap prevents adversarial buffer growth.
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new().max_frame_size(16);
+        let mut buf = BytesMut::from(&b"name: long-name-no-marker-yet-need-more-bytes"[..]);
+        let err = decoder.decode(&mut buf).err().unwrap();
+        assert!(err.to_string().contains("max_frame_size"));
+    }
+
+    #[test]
+    fn decoder_accepts_crlf_boundary() {
+        // C4 — `\r\n---\r\n` framing must be recognised.
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        let mut buf =
+            BytesMut::from(&b"name: a\r\nversion: '1'\r\n---\r\nname: b\r\nversion: '2'\r\n"[..]);
+        let first = decoder.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(first.name, "a");
+    }
+
+    #[tokio::test]
+    async fn reader_multi_with_config_routes_through() {
+        // M6 — multi-with-config entry point.
+        let yaml = b"---\nname: a\nversion: '1'\n---\nname: b\nversion: '2'\n";
+        let mut r = BufReader::new(&yaml[..]);
+        let cfg = ParserConfig::default();
+        let docs: Vec<Pkg> = from_async_reader_multi_with_config(&mut r, &cfg)
+            .await
+            .unwrap();
+        assert_eq!(docs.len(), 2);
     }
 
     #[test]

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Native async YAML parsing for [`tokio`](https://tokio.rs)
+//! runtimes.
+//!
+//! Bridges noyalib's strict-parser entry points
+//! ([`crate::from_str`], [`crate::from_slice`]) onto
+//! [`tokio::io::AsyncRead`] sources without forcing the caller
+//! through [`tokio::task::spawn_blocking`]. Two surface shapes
+//! are provided so callers can pick the right ergonomics for
+//! their workload:
+//!
+//! * [`from_async_reader`] — drain a single document out of any
+//!   [`tokio::io::AsyncRead`] into the caller's `T`.
+//! * [`from_async_reader_multi`] — drain every `---`-separated
+//!   document and return `Vec<T>`.
+//! * [`YamlDecoder<T>`] — [`tokio_util::codec::Decoder`]
+//!   implementation for plugging YAML parsing into a
+//!   [`tokio_util::codec::Framed`] pipeline (web-services /
+//!   tower-middleware integration).
+//!
+//! # Backpressure
+//!
+//! The [`from_async_reader`] entry points buffer the full payload
+//! into a `Vec<u8>` before parsing because the underlying parser
+//! is synchronous. The codec surface is the streaming choice:
+//! it emits one document per `decode` call as soon as a complete
+//! `---` boundary is in the buffer.
+//!
+//! Gated behind the `tokio` Cargo feature (which transitively
+//! enables [`tokio-util`] and [`bytes`] for the codec API).
+//!
+//! # Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "tokio")] {
+//! # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+//! use tokio::io::BufReader;
+//! let bytes: &[u8] = b"name: noyalib\nversion: 0.0.6\n";
+//! let mut reader = BufReader::new(bytes);
+//! #[derive(serde::Deserialize)]
+//! struct Pkg { name: String, version: String }
+//! let pkg: Pkg = noyalib::tokio_async::from_async_reader(&mut reader).await?;
+//! assert_eq!(pkg.name, "noyalib");
+//! # Ok(()) }
+//! # }
+//! ```
+
+use bytes::BytesMut;
+use core::marker::PhantomData;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_util::codec::Decoder;
+
+use crate::de::{ParserConfig, from_slice, from_slice_with_config};
+use crate::error::{Error, Result};
+use serde::de::Error as _;
+
+/// Drain the supplied reader to end-of-stream, then parse the
+/// buffered bytes as a single YAML document into `T`.
+///
+/// Uses the default [`ParserConfig`]; pair with
+/// [`from_async_reader_with_config`] to pass custom limits.
+///
+/// # Errors
+///
+/// Returns the underlying [`Error`] from either the I/O drain or
+/// the parse step.
+pub async fn from_async_reader<R, T>(reader: &mut R) -> Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned + 'static,
+{
+    from_async_reader_with_config(reader, &ParserConfig::default()).await
+}
+
+/// [`from_async_reader`] with a caller-supplied [`ParserConfig`].
+///
+/// # Errors
+///
+/// Returns the underlying [`Error`] from either the I/O drain or
+/// the parse step.
+pub async fn from_async_reader_with_config<R, T>(
+    reader: &mut R,
+    config: &ParserConfig,
+) -> Result<T>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned + 'static,
+{
+    let mut buf = Vec::new();
+    let _ = reader
+        .read_to_end(&mut buf)
+        .await
+        .map_err(Error::from)?;
+    from_slice_with_config(&buf, config)
+}
+
+/// Drain the reader and parse every `---`-separated document
+/// into `Vec<T>`.
+///
+/// Falls through to the workspace's standard multi-document
+/// loader so the per-document semantics (limits, duplicate-key
+/// policy, etc.) match [`crate::load_all_as`].
+///
+/// # Errors
+///
+/// Returns the underlying [`Error`] from either the I/O drain or
+/// the parse step.
+pub async fn from_async_reader_multi<R, T>(reader: &mut R) -> Result<Vec<T>>
+where
+    R: AsyncRead + Unpin,
+    T: DeserializeOwned + 'static,
+{
+    let mut buf = Vec::new();
+    let _ = reader
+        .read_to_end(&mut buf)
+        .await
+        .map_err(Error::from)?;
+    let text = core::str::from_utf8(&buf).map_err(|e| Error::custom(e.to_string()))?;
+    crate::document::load_all_as::<T>(text)
+}
+
+/// [`tokio_util::codec::Decoder`] that emits one parsed `T` per
+/// `---`-delimited YAML document in the byte stream.
+///
+/// Drop this into a
+/// [`tokio_util::codec::FramedRead`] / [`tokio_util::codec::FramedWrite`]
+/// pipeline to plug streaming YAML parsing into a tower service
+/// chain. Each `decode` call returns:
+///
+/// * `Ok(Some(T))` — a complete document was found and parsed.
+/// * `Ok(None)` — no complete document yet; ask for more bytes.
+/// * `Err(e)` — the next document failed to parse.
+///
+/// The decoder treats `---` at column 0 followed by whitespace
+/// or end-of-line as the document terminator, matching the YAML
+/// 1.2.2 §9.1.2 directive-end grammar.
+#[derive(Debug)]
+pub struct YamlDecoder<T> {
+    config: ParserConfig,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> Default for YamlDecoder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> YamlDecoder<T> {
+    /// Create a decoder with default [`ParserConfig`] limits.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            config: ParserConfig::default(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a decoder with caller-supplied [`ParserConfig`].
+    #[must_use]
+    pub fn with_config(config: ParserConfig) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Decoder for YamlDecoder<T>
+where
+    T: DeserializeOwned + 'static,
+{
+    type Item = T;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> core::result::Result<Option<T>, Error> {
+        // Find the next document boundary at column 0 (`\n---` +
+        // whitespace / EOL). The first document starts at index 0.
+        let bytes: &[u8] = src.as_ref();
+        let split_at = find_doc_boundary(bytes);
+
+        let Some(end) = split_at else {
+            // No complete document in the buffer yet.
+            return Ok(None);
+        };
+
+        // Split off everything up to (but not including) the next
+        // `---` marker.
+        let doc = src.split_to(end);
+        if doc.iter().all(u8::is_ascii_whitespace) {
+            // Skip an all-whitespace preamble silently — common
+            // when a stream starts with `---`.
+            return self.decode(src);
+        }
+        let parsed = from_slice_with_config::<T>(&doc, &self.config)?;
+        Ok(Some(parsed))
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> core::result::Result<Option<T>, Error> {
+        if src.is_empty() {
+            return Ok(None);
+        }
+        // Last document — try a normal decode first (it may have
+        // a trailing `---` from a previous frame), otherwise parse
+        // the remainder.
+        if let Some(v) = self.decode(src)? {
+            return Ok(Some(v));
+        }
+        if src.iter().all(u8::is_ascii_whitespace) {
+            src.clear();
+            return Ok(None);
+        }
+        let doc = src.split();
+        let parsed = from_slice::<T>(&doc)?;
+        Ok(Some(parsed))
+    }
+}
+
+/// Find the byte offset of the next column-0 `---` document
+/// boundary (returns the offset of the newline preceding the
+/// `---`, so callers can split there and still see the marker
+/// in the next frame).
+///
+/// Returns `None` if no boundary is present in the buffer.
+fn find_doc_boundary(bytes: &[u8]) -> Option<usize> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    // Search after byte 0 — a leading `---` is the start of the
+    // first document, not a boundary.
+    let mut i = 1;
+    while i + 3 <= bytes.len() {
+        if bytes[i - 1] == b'\n' && &bytes[i..i + 3] == b"---" {
+            let next_ok =
+                i + 3 >= bytes.len() || matches!(bytes[i + 3], b'\n' | b'\r' | b' ' | b'\t');
+            if next_ok {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+    use serde::Deserialize;
+    use tokio::io::BufReader;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Pkg {
+        name: String,
+        version: String,
+    }
+
+    #[tokio::test]
+    async fn reader_parses_single_document() {
+        let mut r = BufReader::new(&b"name: noyalib\nversion: 0.0.6\n"[..]);
+        let p: Pkg = from_async_reader(&mut r).await.unwrap();
+        assert_eq!(
+            p,
+            Pkg {
+                name: "noyalib".into(),
+                version: "0.0.6".into(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_multi_parses_each_document() {
+        let yaml = b"---\nname: a\nversion: '1'\n---\nname: b\nversion: '2'\n";
+        let mut r = BufReader::new(&yaml[..]);
+        let docs: Vec<Pkg> = from_async_reader_multi(&mut r).await.unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].name, "a");
+        assert_eq!(docs[1].name, "b");
+    }
+
+    #[test]
+    fn decoder_emits_first_complete_document() {
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        let mut buf = BytesMut::from(&b"name: a\nversion: '1'\n---\nname: b\nversion: '2'\n"[..]);
+        let first = decoder.decode(&mut buf).unwrap().unwrap();
+        assert_eq!(first.name, "a");
+        // The second document is still in the buffer, prefixed
+        // with the `---` marker; decode_eof handles it.
+        let second = decoder.decode_eof(&mut buf).unwrap().unwrap();
+        assert_eq!(second.name, "b");
+    }
+
+    #[test]
+    fn decoder_returns_none_on_incomplete_buffer() {
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        // No `---` boundary visible — pending.
+        let mut buf = BytesMut::from(&b"name: a\n"[..]);
+        assert!(decoder.decode(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn find_doc_boundary_skips_leading_marker() {
+        // A leading `---` at byte 0 is not a boundary — it's the
+        // start of the first document.
+        assert!(find_doc_boundary(b"---\na: 1\n").is_none());
+        // The second `---` is the boundary.
+        let bs = b"---\na: 1\n---\nb: 2\n";
+        let at = find_doc_boundary(bs).unwrap();
+        // The boundary points at the `---` after the `\n` (byte 9).
+        assert_eq!(at, 9);
+    }
+}

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -81,19 +81,13 @@ where
 ///
 /// Returns the underlying [`Error`] from either the I/O drain or
 /// the parse step.
-pub async fn from_async_reader_with_config<R, T>(
-    reader: &mut R,
-    config: &ParserConfig,
-) -> Result<T>
+pub async fn from_async_reader_with_config<R, T>(reader: &mut R, config: &ParserConfig) -> Result<T>
 where
     R: AsyncRead + Unpin,
     T: DeserializeOwned + 'static,
 {
     let mut buf = Vec::new();
-    let _ = reader
-        .read_to_end(&mut buf)
-        .await
-        .map_err(Error::from)?;
+    let _ = reader.read_to_end(&mut buf).await.map_err(Error::from)?;
     from_slice_with_config(&buf, config)
 }
 
@@ -114,10 +108,7 @@ where
     T: DeserializeOwned + 'static,
 {
     let mut buf = Vec::new();
-    let _ = reader
-        .read_to_end(&mut buf)
-        .await
-        .map_err(Error::from)?;
+    let _ = reader.read_to_end(&mut buf).await.map_err(Error::from)?;
     let text = core::str::from_utf8(&buf).map_err(|e| Error::custom(e.to_string()))?;
     crate::document::load_all_as::<T>(text)
 }

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -292,6 +292,55 @@ mod tests {
         assert!(decoder.decode(&mut buf).unwrap().is_none());
     }
 
+    #[tokio::test]
+    async fn reader_with_config_respects_overrides() {
+        let mut r = BufReader::new(&b"name: x\nversion: '1'\n"[..]);
+        let cfg = ParserConfig::default();
+        let p: Pkg = from_async_reader_with_config(&mut r, &cfg).await.unwrap();
+        assert_eq!(p.name, "x");
+    }
+
+    #[test]
+    fn decoder_with_config_constructor() {
+        let cfg = ParserConfig::default();
+        let _d: YamlDecoder<Pkg> = YamlDecoder::with_config(cfg);
+        let _d2: YamlDecoder<Pkg> = YamlDecoder::default();
+        let _printed = format!("{:?}", YamlDecoder::<Pkg>::new());
+    }
+
+    #[test]
+    fn decoder_eof_on_empty_buffer_returns_none() {
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        let mut buf = BytesMut::new();
+        assert!(decoder.decode_eof(&mut buf).unwrap().is_none());
+    }
+
+    #[test]
+    fn decoder_skips_whitespace_only_preamble() {
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        // Whitespace-only chunk before a `---` boundary — the
+        // decoder recurses and emits the document after it.
+        let mut buf = BytesMut::from(&b"\n\n---\nname: q\nversion: '2'\n"[..]);
+        let p = decoder.decode_eof(&mut buf).unwrap().unwrap();
+        assert_eq!(p.name, "q");
+    }
+
+    #[test]
+    fn decoder_eof_drains_trailing_whitespace() {
+        let mut decoder: YamlDecoder<Pkg> = YamlDecoder::new();
+        // First emit the only doc; then EOF should clean up
+        // any trailing whitespace without erroring.
+        let mut buf = BytesMut::from(&b"name: r\nversion: '3'\n\n\n"[..]);
+        let p = decoder.decode_eof(&mut buf).unwrap().unwrap();
+        assert_eq!(p.name, "r");
+    }
+
+    #[test]
+    fn find_doc_boundary_handles_short_input() {
+        assert!(find_doc_boundary(b"").is_none());
+        assert!(find_doc_boundary(b"abc").is_none());
+    }
+
     #[test]
     fn find_doc_boundary_skips_leading_marker() {
         // A leading `---` at byte 0 is not a boundary — it's the

--- a/crates/noyalib/tests/ariadne_adapter.rs
+++ b/crates/noyalib/tests/ariadne_adapter.rs
@@ -48,9 +48,6 @@ fn typed_target_error_renders() {
         .write(("config.yaml", Source::from(source)), &mut out)
         .unwrap();
     let s = String::from_utf8_lossy(&out);
-    // The deserialization error has no location (the typed-target
-    // path only carries one for parse-time errors), so the report
-    // is header-only — but the message must still render.
     assert!(
         s.contains("port") || s.contains("Error") || s.contains("error"),
         "{s}"
@@ -59,7 +56,6 @@ fn typed_target_error_renders() {
 
 #[test]
 fn report_without_location_still_renders() {
-    // Construct a custom error with no location attached.
     use noyalib::Error;
     let err = Error::Custom("synthetic".into());
     let report = error_to_ariadne_report(&err, "input.yaml", "source: value\n");
@@ -74,9 +70,7 @@ fn report_without_location_still_renders() {
 #[test]
 fn label_clamps_when_index_past_source_end() {
     use noyalib::Error;
-    // Custom error has no location, so this tests the fallback path.
     let err = Error::Custom("late".into());
-    // Even an empty source must not panic.
     let report = error_to_ariadne_report(&err, "input.yaml", "");
     let mut out = Vec::new();
     report
@@ -90,4 +84,40 @@ fn multibyte_unicode_at_label_does_not_panic() {
     let source = "name: 日本語\nbroken: [unclosed\n";
     let bytes = render(source);
     assert!(!bytes.is_empty());
+}
+
+#[test]
+fn label_span_normal_path_with_mid_source_location() {
+    // Force a parse error whose location lands mid-source so the
+    // normal `label_span` path (start < source.len(), char extract,
+    // char-width range) fires.
+    let source = "key: value\nnext: bad: scalar\nthird: value\n";
+    let err = from_str::<Value>(source).unwrap_err();
+    if let Some(loc) = err.location() {
+        assert!(
+            loc.index() < source.len(),
+            "expected mid-source location, got {}",
+            loc.index()
+        );
+    }
+    let report = error_to_ariadne_report(&err, "config.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("config.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    let rendered = String::from_utf8_lossy(&out);
+    assert!(rendered.contains("config.yaml"), "{rendered}");
+}
+
+#[test]
+fn label_span_handles_utf8_boundary() {
+    // Multi-byte UTF-8 at the label position must not panic.
+    let source = "name: 日本語の設定\nbad: [unclosed\n";
+    let err = from_str::<Value>(source).unwrap_err();
+    let report = error_to_ariadne_report(&err, "input.yaml", source);
+    let mut out = Vec::new();
+    report
+        .write(("input.yaml", Source::from(source)), &mut out)
+        .unwrap();
+    assert!(!out.is_empty());
 }

--- a/crates/noyalib/tests/i18n_formatters.rs
+++ b/crates/noyalib/tests/i18n_formatters.rs
@@ -102,6 +102,71 @@ fn message_formatter_works_through_dyn_dispatch() {
 }
 
 #[test]
+fn user_formatter_for_parse_no_location() {
+    let err = Error::Parse("synthetic parse failure".into());
+    let msg = UserFormatter.format(&err);
+    assert_eq!(msg, "The configuration file has a syntax error.");
+}
+
+#[test]
+fn user_formatter_for_deserialize() {
+    let err = Error::Deserialize("synthetic deser failure".into());
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("does not match"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_deserialize_with_location() {
+    use noyalib::Location;
+    let err = Error::DeserializeWithLocation {
+        message: "synthetic".into(),
+        location: Location::new(3, 5, 12),
+    };
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("line 3"), "{msg}");
+    assert!(msg.contains("does not match"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_io_error() {
+    let err = Error::Io(std::io::Error::other("synthetic io"));
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("Could not read"), "{msg}");
+}
+
+#[test]
+fn user_formatter_for_budget_breach() {
+    use noyalib::BudgetBreach;
+    let err = Error::Budget(BudgetBreach::MaxNodes {
+        limit: 100,
+        observed: 101,
+    });
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("large") || msg.contains("nested"), "{msg}");
+}
+
+#[test]
+fn user_formatter_catchall_for_unhandled_variants() {
+    // Custom is the catch-all path in UserFormatter — not one of
+    // the enumerated user-facing categories.
+    let err = Error::Custom("synthetic".into());
+    let msg = UserFormatter.format(&err);
+    assert_eq!(msg, "The configuration file is invalid.");
+}
+
+#[test]
+fn user_formatter_for_unknown_anchor_at() {
+    use noyalib::Location;
+    let err = Error::UnknownAnchorAt {
+        name: "anc".into(),
+        location: Location::new(2, 3, 5),
+        suggestion: None,
+    };
+    let msg = UserFormatter.format(&err);
+    assert!(msg.contains("does not exist"), "{msg}");
+}
+
+#[test]
 fn custom_formatter_implementation() {
     struct UpperFormatter;
     impl MessageFormatter for UpperFormatter {

--- a/crates/noyalib/tests/include_directive.rs
+++ b/crates/noyalib/tests/include_directive.rs
@@ -253,6 +253,65 @@ mod safe_file {
         assert_eq!(split_fragment(""), ("", None));
         assert_eq!(split_fragment("#anchor"), ("", Some("anchor")));
     }
+
+    #[test]
+    fn resolver_with_nonexistent_root_errors() {
+        let dir = temp_dir("nonexistent");
+        let _ = std::fs::remove_dir_all(&dir);
+        let resolver = SafeFileResolver::new(&dir).into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include a.yaml\n", &cfg);
+        assert!(res.is_err(), "non-existent root must error");
+        let msg = res.unwrap_err().to_string();
+        assert!(
+            msg.contains("canonicalise"),
+            "expected canonicalisation error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_symlink_with_missing_file() {
+        let dir = temp_dir("rej-missing");
+        let resolver = SafeFileResolver::new(&dir)
+            .symlink_policy(SymlinkPolicy::Reject)
+            .into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include nope.yaml\n", &cfg);
+        assert!(res.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn resolver_reads_utf8_content() {
+        let dir = temp_dir("utf8");
+        std::fs::write(dir.join("multi.yaml"), "msg: 日本語の値\n").unwrap();
+        let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&dir).into_resolver());
+        let v: Value = from_str_with_config("inc: !include multi.yaml\n", &cfg).unwrap();
+        assert_eq!(v["inc"]["msg"].as_str(), Some("日本語の値"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_sandbox_is_rejected() {
+        // Symlink pointing outside the sandbox should be caught
+        // by the post-canonicalisation root-prefix check (under
+        // the default FollowWithinRoot policy).
+        let dir = temp_dir("escape");
+        // Stage an outside file.
+        let outside = std::env::temp_dir().join("noyalib-include-escape-outside.yaml");
+        std::fs::write(&outside, "secret: outside\n").unwrap();
+        // Symlink from inside dir → outside file.
+        std::os::unix::fs::symlink(&outside, dir.join("link.yaml")).unwrap();
+        let resolver = SafeFileResolver::new(&dir).into_resolver();
+        let cfg = ParserConfig::new().include_resolver(resolver);
+        let res: Result<Value> = from_str_with_config("x: !include link.yaml\n", &cfg);
+        assert!(res.is_err(), "symlink target outside root must be rejected");
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("escapes"), "{msg}");
+        let _ = std::fs::remove_file(&outside);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }
 
 #[test]

--- a/crates/noyalib/tests/issue_46.rs
+++ b/crates/noyalib/tests/issue_46.rs
@@ -109,6 +109,29 @@ fn pnpm_lockfile_with_empty_flow_mappings_parses() {
     }
 }
 
+/// Companion finding to issue #46: the no-span loader path
+/// (used by `from_str::<Value>`'s value-target fast path)
+/// was missing the depth-limit check that the span-tracked
+/// loader has. Adversarial deeply-nested input would consume
+/// stack without ever firing `RecursionLimitExceeded`.
+#[test]
+fn no_span_loader_honours_max_depth() {
+    // 200 levels of nesting — should fire RecursionLimitExceeded
+    // under the default `max_depth = 128`.
+    let mut yaml = String::new();
+    for i in 0..200 {
+        let _ = writeln!(yaml, "{:indent$}- ", "", indent = i * 2);
+    }
+    let r: Result<noyalib::Value, _> = noyalib::from_str(&yaml);
+    match r {
+        Err(noyalib::Error::RecursionLimitExceeded { depth }) => {
+            assert!(depth > 128, "depth = {depth}");
+        }
+        Err(e) => panic!("expected RecursionLimitExceeded, got: {e}"),
+        Ok(_) => panic!("expected RecursionLimitExceeded, got Ok"),
+    }
+}
+
 /// Pathological key suffixes — pnpm v9 packages with many
 /// peer-dependency parens in the key.
 #[test]

--- a/crates/noyalib/tests/issue_46.rs
+++ b/crates/noyalib/tests/issue_46.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Regression test for issue #46 — pnpm-lock.yaml parsing.
+//!
+//! Reported behaviour: large but shallow `pnpm-lock.yaml` files trip
+//! `RecursionLimitExceeded` with default settings even though the
+//! YAML's real nesting depth is ~5 levels.
+
+use std::fmt::Write;
+
+/// Build a `pnpm-lock.yaml`-shaped document with `n` packages.
+/// True nesting depth tops out at 5 (root → packages → key → field → value).
+fn make_lockfile(n: usize) -> String {
+    let mut yaml = String::new();
+    let _ = writeln!(yaml, "lockfileVersion: '9.0'");
+    let _ = writeln!(yaml, "settings:");
+    let _ = writeln!(yaml, "  autoInstallPeers: true");
+    let _ = writeln!(yaml, "  excludeLinksFromLockfile: false");
+    let _ = writeln!(yaml, "importers:");
+    let _ = writeln!(yaml, "  .:");
+    let _ = writeln!(yaml, "    dependencies:");
+    for i in 0..50.min(n) {
+        let _ = writeln!(yaml, "      pkg-{i}:");
+        let _ = writeln!(yaml, "        specifier: ^1.0.0");
+        let _ = writeln!(yaml, "        version: 1.0.{i}");
+    }
+    let _ = writeln!(yaml, "packages:");
+    for i in 0..n {
+        let _ = writeln!(yaml, "  pkg-{i}@1.0.{i}:");
+        let _ = writeln!(
+            yaml,
+            "    resolution: {{integrity: sha512-aaaa{i}, tarball: https://example.invalid/x}}"
+        );
+        let _ = writeln!(yaml, "    engines: {{node: '>=14'}}");
+        let _ = writeln!(yaml, "    dependencies:");
+        let _ = writeln!(yaml, "      pkg-{}: 1.0.{}", (i + 1) % n, (i + 1) % n);
+    }
+    let _ = writeln!(yaml, "snapshots:");
+    for i in 0..n {
+        let _ = writeln!(yaml, "  pkg-{i}@1.0.{i}:");
+        let _ = writeln!(yaml, "    dependencies:");
+        let _ = writeln!(yaml, "      pkg-{}: 1.0.{}", (i + 1) % n, (i + 1) % n);
+    }
+    yaml
+}
+
+#[test]
+fn pnpm_lockfile_500_pkgs_parses_with_default_config() {
+    let yaml = make_lockfile(500);
+    let v: noyalib::Value = noyalib::from_str(&yaml).expect("default config should parse");
+    match v {
+        noyalib::Value::Mapping(m) => assert!(m.contains_key("packages")),
+        _ => panic!("expected top-level mapping"),
+    }
+}
+
+#[test]
+fn pnpm_lockfile_2000_pkgs_parses_with_default_config() {
+    // ~10k+ lines — matches the issue reporter's scale.
+    let yaml = make_lockfile(2000);
+    let v: noyalib::Value = noyalib::from_str(&yaml).expect("default config should parse");
+    match v {
+        noyalib::Value::Mapping(m) => assert!(m.contains_key("packages")),
+        _ => panic!("expected top-level mapping"),
+    }
+}
+
+#[test]
+fn pnpm_lockfile_5000_pkgs_parses_with_default_config() {
+    // Stress: very wide but still shallow.
+    let yaml = make_lockfile(5000);
+    let v: noyalib::Value = noyalib::from_str(&yaml).expect("default config should parse");
+    match v {
+        noyalib::Value::Mapping(m) => assert!(m.contains_key("packages")),
+        _ => panic!("expected top-level mapping"),
+    }
+}
+
+/// Regression: every count up to the default `max_depth` cliff
+/// (128) used to fail with `RecursionLimitExceeded` because each
+/// empty flow mapping `{}` leaked one depth count into the
+/// parent scope. Now they all parse cleanly.
+#[test]
+fn empty_flow_mappings_under_max_depth_cliff_all_parse() {
+    for n in [100usize, 128, 129, 130, 200, 500, 1000] {
+        let mut yaml = String::from("packages:\n");
+        for i in 0..n {
+            let _ = writeln!(yaml, "  pkg-{i}: {{}}");
+        }
+        let r: Result<noyalib::Value, _> = noyalib::from_str(&yaml);
+        assert!(r.is_ok(), "n={n}: {:?}", r.err());
+    }
+}
+
+/// 10k+ lines with empty flow mappings (`{}`) — matches the
+/// shape of real pnpm v9 entries that have no transitive deps.
+/// Multiple flow `{}` per entry in a single block scope.
+#[test]
+fn pnpm_lockfile_with_empty_flow_mappings_parses() {
+    let mut yaml = String::from("packages:\n");
+    for i in 0..3000 {
+        let _ = writeln!(yaml, "  pkg-{i}@1.0.{i}: {{}}");
+    }
+    let v: noyalib::Value = noyalib::from_str(&yaml).expect("default config should parse");
+    match v {
+        noyalib::Value::Mapping(m) => assert_eq!(m.len(), 1),
+        _ => panic!("expected top-level mapping"),
+    }
+}
+
+/// Pathological key suffixes — pnpm v9 packages with many
+/// peer-dependency parens in the key.
+#[test]
+fn pnpm_lockfile_with_deep_peer_suffixes() {
+    let mut yaml = String::from("packages:\n");
+    for i in 0..1000 {
+        // 6 nested peer suffixes — matches some pnpm pkgs.
+        let _ = writeln!(
+            yaml,
+            "  '@scope/pkg-{i}@1.0.0(p1@18.0.0)(p2@5.0.0)(p3@2.0.0)(p4@4.0.0)(p5@6.0.0)(p6@1.0.0)':"
+        );
+        let _ = writeln!(yaml, "    resolution: {{integrity: sha512-x}}");
+    }
+    let _v: noyalib::Value =
+        noyalib::from_str(&yaml).expect("deep peer suffixes should parse cleanly");
+}
+
+/// Real-world scale: 50k packages — bigger than any actual
+/// pnpm-lock — verifies the parser stays linear in input size.
+#[test]
+fn pnpm_lockfile_50000_pkgs_does_not_recursion_limit() {
+    let yaml = make_lockfile(50_000);
+    let v: noyalib::Value = noyalib::from_str(&yaml).expect("50k packages should parse cleanly");
+    match v {
+        noyalib::Value::Mapping(m) => assert!(m.contains_key("packages")),
+        _ => panic!("expected top-level mapping"),
+    }
+}
+
+/// Typed-struct target — mirrors the most common shape users
+/// migrate to when leaving `serde_yml`.
+#[test]
+fn pnpm_lockfile_typed_struct_parses_with_default_config() {
+    use serde::Deserialize;
+    use std::collections::BTreeMap;
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct Lockfile {
+        #[serde(rename = "lockfileVersion")]
+        lockfile_version: String,
+        settings: BTreeMap<String, serde_yaml_value::Value>,
+        importers: BTreeMap<String, serde_yaml_value::Value>,
+        packages: BTreeMap<String, serde_yaml_value::Value>,
+        snapshots: BTreeMap<String, serde_yaml_value::Value>,
+    }
+
+    // Local re-export so we don't depend on serde-yaml directly.
+    mod serde_yaml_value {
+        pub(crate) type Value = serde_json::Value;
+    }
+
+    let yaml = make_lockfile(2000);
+    let _lock: Lockfile = noyalib::from_str(&yaml).expect("default config should parse");
+}
+
+/// pnpm-lock keys contain `(peer)(meta)`-style parenthesised
+/// suffixes. Some users hit issues with these in flow mappings.
+#[test]
+fn pnpm_lockfile_with_complex_keys() {
+    let mut yaml = String::from("packages:\n");
+    for i in 0..500 {
+        let _ = writeln!(
+            yaml,
+            "  '@scope/pkg-{i}@1.0.{i}(peer-a@18.0.0)(peer-b@5.0.0)':"
+        );
+        let _ = writeln!(yaml, "    resolution: {{integrity: sha512-x}}");
+        let _ = writeln!(yaml, "    peerDependencies:");
+        let _ = writeln!(yaml, "      peer-a: '>=16'");
+        let _ = writeln!(yaml, "      peer-b: '>=4'");
+        let _ = writeln!(yaml, "    peerDependenciesMeta:");
+        let _ = writeln!(yaml, "      peer-b:");
+        let _ = writeln!(yaml, "        optional: true");
+    }
+    let _v: noyalib::Value =
+        noyalib::from_str(&yaml).expect("complex pnpm keys should parse cleanly");
+}

--- a/crates/noyalib/tests/recovery.rs
+++ b/crates/noyalib/tests/recovery.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Integration tests for the `recovery` feature.
+
+#![cfg(feature = "recovery")]
+
+use noyalib::Value;
+use noyalib::recovery::{LenientConfig, parse_lenient, parse_lenient_with};
+
+#[test]
+fn clean_input_returns_complete_result() {
+    let r = parse_lenient("name: noyalib\nversion: 0.0.6\n");
+    assert!(r.is_complete);
+    assert!(r.errors.is_empty());
+    let m = r.value.as_mapping().unwrap();
+    assert_eq!(m.get("name").unwrap().as_str(), Some("noyalib"));
+}
+
+#[test]
+fn malformed_flow_collects_error() {
+    let r = parse_lenient("a: [unclosed\n");
+    assert!(!r.is_complete);
+    assert!(!r.errors.is_empty());
+}
+
+#[test]
+fn trailing_garbage_recovers_clean_prefix() {
+    let yaml = "a: 1\nb: 2\nc: [unclosed\n";
+    let r = parse_lenient(yaml);
+    assert!(!r.is_complete);
+    if let Value::Mapping(m) = &r.value {
+        assert_eq!(m.get("a").unwrap().as_i64(), Some(1));
+    } else {
+        panic!("expected mapping, got {:?}", r.value);
+    }
+}
+
+#[test]
+fn multi_document_partial_recovery() {
+    let yaml = "---\nid: 1\n---\nid: 2\n---\nid: [unclosed\n";
+    let r = parse_lenient(yaml);
+    assert!(!r.is_complete);
+    let seq = match r.value {
+        Value::Sequence(s) => s,
+        other => panic!("expected sequence, got {other:?}"),
+    };
+    assert_eq!(seq.len(), 3);
+    assert!(matches!(&seq[0], Value::Mapping(_)));
+    assert!(matches!(&seq[1], Value::Mapping(_)));
+}
+
+#[test]
+fn error_cap_limits_diagnostics() {
+    let cfg = LenientConfig {
+        max_errors: 2,
+        ..LenientConfig::default()
+    };
+    let yaml = "---\na: [x\n---\nb: [x\n---\nc: [x\n---\nd: [x\n";
+    let r = parse_lenient_with(yaml, &cfg);
+    assert!(r.errors.len() <= 2);
+}
+
+#[test]
+fn empty_input_is_null_and_complete() {
+    let r = parse_lenient("");
+    assert!(r.is_complete);
+    assert!(matches!(r.value, Value::Null));
+}

--- a/crates/noyalib/tests/streaming_failsafe_tags.rs
+++ b/crates/noyalib/tests/streaming_failsafe_tags.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Streaming-path coverage for the YAML 1.2 failsafe-schema
+//! `!!`-prefixed tags (`!!int`, `!!float`, `!!str`, `!!bool`,
+//! `!!null`, `!!seq`, `!!map`). The streaming deserialiser
+//! short-circuits these to the appropriate visitor without
+//! enum-dispatch.
+
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::from_str;
+use serde::Deserialize;
+
+#[test]
+fn int_tag_resolves_to_integer() {
+    let n: i64 = from_str("!!int 42").unwrap();
+    assert_eq!(n, 42);
+}
+
+#[test]
+fn float_tag_resolves_to_float() {
+    let f: f64 = from_str("!!float 3.14").unwrap();
+    assert!((f - 3.14).abs() < 1e-9);
+}
+
+#[test]
+fn str_tag_keeps_numeric_as_string() {
+    let s: String = from_str("!!str 8080").unwrap();
+    assert_eq!(s, "8080");
+}
+
+#[test]
+fn bool_tag_resolves_to_bool() {
+    let b: bool = from_str("!!bool true").unwrap();
+    assert!(b);
+}
+
+#[test]
+fn null_tag_resolves_to_unit() {
+    #[derive(Debug, Deserialize)]
+    struct N {
+        x: Option<i64>,
+    }
+    let n: N = from_str("x: !!null ~").unwrap();
+    assert!(n.x.is_none());
+}
+
+#[test]
+fn seq_tag_resolves_to_sequence() {
+    let v: Vec<i64> = from_str("!!seq [1, 2, 3]").unwrap();
+    assert_eq!(v, vec![1, 2, 3]);
+}
+
+#[test]
+fn map_tag_resolves_to_mapping() {
+    #[derive(Debug, Deserialize)]
+    struct Doc {
+        a: i64,
+        b: i64,
+    }
+    let d: Doc = from_str("!!map {a: 1, b: 2}").unwrap();
+    assert_eq!(d.a, 1);
+    assert_eq!(d.b, 2);
+}

--- a/crates/noyalib/tests/streaming_failsafe_tags.rs
+++ b/crates/noyalib/tests/streaming_failsafe_tags.rs
@@ -21,8 +21,8 @@ fn int_tag_resolves_to_integer() {
 
 #[test]
 fn float_tag_resolves_to_float() {
-    let f: f64 = from_str("!!float 3.14").unwrap();
-    assert!((f - 3.14).abs() < 1e-9);
+    let f: f64 = from_str("!!float 2.5").unwrap();
+    assert!((f - 2.5).abs() < 1e-9);
 }
 
 #[test]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.5", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.6", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 clap_mangen   = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -7,20 +7,13 @@ yanked = "warn"
 # Bench-only competitor surface — these crates are never compiled
 # into a release artefact. They appear in `crates/noyalib/Cargo.toml`
 # under `[dev-dependencies]` purely so the comparison harness in
-# `crates/noyalib/benches/comparison.rs` can produce honest
-# head-to-head numbers vs every popular Rust YAML library, including
-# the ones flagged unsound or unmaintained by RustSec. The point of
-# the comparison is showing noyalib's safety+speed posture against
-# the alternatives — silencing the advisories on dev-deps lets the
-# audit pipeline reflect that intent without weakening the
-# advisory enforcement on production deps.
-ignore = [
-    # serde_yml: RUSTSEC-2025-0068 (unsound + unmaintained, see also
-    # advisory-db#2395). Bench-only via dev-dep; the maintainer's
-    # prior crate, kept so `cargo bench --bench comparison` covers
-    # the full ecosystem.
-    "RUSTSEC-2025-0068",
-]
+# `crates/noyalib/benches/comparison.rs` produces honest head-to-
+# head numbers vs every still-maintained Rust YAML library. The
+# unmaintained / unsound contenders (`serde_yml`, `libyml`) used
+# to be benched too — they were retired in v0.0.6 so `cargo
+# audit` and the OpenSSF Scorecard Vulnerabilities check stay
+# clean without needing per-advisory exemptions.
+ignore = []
 
 [licenses]
 allow = [

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -294,6 +294,25 @@ is the YAML 1.2 schema-resolution table:
 prefix; off by default because the modern `0o` form is
 unambiguous.
 
+## Optional surfaces (v0.0.6)
+
+Three v0.0.6 modules sit alongside the core pipeline; each is
+gated behind its own Cargo feature so the default build pays
+zero compile / binary-size cost for them.
+
+| Module | Feature | Pipeline shape | Source |
+|---|---|---|---|
+| `recovery` | `recovery` | Wraps `from_str_with_config` in a three-pass retry loop (strict → `DuplicateKeyPolicy::Last` → line-truncation). Multi-document input split via the same `---` scanner the `parallel` module uses. Returns `ParseResult { value, errors, is_complete }`. Zero extra deps. | `crates/noyalib/src/recovery.rs` |
+| `sval_adapter` | `sval` | `impl sval::Value for Value` (and `Number` / `Mapping` / `MappingAny` / `TaggedValue`) — streams a noyalib value graph through any `sval::Stream` consumer. Bypasses the serde monomorphisation chain entirely. | `crates/noyalib/src/sval_adapter.rs` |
+| `tokio_async` | `tokio` | `from_async_reader` drains a `tokio::io::AsyncRead` to a `Vec<u8>` then runs the standard sync parser. `YamlDecoder` is a `tokio_util::codec::Decoder` that emits one document per `decode` call as soon as a column-0 `---` boundary lands in the buffer. | `crates/noyalib/src/tokio_async.rs` |
+
+All three are pure-safe Rust (preserving the workspace
+`unsafe_code = "forbid"` invariant) and exercised by unit
+tests inline, integration tests under
+[`crates/noyalib/tests/`](../crates/noyalib/tests/), and bench
+arms in
+[`crates/noyalib/benches/v006_features.rs`](../crates/noyalib/benches/v006_features.rs).
+
 ## Tests
 
 | Suite | Where | What |

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -219,6 +219,21 @@ single-threaded.
 Reproduce: `cargo bench --bench comparison` and
 `cargo bench --bench architecture`.
 
+## v0.0.6 feature benchmarks
+
+Three additional bench arms cover the optional surfaces added
+in v0.0.6 (`recovery`, `sval`, `tokio`). Run together with:
+
+```bash
+cargo bench --bench v006_features --features recovery,sval,tokio
+```
+
+| Group | Compares | Interpretation |
+| :--- | :--- | :--- |
+| `recovery_strict_vs_lenient` | `from_str` vs `recovery::parse_lenient` on valid input | The lenient wrapper should not regress strict throughput by more than rounding noise (recovery retries only execute on `Err`). |
+| `sval_vs_serde_value` | `from_str` → `Value` (serde) vs streaming a pre-built `Value` through a no-op `sval::Stream` | Isolates the per-event cost of the sval surface — useful when deciding whether the serde-free route is worth the extra dep. |
+| `tokio_async_drain` | `from_slice` (sync) vs `tokio_async::from_async_reader` against an in-memory `BufReader` | Quantifies the async fixed-overhead cost when I/O latency is zero; real network latency dwarfs this. |
+
 ## Project metrics
 
 | Metric | Value |

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -245,4 +245,4 @@ cargo bench --bench v006_features --features recovery,sval,tokio
 | **Coverage** | 95%+ function coverage / 92%+ region coverage / 93%+ line coverage (CI-gated) |
 | **Dependencies** | 5 unconditional + 3 default-on optional (`itoa`, `ryu`, `serde_ignored`) + 12 opt-in optional (`miette`, `garde`, `validator`, `schemars`, `serde_json`, `jsonschema`, `figment`, `rayon`, `serde-saphyr`, plus the three default-on opt-outs) |
 | **WASM binary** | 338 KB (release, LTO) |
-| **MSRV** | Rust 1.75.0 (core); newer for optional features (see [POLICIES.md](POLICIES.md#1-msrv-minimum-supported-rust-version)) |
+| **MSRV** | Rust 1.85.0 (core, since v0.0.5 — edition 2024); newer for optional features (see [POLICIES.md](POLICIES.md#1-msrv-minimum-supported-rust-version)) |

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -243,6 +243,26 @@ Weekly (or on-demand) jobs:
 - Verification recipe in
   [`pkg/VERIFY.md`](../pkg/VERIFY.md).
 
+### OpenSSF Scorecard posture
+
+The scorecard report lives at
+[`scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib`](https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/noyalib).
+v0.0.6 lifts the score from `6.5/10` to `~9/10` by closing
+every check that is fixable in source — the four remaining
+items below require external action and are tracked here so
+contributors can see the residual gap:
+
+| Check | Status | Action |
+|---|---|---|
+| Token-Permissions | ✓ fixed | Top-level workflow tokens demoted to `contents: read`; writes scoped per-job. |
+| Pinned-Dependencies | ✓ fixed | Every GitHub Action `uses:` is pinned by full commit SHA, with the human-readable tag in a trailing comment. |
+| Dependency-Update-Tool | ✓ fixed | [`.github/dependabot.yml`](../.github/dependabot.yml) covers `cargo`, `github-actions`, and `npm` ecosystems on a weekly schedule. |
+| Vulnerabilities | ✓ fixed | `serde_yml` / `libyml` dropped from the bench dev-deps in v0.0.6 (RUSTSEC-2025-0067 + -0068); `Cargo.lock` is now clean. |
+| **CII-Best-Practices** | external | Apply for the OpenSSF Best Practices Badge at <https://www.bestpractices.dev/>. The self-assessment maps directly onto noyalib's existing CI / policies posture; tracked for v0.1 milestone. |
+| **Code-Review** | external | Single-maintainer project. The natural fix is a second committer + branch-protection rule requiring review; until then the score will stay 0 by design. |
+| **Branch-Protection** | external | Repo-admin UI configuration required: enable "require approvals", "require codeowners review", "last push approval". |
+| **Contributors** | external | Improves organically as the project gains maintainers / contributing organisations. |
+
 ### Disclosure
 
 Report security issues to **sebastian.rousseau@gmail.com**.

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -179,6 +179,40 @@ the shared parser limits:
   instead, required for downstreams like `sval_json` that
   reject NaN / ±∞.
 
+#### `max_depth` guard correctness (fixed in v0.0.6 / issue #46)
+
+The `max_depth` limit above relies on **balanced** increment /
+decrement of `self.depth` along every code path. Two
+correctness bugs that made the guard either over- or
+under-count were patched in v0.0.6:
+
+- *Over-count, false-positive.* `StreamingMapAccess`'s
+  iterators did not check the access object's `finished` flag.
+  Serde visitors that called `next_entry` after `Ok(None)` —
+  `ValueVisitor::visit_map` does this — re-entered the
+  iterator, read the next event from the **parent** mapping,
+  and treated it as the inner exhausted child's. The
+  recursive `deserialize_any` on each spilled value inflated
+  `self.depth` by one per empty flow `{}`, so a
+  `pnpm-lock.yaml`-shaped input with N consecutive `{}` hit
+  the limit at exactly N = `max_depth`. Fixed: explicit
+  `if self.finished { return Ok(None) }` guards on the three
+  iterators; balanced decrement on `Ok` *and* `Err` in
+  `deserialize_any` / `_seq` / `_map`.
+- *Under-count, silent bypass.* The `NoSpanLoader` path
+  (value-target fast path, `no_std` multi-document loading)
+  incremented `self.depth` on `SequenceStart` / `MappingStart`
+  but **did not compare** against `max_depth`. Adversarial
+  deeply-nested input through that path could consume stack
+  without ever firing the documented guard. Fixed: mirror
+  the span loader's check.
+
+Regression suite: `crates/noyalib/tests/issue_46.rs` — 10
+tests including a 50 000-package full `pnpm-lock-v9` shape,
+3 000 consecutive empty flow mappings, deterministic
+depth-cliff probe at `n ∈ [100, 128, 129, 130, 200, 500,
+1000]`, and a 200-level-deep sequence for the no-span path.
+
 ### Audit pipeline
 
 Each PR runs:

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -150,6 +150,35 @@ override via `ParserConfig`.
 The corresponding regression tests live in
 [`tests/stress_load.rs`](../crates/noyalib/tests/stress_load.rs).
 
+#### v0.0.6 opt-in surface limits
+
+The `recovery`, `tokio`, and `sval` modules (each behind its own
+Cargo feature) add their own DoS-resistance posture on top of
+the shared parser limits:
+
+- **`recovery::parse_lenient`** caps the `---`-marker scan at
+  `ParserConfig::max_documents` to defeat marker-spam inputs,
+  and caps the cumulative line-truncation-retry cost at
+  `LenientConfig::truncation_event_budget` (default 1 MiB) to
+  defeat O(n²) re-parse on 10k-line adversarial documents.
+- **`tokio_async::from_async_reader{,_multi}{,_with_config}`**
+  drain the reader through `AsyncReadExt::take(max_document_length)`
+  so a slow-drip producer cannot grow the in-memory buffer
+  beyond the configured limit before the parser fires its own
+  size check. A leading UTF-8 BOM is stripped so Windows-saved
+  buffers round-trip identically to LF-on-Linux equivalents.
+- **`tokio_async::YamlDecoder`** exposes
+  `max_frame_size(usize)`: when the inter-frame `BytesMut`
+  buffer exceeds the cap, the next `decode` call returns
+  `Error::Io(InvalidData)` rather than letting an adversarial
+  producer pin memory by streaming without `---`. The cap is
+  off by default — set it on untrusted-network inputs.
+- **`sval_adapter`** forwards non-finite floats verbatim by
+  default; use `to_sval_writer_with_config` with
+  `SvalConfig::coerce_non_finite_to_null` to emit `Null`
+  instead, required for downstreams like `sval_json` that
+  reject NaN / ±∞.
+
 ### Audit pipeline
 
 Each PR runs:

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -473,6 +473,72 @@ let docs: Vec<MyConfig> = noyalib::parallel::parse(stream)?;
 The pre-scan is `O(input_len)`; the per-document work
 parallelises across the Rayon thread pool.
 
+## 10b. Error-recovering parser for LSP / IDE (`recovery` feature)
+
+The default `from_str` family returns `Err` at the first syntax
+violation. LSP / IDE consumers need the opposite contract: keep
+going past errors, build a best-effort partial tree, collect
+every error encountered so the editor can show a complete
+diagnostics list and offer autocomplete on the recoverable
+subtrees.
+
+```rust
+// Cargo.toml: noyalib = { version = "0.0.6", features = ["recovery"] }
+use noyalib::recovery::parse_lenient;
+
+let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
+let r = parse_lenient(half_typed);
+assert!(!r.is_complete);
+println!("errors: {}", r.errors.len());
+// r.value is the best-effort recovered tree.
+```
+
+Three-pass recovery: strict pass → `DuplicateKeyPolicy::Last`
+retry → line-truncation retry. Multi-document input split on
+`---`; each document recovered independently. Error collection
+bounded by `LenientConfig::max_errors`.
+
+See [`crates/noyalib/examples/recovery_lenient.rs`](../crates/noyalib/examples/recovery_lenient.rs).
+
+## 10c. Native async parsing on tokio (`tokio` feature)
+
+For high-concurrency services parsing YAML from network sources,
+the `tokio` feature lets you skip `spawn_blocking`:
+
+```rust
+// Cargo.toml: noyalib = { version = "0.0.6", features = ["tokio"] }
+use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
+
+// Pattern 1: drain-and-parse
+let docs: Vec<MyDoc> = from_async_reader_multi(&mut reader).await?;
+
+// Pattern 2: streaming codec — for tower middleware pipelines
+let framed = tokio_util::codec::FramedRead::new(reader, YamlDecoder::<MyDoc>::new());
+```
+
+Per-document boundaries follow the YAML 1.2.2 §9.1.2 `---`
+grammar — column-0 marker followed by whitespace or EOL.
+
+See [`crates/noyalib/examples/tokio_async_reader.rs`](../crates/noyalib/examples/tokio_async_reader.rs).
+
+## 10d. `sval` streaming adapter (`sval` feature)
+
+Alternative to the default serde route for callers wanting to
+skip `serde_derive`'s compile-time overhead or the binary-size
+cost of serde monomorphisation. The adapter implements
+`sval::Value` for the noyalib value graph so any
+`sval::Stream` consumer can read it:
+
+```rust
+// Cargo.toml: noyalib = { version = "0.0.6", features = ["sval"] }
+let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
+sval::Value::stream(&value, &mut my_stream)?;
+```
+
+serde remains the default route; sval is opt-in.
+
+See [`crates/noyalib/examples/sval_streaming.rs`](../crates/noyalib/examples/sval_streaming.rs).
+
 ## 11. The CLI tools (`noyafmt`, `noyavalidate`)
 
 Two command-line companions ship under `crates/noya-cli/`:

--- a/pkg/PUBLISH.md
+++ b/pkg/PUBLISH.md
@@ -292,7 +292,10 @@ reports.
 
 Both publish with `npm publish --provenance` so each release
 carries an npm-native SLSA attestation linked to the GitHub
-Actions run that produced it.
+Actions run that produced it. Authentication uses npm Trusted
+Publishing (OIDC) — no long-lived `NPM_TOKEN` is required;
+GitHub Actions mints a per-run identity token that npm validates
+against the package's trusted-publisher policy.
 
 **Status: ⏳ Bootstrap pending.**
 
@@ -301,11 +304,32 @@ Actions run that produced it.
 1. Sign in to npm with the maintainer GitHub identity.
 2. Create the org / scope `@noyalib` (free for an open-source
    project).
-3. Generate a granular access token at
+3. **First publish only:** the chicken-and-egg around Trusted
+   Publishing means the package must exist on npm before a
+   trusted publisher can be configured. Generate a *short-lived*
+   granular access token at
    <https://www.npmjs.com/settings/<user>/tokens> with
    `Read and Publish` scope and the package allowlist `@noyalib/*`
-   plus `noyalib-mcp`.
-4. `gh secret set NPM_TOKEN --repo sebastienrousseau/noyalib`
+   plus `noyalib-mcp`. Use it for the very first publish only,
+   then **revoke immediately**.
+4. **After the first publish — configure Trusted Publishing:**
+   - <https://www.npmjs.com/package/@noyalib/noyalib-wasm/access>
+     → *Trusted Publishers → Add*:
+       - Repository: `sebastienrousseau/noyalib`
+       - Workflow filename: `release-binaries.yml`
+       - Environment: *(leave blank)*
+   - Repeat the same for
+     <https://www.npmjs.com/package/noyalib-mcp/access>.
+5. **Retire the bootstrap secret** once Trusted Publishing is
+   wired:
+
+   ```bash
+   gh secret delete NPM_TOKEN --repo sebastienrousseau/noyalib
+   ```
+
+   The `release-binaries.yml` workflow no longer reads
+   `NPM_TOKEN`; both publish jobs declare `id-token: write` and
+   rely on the OIDC handshake exclusively.
 
 ### First publish
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,16 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 suggest = false
 
+[[exemptions.bytes]]
+version = "1.11.1"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.futures-sink]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.granit-parser]]
 version = "0.0.2"
 criteria = "safe-to-deploy"
@@ -60,3 +70,23 @@ suggest = false
 [[exemptions.serde-saphyr]]
 version = "0.0.26"
 criteria = "safe-to-deploy"
+
+[[exemptions.sval]]
+version = "2.20.0"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.tokio]]
+version = "1.52.3"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.tokio-macros]]
+version = "2.7.0"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.tokio-util]]
+version = "0.7.18"
+criteria = "safe-to-deploy"
+suggest = false


### PR DESCRIPTION
## Summary

The **v0.0.6 Ecosystem Integration + Security/Hardening** cut. Closes every open issue on the v0.0.6 milestone, the four-agent audit findings, **issue #46** (user-reported `pnpm-lock.yaml` recursion-limit bug), and a companion audit finding in the no-span loader.

Closes #18, #19, #22, #24, #25, #33, #46.

## Validation

All gates green on tip `ad28829` ([CI run 26686111016](https://github.com/sebastienrousseau/noyalib/actions/runs/26686111016)):

```
✓ cargo-deny                     ✓ Rust CI / Audit
✓ cargo-vet                      ✓ Rust CI / Check & Test
✓ cargo-machete                  ✓ Coverage gate (≥95%)
✓ Differential fuzz (10s smoke)  ✓ REUSE.software compliance
✓ MSRV (1.85.0) core build       ✓ no_std (alloc-only) build
✓ Per-crate MSRV                 ✓ vendor + offline build
✓ Test matrix — ubuntu/macos/windows × stable/nightly
```

Local sweep on `ad28829`:

- `cargo test --workspace --all-features` — **5 405 tests pass, 0 failures**.
- `cargo clippy --workspace --all-features --no-deps -- -D warnings` — clean.
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps` — clean.
- `cargo fmt --all --check` — clean.
- `cargo build --no-default-features --features std` — clean (no_std-shaped path).
- `cargo bench --bench v006_features --features recovery,sval,tokio` — no regression.

## Issues closed

| # | Title | How |
| - | - | - |
| #18 | Error message localization hooks | `MessageFormatter` trait + `DefaultFormatter` / `UserFormatter` in `noyalib::i18n`. |
| #19 | API stabilization audit | Folded across v0.0.5 + v0.0.6 release notes — `#[non_exhaustive]`, doc coverage, comprehensive `Error`, CHANGELOG, benchmark suite. |
| #22 | Error recovery for LSP/IDE | New `recovery` Cargo feature — `parse_lenient` with 3-pass strategy + bounded retries (`truncation_event_budget`). |
| #24 | Native async stream parsing (tokio) | New `tokio` Cargo feature — `from_async_reader{,_with_config,_multi,_multi_with_config}` + `YamlDecoder` codec with frame-size cap. |
| #25 | sval integration | New `sval` Cargo feature — `impl sval::Value` for `Value` / `Number` / `Mapping` / `MappingAny` / `Tag` / `TaggedValue`, plus `to_sval_writer{,_with_config}` and NaN coercion. |
| #33 | npm Trusted Publishing (OIDC) | `release-binaries.yml` drops `NPM_TOKEN`; per-job `id-token: write` + OIDC. `pkg/PUBLISH.md` §6 documents bootstrap + retirement. |
| #46 | pnpm-lock RecursionLimitExceeded | `StreamingMapAccess::next_key_seed` now checks `finished` before reading the next event; companion `next_value_seed` / `next_element_seed` mirror the guard; `deserialize_any/_seq/_map` decrement `depth` on both `Ok` and `Err` so a failed inner visit can't leak depth either. Companion audit fix: `NoSpanLoader` now mirrors the span-loader's `max_depth` check. |

## Surfaces added

### `noyalib::recovery` (feature `recovery`, issue #22 / P1)

`parse_lenient` returns `ParseResult { value, errors, is_complete }` carrying the best-effort tree plus every collected error. Three-pass recovery: strict → `DuplicateKeyPolicy::Last` retry → line-truncation retry. Multi-document input split on `---` and recovered per-doc; per-doc indices preserved through budget exhaustion.

### `noyalib::sval_adapter` (feature `sval`, issue #25 / P2)

`impl sval::Value` for the noyalib value graph + `to_sval_writer{,_with_config}` entry points. Alternative to the default serde route for callers wanting to skip `serde_derive`'s compile-time overhead or the binary-size cost of serde monomorphisation. NaN / ±∞ coercion knob (`SvalConfig::coerce_non_finite_to_null`) for downstreams like `sval_json` that reject non-finites.

### `noyalib::tokio_async` (feature `tokio`, issue #24 / P2)

```rust
let pkg: Pkg = noyalib::tokio_async::from_async_reader(&mut reader).await?;
let docs: Vec<Pkg> = noyalib::tokio_async::from_async_reader_multi(&mut reader).await?;
let decoder = noyalib::tokio_async::YamlDecoder::<Pkg>::new()
    .max_frame_size(1 << 20);  // untrusted-network upper bound
```

`AsyncReadExt::take(max_document_length)` bounds the drain; `YamlDecoder::max_frame_size` bounds inter-frame buffer growth; both honour the standard `ParserConfig` chain for per-document limits.

### npm Trusted Publishing (issue #33)

`release-binaries.yml` jobs declare `id-token: write` and drop `NODE_AUTH_TOKEN`. `pkg/PUBLISH.md` §6 documents the bootstrap-token-then-retire flow.

## Security / hardening pass

Deep-dive audit (four parallel agents: defect/gap, security, performance, competitive landscape) surfaced six high-severity findings in the new modules. All closed in commit `8503325`:

| ID | Finding | Fix |
| - | - | - |
| C1 | Recovery O(n²) line-truncation on adversarial 10k-line input | `LenientConfig::truncation_event_budget` (default 1 MiB) caps cumulative retry bytes |
| C2 | `---`-marker spam → unbounded `Vec` growth | Marker scan capped by `ParserConfig::max_documents` |
| C3 | Async `read_to_end` unbounded on slow-drip producer | `AsyncReadExt::take(max_document_length)` on every reader entry |
| C4 | Three divergent `---` scanners (recovery / tokio_async / parallel) — CRLF missed by some, not others | New `crate::doc_boundary` consolidates one CRLF-aware scanner |
| C5 | UTF-8 BOM not stripped — Windows editors emit one | Stripped in `parse_lenient` and both async readers |
| C6 | `YamlDecoder::decode` recursed on whitespace-only frames | Rewritten as in-function loop |

Plus 6 P1 correctness fixes (M1–M3, M6, M7, M9, M13) and 2 P2 surface fixes (M10, M12) — see `CHANGELOG.md` for the full list with line-level citations.

## Issue #46 — streaming depth leak + companion audit

User report: large but shallow `pnpm-lock.yaml` files failed with `Error::RecursionLimitExceeded { depth: 129 }` even though real nesting was ~5 levels.

**Root cause** (commit `6991350`): `StreamingMapAccess::next_key_seed` did not check the access object's `finished` flag. Serde visitors that call `next_entry` after the previous call returned `Ok(None)` — `noyalib::Value`'s `ValueVisitor::visit_map` does this — re-entered the iterator, which read the next event from the **parent** mapping and treated it as belonging to the now-exhausted child. The recursive `deserialize_any` on each spilled value inflated `self.depth` by one per empty flow `{}`. Depth hit `max_depth + 1` after exactly 128 entries.

**Companion audit finding** (commit `ad28829`): the `NoSpanLoader` path used by `from_str::<Value>`'s value-target fast path incremented `self.depth` on `SequenceStart` / `MappingStart` but did **not** check against `max_depth` (the span-tracked loader does). Adversarial deeply-nested input through that path could consume stack without ever firing `RecursionLimitExceeded`. Same one-line fix.

**Audit verdict** for similar bugs elsewhere — all clean:

- All other `MapAccess` / `SeqAccess` / `EnumAccess` / `VariantAccess` impls across `streaming.rs`, `de.rs`, and `value.rs` either consult a `finished` flag or wrap Rust iterators that naturally return `None` on exhaustion.
- Resource counters (`alias_count`, `alias_bytes`, `key_count`) are document-scoped and the deserializer is dropped on `Err` — no leak path.
- Recursion-guard flags (`raw_str_mode`, `recording`) are reset unconditionally or use `Option::take()` — safe by construction.

Regression tests in `crates/noyalib/tests/issue_46.rs` (10 tests):
- 50 000-package full `pnpm-lock-v9` shape
- 3 000 consecutive empty flow mappings
- Deterministic depth-cliff probe at `n ∈ [100, 128, 129, 130, 200, 500, 1000]`
- Complex peer-dependency keys
- 200-level-deep sequence asserting `RecursionLimitExceeded` from the no-span path

## Benchmark numbers (`cargo bench --bench v006_features --features recovery,sval,tokio`)

| Bench | Time | Notes |
|---|---|---|
| `recovery/strict_from_str` (valid) | 5.25 µs | baseline |
| `recovery/lenient_parse_lenient_valid` | 5.14 µs | wrapper overhead within criterion noise |
| `recovery/lenient_parse_lenient_invalid` | 22.9 µs | 4.4× strict, *bounded* by `truncation_event_budget` |
| `sval/serde_from_str_to_value` | 5.15 µs | baseline (full parse) |
| `sval/sval_stream_prebuilt_value` | 52.1 ns | ~99× faster than re-parsing for cached `Value` |
| `tokio/sync_from_slice` | 5.27 µs | baseline |
| `tokio/async_from_async_reader` | 5.55 µs | +5% in synthetic `block_on` bench; ~0% in production async stacks |

Existing competitive benches (`comparison.rs`, `architecture.rs`, `numeric_parse.rs`, `structural_bitmask.rs`) unchanged — no regression on default-feature paths.

## Documentation updates

- **`README.md` (workspace)** — `recovery` / `sval` / `tokio` rows in Cargo-features table; MSRV corrected to 1.85 (edition 2024).
- **`crates/noyalib/README.md`** — same feature rows + new example-runner lines.
- **`crates/noyalib/src/lib.rs`** — module re-exports + module-level docs for the new modules; MSRV policy section updated.
- **`doc/USER-GUIDE.md`** — §10b (recovery / LSP), §10c (tokio async), §10d (sval streaming) with runnable snippets and example links.
- **`doc/ARCHITECTURE.md`** — "Optional surfaces (v0.0.6)" section mapping each gated module to its pipeline shape and source.
- **`doc/BENCHMARKS.md`** — `cargo bench --bench v006_features` run-line + per-group interpretation.
- **`SECURITY.md`** — v0.0.6 optional-surface threat model + the four new knobs.
- **`doc/POLICIES.md`** — Resource-limit-gates section extended for the recovery / tokio / sval surfaces.
- **`CHANGELOG.md`** — `[Unreleased]` section with feature highlights + the hardening-pass subsection + the issue #46 / no-span-loader fix subsections.
- **`RELEASE-NOTES-v0.0.6.md`** — full release notes (highlights, what-ships, compatibility, outstanding follow-ups).
- **`pkg/PUBLISH.md`** §6 — npm Trusted Publishing bootstrap + `NPM_TOKEN` retirement flow.

## Surface coverage audit

Independent agent audit of 22 public items across the three new modules + the new private `doc_boundary`:

- **Rustdoc** — every public item has at least a one-liner doc-comment; 18/22 carry a `# Examples` block (the 4 "thin" cases are trait-impl blocks that idiomatically inherit struct/trait docs).
- **README mentions** — 3/3 modules listed in workspace + crate READMEs.
- **doc/ folder** — 3/3 modules covered across USER-GUIDE, ARCHITECTURE, BENCHMARKS, POLICIES.
- **Runnable examples** — 3/3 modules have dedicated examples (`recovery_lenient.rs`, `sval_streaming.rs`, `tokio_async_reader.rs`).
- **Unit tests** — 22/22 public items exercised; 61 tests across the three modules; +10 integration tests for issue #46 + no-span loader; +6 in `tests/recovery.rs`.
- **Benchmarks** — `benches/v006_features.rs` covers all three modules with valid + adversarial-input arms for recovery.

**0 hard-missing gaps.**

## Diff stat (against `origin/main`)

```
 33 files changed, 3689 insertions(+), 43 deletions(-)
```

Key files:

```
crates/noyalib/src/recovery.rs                  | 581 ++
crates/noyalib/src/tokio_async.rs               | 548 ++
crates/noyalib/src/sval_adapter.rs              | 440 ++
crates/noyalib/src/doc_boundary.rs              | 215 ++  [new]
crates/noyalib/benches/v006_features.rs         | 236 ++  [new]
crates/noyalib/src/streaming.rs                 |  53 ++  [#46 fix]
crates/noyalib/src/parser/loader.rs             |   6 ++  [no-span depth check]
crates/noyalib/examples/recovery_lenient.rs     |  35 ++  [new]
crates/noyalib/examples/sval_streaming.rs       | 125 ++  [new]
crates/noyalib/examples/tokio_async_reader.rs   |  71 ++  [new]
crates/noyalib/tests/recovery.rs                |  69 ++  [new]
crates/noyalib/tests/issue_46.rs                | 211 ++  [new]
RELEASE-NOTES-v0.0.6.md                         | 131 ++  [new]
CHANGELOG.md                                    | 211 ++
SECURITY.md                                     |  18 ++
doc/USER-GUIDE.md                               |  66 ++
doc/ARCHITECTURE.md                             |  19 ++
doc/BENCHMARKS.md                               |  17 ++
doc/POLICIES.md                                 |  29 ++
pkg/PUBLISH.md                                  |  32 +-
supply-chain/config.toml                        |  30 ++
.github/workflows/release-binaries.yml          |  23 +-
```

## Commits

| SHA | Title |
| - | - |
| `ad28829` | `fix(loader): NoSpan path was missing the max_depth check (#46 audit)` |
| `6991350` | `fix(streaming): stop depth leak on empty flow mappings (#46)` |
| `4d36423` | `test(tokio_async): satisfy strict clippy on the external Rust CI pipeline` |
| `8503325` | `fix(v0.0.6): security/hardening pass on recovery+tokio+sval (6 P0, 4 P1, 2 P2)` |
| `9604335` | `test(tokio_async): cover invalid-UTF-8 branch in from_async_reader_multi` |
| `afda7ce` | `docs+tests(v0.0.6): examples, benchmarks, READMEs, coverage uplift` |
| `e02da42` | `test(failsafe-tags): change 3.14 → 2.5 to dodge clippy::approx_constant` |
| `212a3bc` | `chore(v0.0.6): rustfmt + cargo-vet exemptions for tokio/sval deps` |
| `ed7cadb` | `docs(v0.0.6): drop broken intra-doc links in new modules` |
| `8b740fa` | `feat(v0.0.6): Ecosystem Integration — recovery, sval, tokio, OIDC publish (#22 #24 #25 #33)` |
| `9b79f8e` | `test+docs: cover v0.0.5 surface (i18n + ariadne + include) — coverage uplift` |

All commits ED25519-signed.

## Compatibility

- MSRV unchanged from v0.0.5 (Rust 1.85 / edition 2024).
- Default-features behaviour unchanged.
- All new functionality is gated behind opt-in Cargo features (`recovery`, `sval`, `tokio`); callers that don't enable them see zero new surface, zero new deps, zero behavioural change.
- Issue #46 fix and the no-span depth-check fix are pure bug fixes — no API change. Documents that previously failed with `RecursionLimitExceeded` will now parse cleanly; documents that previously parsed unchanged.

## Post-merge follow-ups (external, not gating this PR)

- Configure Trusted Publishers on `npmjs.com/package/@noyalib/noyalib-wasm/access` and `npmjs.com/package/noyalib-mcp/access` after the first publish (npm account access required).
- `gh secret delete NPM_TOKEN --repo sebastienrousseau/noyalib` once Trusted Publisher policies are live.
- v0.0.7 candidates surfaced by the audit (tracked separately): rowan-interop adapter for `cst::Document`, `from_sval` inverse direction for the sval adapter, `YamlEncoder` companion for `tokio_util::codec::Framed`, fuzz targets for the three new entry points.