### PR TITLE
chore(release): cut v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,56 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.6]` is the cut.)
+(Nothing yet — `[v0.0.7]` is the cut.)
+
+## [v0.0.7] — 2026-06-02
+
+The **Supply-chain Hardening** cut. Closes three CVEs in the
+VS Code extension's npm tree (xml2js, qs, tmp — all dragged in
+by the legacy `vsce` devDep, which was removed), tightens the
+release pipeline with `npm ci` + exact-pinned lockfile, and
+folds in the routine Dependabot backlog: serde, clap, criterion
+0.8 (with the `std::hint::black_box` migration across 14 bench
+files), yaml-competitors, the actions group (10 actions headed
+by checkout v5 → v6), plus eight standalone action bumps and
+the sigstore cosign-installer v3 → v4 bump.
+
+### Security
+
+- **Drop legacy `vsce`.** `pkg/vscode/devDependencies` removed;
+  the release pipeline already used `npx --yes @vscode/vsce`,
+  so the legacy package was inert. Clears GHSA-776f-qx25-q3cc
+  (xml2js), GHSA-q8mj-m7cp-5q26 (qs), and GHSA-ph9p-34f9-6g65
+  (tmp). [#70]
+- **`npm install` → `npm ci`** in the `vscode-extension` job
+  with a committed, exact-pinned `package-lock.json`. [#69]
+- **cosign-installer** upgraded to v4.1.2; release artefact
+  signing flow unchanged. [#63]
+- **Auto-approve Dependabot** workflow added to satisfy
+  OpenSSF Scorecard's `Code-Review` check on a
+  solo-maintainer project. [#64]
+
+### Changed
+
+- **criterion 0.5.1 → 0.8.2.** All 14 bench files migrated from
+  `criterion::black_box` to `std::hint::black_box` (criterion
+  0.8 deprecated the re-export). [#80]
+- **yaml-competitors group bump** — yaml-rust2 0.9 → 0.11,
+  rust-yaml 0.0.5 → 1.1; both are bench/comparison-only deps,
+  not part of the runtime tree. [#80]
+- **actions group bump (10 actions)** including checkout v5 →
+  v6, cache v4 → v5, configure-pages v4 → v6,
+  upload-pages-artifact v3 → v5, plus 6 others. [#80]
+- **clap_complete 4.5 → 4.6, clap_mangen 0.2 → 0.3** in
+  noya-cli and xtask. [#80]
+- **Docker base** bumped from `rust:1.85-bookworm` to
+  `rust:1.96-bookworm` in all three Dockerfiles. [#62]
+
+### Fixed
+
+- **OpenSSF Scorecard Pinned-Dependencies** 9/10 → 10/10 by
+  exact-pinning every npm dep and switching to `npm ci`. [#66,
+  #69]
 
 ## [v0.0.6] — 2026-05-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "ariadne",
  "bytes",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ wants to *use* the library. The full reference is the
 
 ```toml
 [dependencies]
-noyalib = "0.0.6"
+noyalib = "0.0.7"
 ```
 
 `no_std` (alloc-only) and lean profiles are documented in the

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.6"
+noyalib = "0.0.7"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.6", default-features = false }
+noyalib = { version = "0.0.7", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -175,7 +175,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.6", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.7", features = ["miette", "validate-schema"] }
 ```
 
 ---
@@ -280,7 +280,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.6"
++noyalib = "0.0.7"
 ```
 
 ```diff

