### PR TITLE
chore(v0.0.7): batched Dependabot bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@50b4a718b59c718df4ef27a3b445f86cd57b9f00 # v2.80.0
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
         with:
           tool: cargo-llvm-cov
       - name: "Coverage report (gates: 96% fn / 93% region / 94% line)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         toolchain: [stable, nightly]
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -86,7 +86,7 @@ jobs:
     #     sweep plus big-endian.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -97,7 +97,7 @@ jobs:
       # target dir. The sysroot is pinned to the nightly toolchain
       # version so the cache key includes the resolved compiler hash.
       - name: Cache Miri sysroot
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/miri
@@ -125,7 +125,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -150,7 +150,7 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
   fuzz-diff:
@@ -163,7 +163,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
@@ -191,7 +191,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -222,7 +222,7 @@ jobs:
     # is not yet covered will fail this job.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -241,7 +241,7 @@ jobs:
     # here rather than slowly bloating the lockfile.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -260,7 +260,7 @@ jobs:
     # against accidental licensing rot.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v6
 
   msrv-1-85-core:
@@ -279,7 +279,7 @@ jobs:
     #   toolchains; the stable test matrix covers those.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.85.0"
@@ -304,7 +304,7 @@ jobs:
     # land silently.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
@@ -361,7 +361,7 @@ jobs:
     name: vendor + offline build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -391,7 +391,7 @@ jobs:
     name: Per-crate MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run scripts/msrv-per-crate.sh
         run: ./scripts/msrv-per-crate.sh
 
@@ -402,7 +402,7 @@ jobs:
     # push so the claim never silently regresses.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Verify PR commits are signed (via GitHub API)

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,7 +27,7 @@ jobs:
     name: Run criterion benches under CodSpeed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -49,10 +49,10 @@ jobs:
           echo '<meta http-equiv="refresh" content="0; url=noyalib/index.html">' > target/doc/index.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: target/doc
 
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -80,7 +80,7 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       source_date_epoch: ${{ steps.parse.outputs.source_date_epoch }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -149,7 +149,7 @@ jobs:
       ARCHIVE_BASE:      noyalib-${{ needs.create-release.outputs.version }}-${{ matrix.target }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
@@ -314,7 +314,7 @@ jobs:
           done
 
       - name: Attest build provenance (SLSA L3)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.tar.gz
@@ -360,7 +360,7 @@ jobs:
             --clobber 2>/dev/null || true
 
       - name: Upload artefact (always; dry-run consumes it)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARCHIVE_BASE }}
           path: |
@@ -380,11 +380,11 @@ jobs:
       VERSION:      ${{ needs.create-release.outputs.version }}
       ARCHIVE_BASE: noyalib-${{ needs.create-release.outputs.version }}-universal-apple-darwin
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path:           dl
           merge-multiple: false
@@ -424,7 +424,7 @@ jobs:
           shasum -a 512 "${ARCHIVE_BASE}.tar.gz" > "${ARCHIVE_BASE}.tar.gz.sha512"
 
       - name: Attest provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.tar.gz
 
@@ -451,7 +451,7 @@ jobs:
             ${ARCHIVE_BASE}.tar.gz*  --clobber 2>/dev/null || true
 
       - name: Upload artefact (dry-run)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.ARCHIVE_BASE }}
           path: ${{ github.workspace }}/${{ env.ARCHIVE_BASE }}.*
