### PR TITLE
ci(npm): actually apply exact-pin + npm ci (fixes #66)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -687,7 +687,11 @@ jobs:
         working-directory: pkg/vscode
         run: |
           set -euo pipefail
-          npm install
+          # `npm ci` over `npm install` pins all dep versions to the
+          # committed `package-lock.json`. Scorecard's Pinned-
+          # Dependencies check counts `npm ci` as pinned and `npm
+          # install` as unpinned.
+          npm ci
           mkdir -p bin
           # The ext bundle includes only the host's noyalib-lsp; the
           # `noyalib.path` setting lets users point at a system one.

--- a/pkg/vscode/package.json
+++ b/pkg/vscode/package.json
@@ -2,7 +2,7 @@
   "//": "VS Code / Open VSX extension manifest. Built and published by the `vscode-extension` job in release-binaries.yml. Templated; the release pipeline rewrites the version field from the git tag.",
   "name": "noyalib",
   "displayName": "noyalib YAML",
-  "description": "YAML language support powered by noyalib — formatting via noyafmt, validation via JSON Schema 2020-12, hover-driven docs from schemas.",
+  "description": "YAML language support powered by noyalib \u2014 formatting via noyafmt, validation via JSON Schema 2020-12, hover-driven docs from schemas.",
   "version": "0.0.1",
   "publisher": "sebastienrousseau",
   "license": "MIT OR Apache-2.0",
@@ -16,8 +16,19 @@
     "url": "https://github.com/sebastienrousseau/noyalib/issues"
   },
   "icon": "icon.png",
-  "categories": ["Programming Languages", "Linters", "Formatters"],
-  "keywords": ["yaml", "noyalib", "formatter", "validator", "lsp", "schema"],
+  "categories": [
+    "Programming Languages",
+    "Linters",
+    "Formatters"
+  ],
+  "keywords": [
+    "yaml",
+    "noyalib",
+    "formatter",
+    "validator",
+    "lsp",
+    "schema"
+  ],
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -29,8 +40,14 @@
     "languages": [
       {
         "id": "yaml",
-        "aliases": ["YAML", "yaml"],
-        "extensions": [".yaml", ".yml"],
+        "aliases": [
+          "YAML",
+          "yaml"
+        ],
+        "extensions": [
+          ".yaml",
+          ".yml"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],
@@ -45,7 +62,11 @@
         },
         "noyalib.trace.server": {
           "type": "string",
-          "enum": ["off", "messages", "verbose"],
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
           "default": "off",
           "description": "Trace LSP messages between VS Code and the server."
         }
@@ -54,16 +75,16 @@
   },
   "scripts": {
     "compile": "tsc -p .",
-    "watch":   "tsc -watch -p .",
+    "watch": "tsc -watch -p .",
     "package": "vsce package --out ../../noyalib-${npm_package_version}.vsix"
   },
   "devDependencies": {
-    "@types/node":   "^20",
-    "@types/vscode": "^1.85.0",
-    "typescript":    "^5.4",
-    "vsce":          "^2.15"
+    "@types/node": "20.19.0",
+    "@types/vscode": "1.85.0",
+    "typescript": "5.4.5",
+    "vsce": "2.15.0"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "9.0.1"
   }
 }


### PR DESCRIPTION
## Summary

Repairs PR #66, whose merge commit only included the lockfile —
the `package.json` exact-pinning and the workflow `npm install`
→ `npm ci` swap never landed. Scorecard's latest scan still
reports `release-binaries.yml:690` unpinned because of it.

* Exact-pin every dep in `pkg/vscode/package.json` (no `^`)
* `npm install` → `npm ci` in the `vscode-extension` job
* Regenerate `pkg/vscode/package-lock.json` against the pinned
  versions so the integrity hashes match what `npm ci` checks

## Test plan

- [ ] CI green
- [ ] After merge, next Scorecard scan reports Pinned-Dependencies
      10/10 (was stuck at 9/10 due to the `npm install` line)