--- a/RELEASE-NOTES-v0.0.7.md
+++ b/RELEASE-NOTES-v0.0.7.md
@@ -1,0 +1,145 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.7 — Release Notes
+
+The **Supply-chain Hardening** cut. Closes three CVEs in the
+VS Code extension's npm tree, tightens the release pipeline
+end-to-end, and folds in the routine Dependabot backlog
+(serde, clap, criterion 0.8, yaml-competitors, actions group,
+plus eight standalone action bumps).
+
+No public API change; no MSRV change (still 1.85). Existing
+v0.0.6 callers can upgrade with no code edits.
+
+## Highlights
+
+* **Three CVEs cleared.** The legacy `vsce` devDependency in
+  `pkg/vscode/` was dragging in vulnerable transitives
+  (`xml2js@0.4.x` → GHSA-776f-qx25-q3cc,
+  `qs@6.11–6.15.1` → GHSA-q8mj-m7cp-5q26,
+  `tmp@<0.2.6` → GHSA-ph9p-34f9-6g65). The package wasn't
+  actually invoked by CI — the release job already used
+  `npx --yes @vscode/vsce` — so the whole subtree was removed.
+* **`npm install` → `npm ci`** in the VS Code extension build,
+  with `pkg/vscode/package.json` exact-pinned (no `^`) and a
+  committed `package-lock.json`. OpenSSF Scorecard's
+  `Pinned-Dependencies` check now reads 10/10.
+* **Cosign installer pinned to v4.1.2** (was v3.9.2) via the
+  sigstore group bump; signed release artefacts continue to
+  upload `.crate.sig` + `.crate.pem` to every GitHub Release.
+* **Auto-approve workflow for Dependabot** so bot PRs accrue
+  the implicit approvals Scorecard's `Code-Review` check
+  counts, without manual intervention.
+* **criterion 0.8** across all benches, with the
+  `criterion::black_box` → `std::hint::black_box` migration
+  done in every bench file so the 0.8 deprecation lint stays
+  clean.
+
+## What ships
+
+### Security — drop legacy `vsce` (PR #70)
+
+The `vsce` npm package was retired upstream in favour of
+`@vscode/vsce`. `pkg/vscode/package.json` carried it as a
+devDependency, but the `vscode-extension` release job in
+`.github/workflows/release-binaries.yml` never invoked it —
+it called `npx --yes @vscode/vsce package` / `publish`
+directly. Removing the dead devDep deleted the entire
+vulnerable transitive subtree at once. The lockfile was
+regenerated against the slimmer tree.
+
+### Supply-chain — npm pinning (PRs #66 / #69 / #80)
+
+* `pkg/vscode/package.json` — every dep pinned to an exact
+  version (no `^`).
+* `pkg/vscode/package-lock.json` — committed, with integrity
+  hashes for the entire transitive tree.
+* `.github/workflows/release-binaries.yml` — the
+  `vscode-extension` job now runs `npm ci` instead of
+  `npm install`. `npm ci` refuses to run without a lockfile
+  and refuses to mutate one, so every release build resolves
+  to exactly the integrity-checked tree we committed.
+
+### Dependabot backlog (PR #80)
+
+Serde, clap, criterion (0.5.1 → 0.8.2), yaml-competitors
+(yaml-rust2 0.9 → 0.11, rust-yaml 0.0.5 → 1.1), the actions
+group (10 actions, headed by checkout v5 → v6), taiki-e
+install-action, docker/setup-qemu-action v3 → v4,
+mislav/bump-homebrew-formula-action v3 → v4, plus the
+sigstore/cosign-installer v3 → v4.1.2 bump from PR #63.
+
+cargo-vet exemptions added for the 13 new bench/competitor
+transitives and clap_mangen 0.3.0 promoted to safe-to-deploy.
+
+### Benches — `criterion::black_box` migration
+
+criterion 0.8 deprecates `criterion::black_box` in favour of
+`std::hint::black_box`. Every bench file in the workspace —
+14 files across `crates/noyalib/`, `crates/noyalib-lsp/`,
+`crates/noyalib-mcp/`, and `crates/noya-cli/` — drops the
+`black_box` import from criterion and pulls it from
+`std::hint` instead.
+
+### OpenSSF — Code-Review auto-approve (PR #64)
+
+`.github/workflows/auto-approve-dependabot.yml` uses
+`dependabot/fetch-metadata` to identify patch + minor bumps
+and auto-approves them. This is the lever for Scorecard's
+`Code-Review` check on a solo-maintainer project: bot PRs
+acquire the implicit approval Scorecard counts, while human
+PRs continue to merge via `gh pr merge --admin`.
+
+### Docker base bump (PR #62)
+
+`pkg/docker/Dockerfile{,.full,.mcp}` move from
+`rust:1.85-bookworm` to `rust:1.96-bookworm`, all pinned by
+`@sha256:` digest.
+
+## OpenSSF Scorecard
+
+The v0.0.6 cut hit 8.5/10. v0.0.7 adds:
+
+* **Pinned-Dependencies** 9/10 → 10/10 (npm exact-pin + ci).
+* **Vulnerabilities** 7/10 → expected 10/10 once the next
+  scan picks up the dropped `xml2js`/`qs`/`tmp`.
+* **CII-Best-Practices** — Passing badge earned during the
+  v0.0.6 release; the next scan should lift this from 0/10 to
+  the corresponding tier score.
+* **Code-Review** auto-approve workflow is in place; the
+  metric will climb as bot PRs land.
+
+## Upgrade
+
+```toml
+# Cargo.toml
+noyalib  = "0.0.7"
+```
+
+No code changes required; the runtime API is unchanged from
+v0.0.6.
+
+## Verification
+
+```bash
+# Verify the release-artefact signatures (keyless, sigstore).
+cosign verify-blob \
+  --certificate noya-cli-0.0.7.crate.pem \
+  --signature   noya-cli-0.0.7.crate.sig \
+  --certificate-identity-regexp \
+    'https://github.com/sebastienrousseau/noyalib/\.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  noya-cli-0.0.7.crate
+
+# Verify the SLSA L3 build provenance against the public
+# attestation store.
+gh attestation verify noya-cli-0.0.7.crate \
+  --owner sebastienrousseau
+```
+
+## Acknowledgements
+
+This was a chore-heavy release driven entirely by Dependabot
+and OpenSSF Scorecard signal. No external contributions to
+call out for this cut.

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.6", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.7", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.6", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.7", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.6" }
+noyalib = { path = "../noyalib", version = "0.0.7" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.6", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.7", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.6"
+noyalib = "0.0.7"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.6", default-features = false }
+noyalib = { version = "0.0.7", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -48,7 +48,7 @@
 //! # Cargo.toml — before
 //! serde_yaml = "0.9"
 //! # Cargo.toml — after
-//! noyalib = { version = "0.0.6", features = ["compat-serde-yaml"] }
+//! noyalib = { version = "0.0.7", features = ["compat-serde-yaml"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/crates/noyalib/src/schema_codegen.rs
+++ b/crates/noyalib/src/schema_codegen.rs
@@ -61,7 +61,7 @@ use crate::value::Value;
 ///
 /// ```toml
 /// [dependencies]
-/// noyalib = { version = "0.0.6", features = ["schema"] }
+/// noyalib = { version = "0.0.7", features = ["schema"] }
 /// schemars = "1.2"
 /// ```
 ///

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -374,7 +374,7 @@ mod tests {
             p,
             Pkg {
                 name: "noyalib".into(),
-                version: "0.0.6".into(),
+                version: "0.0.7".into(),
             }
         );
     }

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -374,7 +374,7 @@ mod tests {
             p,
             Pkg {
                 name: "noyalib".into(),
-                version: "0.0.7".into(),
+                version: "0.0.6".into(),
             }
         );
     }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.6", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.7", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.6"
 clap_mangen   = "0.3"

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -483,7 +483,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.6", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.7", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -506,7 +506,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.6", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.7", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -530,7 +530,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.6", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.7", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```


### PR DESCRIPTION
Cuts v0.0.7 — the Supply-chain Hardening release.

See `RELEASE-NOTES-v0.0.7.md` for the full notes.  Headline:

- Three CVEs cleared by dropping the legacy `vsce` devDep
  (xml2js, qs, tmp transitives).
- `npm install` → `npm ci` with exact-pinned lockfile —
  OpenSSF Pinned-Dependencies 9 → 10.
- Full Dependabot backlog folded: serde, clap, criterion 0.8
  (with `std::hint::black_box` migration in 14 bench files),
  yaml-competitors, actions group (10 actions), and 8
  standalone action bumps.
- No public API change.

## Test plan

- [ ] CI green
- [ ] `cargo publish --dry-run` succeeds for every publishable
      crate (release workflow runs this for real on tag push)
- [ ] After merge: run `./.git/release-v0.0.7-tag.sh` to tag +
      push, which triggers the release workflow → GitHub
      Release + crates.io publish