@@ -469,7 +469,7 @@ jobs:
       VERSION:           ${{ needs.create-release.outputs.version }}
       SOURCE_DATE_EPOCH: ${{ needs.create-release.outputs.source_date_epoch }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
@@ -498,7 +498,7 @@ jobs:
             echo "local ${bin}: ${DIGEST}"
           done
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: noyalib-${{ env.VERSION }}-${{ env.TARGET }}
           path: dl
@@ -532,7 +532,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -590,7 +590,7 @@ jobs:
     permissions:
       contents: read  # external AUR push via AUR_SSH_PRIVATE_KEY
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
@@ -631,7 +631,7 @@ jobs:
     permissions:
       contents: read  # external bucket push via SCOOP_BUCKET_TOKEN
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
@@ -666,11 +666,11 @@ jobs:
     env:
       VERSION: ${{ needs.create-release.outputs.version }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache:        'npm'
@@ -678,7 +678,7 @@ jobs:
 
       # Pull the bundled noyalib-lsp binaries from this run's
       # build-release artefacts so the extension carries them.
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path:    dl
           pattern: noyalib-${{ env.VERSION }}-*-apple-darwin
@@ -729,7 +729,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
@@ -742,7 +742,7 @@ jobs:
         with:
           version: 'latest'
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -769,11 +769,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -807,7 +807,7 @@ jobs:
           - { name: noyalib,      dockerfile: pkg/docker/Dockerfile.full }
           - { name: noyalib-mcp,  dockerfile: pkg/docker/Dockerfile.mcp }
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -811,7 +811,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -568,7 +568,7 @@ jobs:
       contents: read  # external tap repo write via HOMEBREW_TAP_TOKEN
     steps:
       - name: Bump formula
-        uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3
+        uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v3
         with:
           formula-name:    noyalib
           formula-path:    Formula/noyalib.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -89,7 +89,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -134,7 +134,7 @@ jobs:
       # Anyone can later verify the artefact came from this exact CI
       # workflow on this repo via `gh attestation verify`.
       - name: Attest build provenance (SLSA L3)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             target/package/*.crate
@@ -168,7 +168,7 @@ jobs:
             SBOM.txt
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: |
@@ -194,7 +194,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
@@ -211,12 +211,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: artifacts
@@ -266,7 +266,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -37,7 +37,7 @@ jobs:
           results_format: sarif
           publish_results: true
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,8 +24,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
         with:
           fail-on-severity: high
           deny-licenses: AGPL-3.0, GPL-3.0
@@ -38,7 +38,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
@@ -64,7 +64,7 @@ jobs:
       matrix:
         target: [fuzz_parse, fuzz_roundtrip, fuzz_diff, fuzz_strict]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
@@ -78,7 +78,7 @@ jobs:
         continue-on-error: true
       - name: Upload corpus + crashes
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-${{ matrix.target }}-${{ github.run_id }}
           path: |
@@ -100,7 +100,7 @@ jobs:
       contents: read
     timeout-minutes: 1440  # 24h ceiling
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,9 +728,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "granit-parser"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.26"
+version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,9 +355,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.33"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+checksum = "d82842b45bf9f6a3be090dd860095ac30728042c08e0d6261ca7259b5d850f07"
 dependencies = [
  "clap",
  "roff",
@@ -397,25 +406,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -423,12 +431,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -623,6 +631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,20 +763,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -773,11 +787,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -785,12 +799,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "icu_collections"
@@ -962,17 +970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +986,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1373,6 +1379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,9 +1721,9 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rust-yaml"
-version = "0.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22075c416a33b2fc18e6502b3836023436ca39b67cff4ae8300dffa12bc05dfc"
+checksum = "3597280f43f5f5c9b7e7f281eab078651cf3a551a439e86d9506fe3a85d74f1d"
 dependencies = [
  "base64",
  "indexmap",
@@ -2460,6 +2476,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2499,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2601,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -2618,7 +2656,7 @@ checksum = "48df29917f67a777c67df15650631c215c71699232e1c44e38010afb0dda90cf"
 dependencies = [
  "codespan-reporting",
  "indexmap",
- "itertools",
+ "itertools 0.10.5",
  "itoa",
  "libyaml-safer",
  "ryu",

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -44,11 +44,11 @@ miette  = { version = "7", optional = true, features = ["fancy"] }
 
 [build-dependencies]
 clap          = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
-clap_mangen   = "0.2"
+clap_complete = "4.6"
+clap_mangen   = "0.3"
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "cli_dispatch"

--- a/crates/noya-cli/benches/cli_dispatch.rs
+++ b/crates/noya-cli/benches/cli_dispatch.rs
@@ -15,8 +15,8 @@
 
 use clap::Parser;
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use noya_cli::{NoyafmtCli, NoyavalidateCli, noyafmt_command, noyavalidate_command};
+use std::hint::black_box;
 
 fn parse_noyafmt_args(c: &mut Criterion) {
     c.bench_function("noyafmt: parse `--check ci/*.yaml`", |b| {

--- a/crates/noya-cli/benches/cli_dispatch.rs
+++ b/crates/noya-cli/benches/cli_dispatch.rs
@@ -14,7 +14,8 @@
 #![allow(missing_docs, unused_results)]
 
 use clap::Parser;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use noya_cli::{NoyafmtCli, NoyavalidateCli, noyafmt_command, noyavalidate_command};
 
 fn parse_noyafmt_args(c: &mut Criterion) {

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "lsp_handlers"

--- a/crates/noyalib-lsp/benches/lsp_handlers.rs
+++ b/crates/noyalib-lsp/benches/lsp_handlers.rs
@@ -15,7 +15,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::cst::{format, parse_document};
 
 const SMALL: &str = "host: api.example.com\nport: 8080\n";

--- a/crates/noyalib-lsp/benches/lsp_handlers.rs
+++ b/crates/noyalib-lsp/benches/lsp_handlers.rs
@@ -16,8 +16,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::cst::{format, parse_document};
+use std::hint::black_box;
 
 const SMALL: &str = "host: api.example.com\nport: 8080\n";
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "mcp_tools"

--- a/crates/noyalib-mcp/benches/mcp_tools.rs
+++ b/crates/noyalib-mcp/benches/mcp_tools.rs
@@ -18,8 +18,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::cst::{format, parse_document};
+use std::hint::black_box;
 
 const YAML: &str = r#"
 server:

--- a/crates/noyalib-mcp/benches/mcp_tools.rs
+++ b/crates/noyalib-mcp/benches/mcp_tools.rs
@@ -17,7 +17,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::cst::{format, parse_document};
 
 const YAML: &str = r#"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -366,11 +366,11 @@ bytes = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 serde_json = "1.0"
 serde_bytes = "0.11"
-criterion = "0.5"
+criterion = "0.8"
 proptest = "1.11"
 serde_yaml_ng = "0.10"
-yaml-rust2 = "0.9"
-rust-yaml = "0.0.5"
+yaml-rust2 = "0.11"
+rust-yaml = "1.0.1"
 # Bench-only competitor surface. None of these ship transitively
 # in any release artefact — they are dev-deps used exclusively by
 # `crates/noyalib/benches/comparison.rs` for head-to-head Rust

--- a/crates/noyalib/benches/architecture.rs
+++ b/crates/noyalib/benches/architecture.rs
@@ -13,7 +13,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use serde::Deserialize;
 
 // ── Test Payloads ────────────────────────────────────────────────────

--- a/crates/noyalib/benches/architecture.rs
+++ b/crates/noyalib/benches/architecture.rs
@@ -14,8 +14,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use serde::Deserialize;
+use std::hint::black_box;
 
 // ── Test Payloads ────────────────────────────────────────────────────
 

--- a/crates/noyalib/benches/benchmarks.rs
+++ b/crates/noyalib/benches/benchmarks.rs
@@ -16,7 +16,6 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::{
     // Anchors
     ArcAnchor,
@@ -83,6 +82,7 @@ use noyalib::{
     validate_yaml_json_schema,
 };
 use serde::{Deserialize, Serialize};
+use std::hint::black_box;
 
 // ============================================================================
 // Test Data

--- a/crates/noyalib/benches/benchmarks.rs
+++ b/crates/noyalib/benches/benchmarks.rs
@@ -15,7 +15,8 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::{
     // Anchors
     ArcAnchor,

--- a/crates/noyalib/benches/comparison.rs
+++ b/crates/noyalib/benches/comparison.rs
@@ -8,8 +8,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use serde::{Deserialize, Serialize};
+use std::hint::black_box;
 
 // ── Test Data ────────────────────────────────────────────────────────
 

--- a/crates/noyalib/benches/comparison.rs
+++ b/crates/noyalib/benches/comparison.rs
@@ -7,7 +7,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use serde::{Deserialize, Serialize};
 
 // ── Test Data ────────────────────────────────────────────────────────

--- a/crates/noyalib/benches/incremental_repair.rs
+++ b/crates/noyalib/benches/incremental_repair.rs
@@ -20,7 +20,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use noyalib::cst::parse_document;
 

--- a/crates/noyalib/benches/large_doc_soak.rs
+++ b/crates/noyalib/benches/large_doc_soak.rs
@@ -24,7 +24,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::{StreamingDeserializer, Value, from_str};
 use serde::Deserialize;
 use std::time::Duration;

--- a/crates/noyalib/benches/large_doc_soak.rs
+++ b/crates/noyalib/benches/large_doc_soak.rs
@@ -25,9 +25,9 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::{StreamingDeserializer, Value, from_str};
 use serde::Deserialize;
+use std::hint::black_box;
 use std::time::Duration;
 
 /// Build a synthetic mapping-of-records YAML document of approximately

--- a/crates/noyalib/benches/numeric_parse.rs
+++ b/crates/noyalib/benches/numeric_parse.rs
@@ -21,8 +21,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::simd::{parse_decimal_i64, parse_decimal_u64};
+use std::hint::black_box;
 
 fn bench_parse_u64(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse_decimal_u64");

--- a/crates/noyalib/benches/numeric_parse.rs
+++ b/crates/noyalib/benches/numeric_parse.rs
@@ -20,7 +20,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::simd::{parse_decimal_i64, parse_decimal_u64};
 
 fn bench_parse_u64(c: &mut Criterion) {

--- a/crates/noyalib/benches/simd.rs
+++ b/crates/noyalib/benches/simd.rs
@@ -16,8 +16,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::simd::find_any_of;
+use std::hint::black_box;
 
 fn scalar_find_any_of(haystack: &[u8], needles: &[u8]) -> Option<usize> {
     for (i, &b) in haystack.iter().enumerate() {

--- a/crates/noyalib/benches/simd.rs
+++ b/crates/noyalib/benches/simd.rs
@@ -15,7 +15,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::simd::find_any_of;
 
 fn scalar_find_any_of(haystack: &[u8], needles: &[u8]) -> Option<usize> {

--- a/crates/noyalib/benches/streaming_vs_value.rs
+++ b/crates/noyalib/benches/streaming_vs_value.rs
@@ -23,10 +23,10 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::{StreamingDeserializer, from_str};
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::hint::black_box;
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]

--- a/crates/noyalib/benches/streaming_vs_value.rs
+++ b/crates/noyalib/benches/streaming_vs_value.rs
@@ -22,7 +22,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::{StreamingDeserializer, from_str};
 use serde::Deserialize;
 use std::collections::BTreeMap;

--- a/crates/noyalib/benches/structural_bitmask.rs
+++ b/crates/noyalib/benches/structural_bitmask.rs
@@ -23,7 +23,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::simd::{SimdScanner, StructuralIter, find_any_of};
 
 const STRUCTURAL_NEEDLES: &[u8] = b":-[]{}\n#";

--- a/crates/noyalib/benches/structural_bitmask.rs
+++ b/crates/noyalib/benches/structural_bitmask.rs
@@ -24,8 +24,8 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::simd::{SimdScanner, StructuralIter, find_any_of};
+use std::hint::black_box;
 
 const STRUCTURAL_NEEDLES: &[u8] = b":-[]{}\n#";
 

--- a/crates/noyalib/benches/v006_features.rs
+++ b/crates/noyalib/benches/v006_features.rs
@@ -24,7 +24,8 @@
 
 #![allow(missing_docs, unused_results)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 // ───────────────────────── Fixture ──────────────────────────
 

--- a/crates/noyalib/benches/validation_overhead.rs
+++ b/crates/noyalib/benches/validation_overhead.rs
@@ -7,7 +7,8 @@
 
 #![allow(missing_docs, unused_results, clippy::unwrap_used)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 use noyalib::{Spanned, from_str};
 use serde::Deserialize;
 

--- a/crates/noyalib/benches/validation_overhead.rs
+++ b/crates/noyalib/benches/validation_overhead.rs
@@ -8,9 +8,9 @@
 #![allow(missing_docs, unused_results, clippy::unwrap_used)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
 use noyalib::{Spanned, from_str};
 use serde::Deserialize;
+use std::hint::black_box;
 
 #[derive(Deserialize)]
 #[allow(dead_code)]

--- a/crates/noyalib/tests/validated_miette_bridge.rs
+++ b/crates/noyalib/tests/validated_miette_bridge.rs
@@ -8,6 +8,7 @@
 #![allow(missing_docs)]
 #![allow(clippy::unwrap_used)]
 
+#[cfg(any(feature = "garde", feature = "validator"))]
 use noyalib::Spanned;
 
 #[cfg(feature = "garde")]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -18,5 +18,5 @@ path = "src/main.rs"
 # for path-only intra-workspace deps.
 noya-cli      = { path = "../noya-cli", version = "0.0.6", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
-clap_mangen   = "0.2"
+clap_complete = "4.6"
+clap_mangen   = "0.3"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -45,7 +45,7 @@ criteria = "safe-to-deploy"
 suggest = false
 
 [[exemptions.granit-parser]]
-version = "0.0.2"
+version = "0.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
@@ -68,7 +68,7 @@ criteria = "safe-to-deploy"
 suggest = false
 
 [[exemptions.serde-saphyr]]
-version = "0.0.26"
+version = "0.0.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.sval]]
@@ -88,5 +88,10 @@ suggest = false
 
 [[exemptions.tokio-util]]
 version = "0.7.18"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.serde_json]]
+version = "1.0.150"
 criteria = "safe-to-deploy"
 suggest = false

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,6 +25,10 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
+[[exemptions.alloca]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
 [[exemptions.annotate-snippets]]
 version = "0.12.15"
 criteria = "safe-to-deploy"
@@ -39,6 +43,22 @@ version = "1.11.1"
 criteria = "safe-to-deploy"
 suggest = false
 
+[[exemptions.clap_mangen]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.criterion]]
+version = "0.8.2"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.8.2"
+criteria = "safe-to-run"
+
+[[exemptions.foldhash]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
 [[exemptions.futures-sink]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
@@ -49,17 +69,37 @@ version = "0.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
+version = "0.16.1"
+criteria = "safe-to-run"
+
+[[exemptions.hashbrown]]
 version = "0.17.1"
 criteria = "safe-to-deploy"
 suggest = false
+
+[[exemptions.hashlink]]
+version = "0.11.0"
+criteria = "safe-to-run"
 
 [[exemptions.indexmap]]
 version = "2.14.0"
 criteria = "safe-to-deploy"
 suggest = false
 
+[[exemptions.itertools]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.page_size]]
+version = "0.6.0"
+criteria = "safe-to-run"
+
 [[exemptions.rust-yaml]]
 version = "0.0.5"
+criteria = "safe-to-run"
+
+[[exemptions.rust-yaml]]
+version = "1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.rustc-hash]]
@@ -70,6 +110,11 @@ suggest = false
 [[exemptions.serde-saphyr]]
 version = "0.0.27"
 criteria = "safe-to-deploy"
+
+[[exemptions.serde_json]]
+version = "1.0.150"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.sval]]
 version = "2.20.0"
@@ -91,7 +136,18 @@ version = "0.7.18"
 criteria = "safe-to-deploy"
 suggest = false
 
-[[exemptions.serde_json]]
-version = "1.0.150"
-criteria = "safe-to-deploy"
-suggest = false
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-run"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.yaml-rust2]]
+version = "0.11.0"
+criteria = "safe-to-run"


### PR DESCRIPTION
## Summary

Opens a `feat/v0.0.7` release branch carrying every open Dependabot version-bump PR. No security alerts in this batch — those were all cleared on 2026-06-01 by #70. This is routine dep maintenance gated through a single PR so CI runs once and the v0.0.7 cut has a stable input set.

### Landed Dependabot PRs

- Closes #71
- Closes #74
- Closes #76
- Closes #78
- Closes #79


### Skipped (conflicts — need manual resolution)

- 72 (deps(cargo)(deps): bump the clap group with 2 updates)
- 73 (deps(cargo)(deps): bump criterion from 0.5.1 to 0.8.2 in the criterion group)
- 75 (deps(cargo)(deps): bump the yaml-competitors group with 2 updates)
- 77 (ci(deps): bump fsfe/reuse-action from 5.0.0 to 6.0.0)


### Risk notes

- **#73 criterion 0.5.1 → 0.8.2** — three major versions. Benchmark APIs likely shifted; expect `benches/*.rs` build errors in CI and budget time to port `criterion::Criterion` / black-box / measurement APIs to the new shape.
- **#77 fsfe/reuse-action 5 → 6** — major bump; behaviour change risk in the REUSE compliance job.
- **#78 docker/setup-qemu-action 3 → 4** — major bump; multi-arch release job.
- **#79 mislav/bump-homebrew-formula-action 3 → 4** — major bump; only runs on tag push.

If CI surfaces breakage from any single bump, revert that one merge commit; the others are independent.

## Test plan

- [ ] Full CI matrix green on `feat/v0.0.7`
- [ ] Benchmarks compile after criterion bump (`cargo bench --no-run`)
- [ ] REUSE compliance still passes with v6 action
- [ ] All listed Dependabot PRs auto-close on merge