### PR TITLE
docs(ci): update cosign-installer trailing comment v3 → v4.1.2

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -325,7 +325,7 @@ jobs:
             ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}-debuginfo.tar.gz
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign artefacts (keyless)
         env:
@@ -429,7 +429,7 @@ jobs:
           subject-path: ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.tar.gz
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
       # Verifiers run `cosign verify-blob` with the issuer / identity
       # constraints documented in SECURITY.md.
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign release artefacts (keyless)
         env:
           COSIGN_YES: "true"


### PR DESCRIPTION
Cosmetic follow-up to PR #63 — Dependabot left the trailing `# v3` comment in place after bumping the SHA to v4.1.2's commit. This syncs the comment so the SHA → human tag mapping stays accurate.

Pure docs fix; no behavioural change.