### PR TITLE
fix(release): cosign v4 sign-blob needs explicit --bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,15 +154,27 @@ jobs:
           COSIGN_YES: "true"
         run: |
           set -euo pipefail
+          # cosign v4 emits a sigstore protobuf bundle by default;
+          # without an explicit `--bundle` path the binary opens
+          # "" and dies with `create bundle file: open : no such
+          # file or directory`. We pass `--bundle <path>.bundle`
+          # alongside the legacy `--output-signature` / `--output-
+          # certificate` so the artefacts directory carries both
+          # formats: `.sig` + `.pem` for the existing
+          # `cosign verify-blob` flow documented in SECURITY.md,
+          # and `.bundle` for the modern sigstore verify path and
+          # for Scorecard's Signed-Releases provenance detection.
           cd target/package
           for f in *.crate; do
             cosign sign-blob \
+              --bundle "${f}.bundle" \
               --output-signature "${f}.sig" \
               --output-certificate "${f}.pem" \
               "$f"
           done
           cd -
           cosign sign-blob \
+            --bundle "SBOM.txt.bundle" \
             --output-signature "SBOM.txt.sig" \
             --output-certificate "SBOM.txt.pem" \
             SBOM.txt
@@ -175,11 +187,13 @@ jobs:
             target/package/*.crate
             target/package/*.sig
             target/package/*.pem
+            target/package/*.bundle
             target/package/SHA256SUMS.txt
             target/package/SHA512SUMS.txt
             SBOM.txt
             SBOM.txt.sig
             SBOM.txt.pem
+            SBOM.txt.bundle
           retention-days: 5
 
   # ── Cross-platform verification ─────────────────────────────────────
@@ -250,11 +264,13 @@ jobs:
             artifacts/target/package/*.crate \
             artifacts/target/package/*.sig \
             artifacts/target/package/*.pem \
+            artifacts/target/package/*.bundle \
             artifacts/target/package/SHA256SUMS.txt \
             artifacts/target/package/SHA512SUMS.txt \
             artifacts/SBOM.txt \
             artifacts/SBOM.txt.sig \
-            artifacts/SBOM.txt.pem
+            artifacts/SBOM.txt.pem \
+            artifacts/SBOM.txt.bundle
 
   # ── Publish to crates.io ────────────────────────────────────────────
   crates-io:


### PR DESCRIPTION
## Summary

Fixes the v0.0.7 release workflow failure in run #26816735609.
cosign v4 (we bumped to it in #63) always writes a sigstore
protobuf bundle on `sign-blob` and dies on an empty `--bundle`
path. Pass an explicit `--bundle "${f}.bundle"` alongside the
existing `--output-signature` / `--output-certificate` so both
the legacy and modern formats land in the release artefacts.

Bundle files added to both the upload-artifact step and the
`gh release create` asset list.

## Follow-up

After merge, run `./.git/release-v0.0.7-retag.sh` to:

1. Delete the existing `v0.0.7` tag locally and on origin.
2. Re-create the tag at the new main HEAD (containing this
   fix) — annotated + SSH-signed, same message as before.
3. Push — which re-fires `release.yml` with the working cosign
   invocation.

The tag rewrite is safe: no GitHub Release was created and
nothing was published to crates.io for v0.0.7 yet, so external
consumers can't have pulled it.

## Test plan

- [ ] CI green
- [ ] After retag: release workflow's Build-artifacts job
      succeeds, GitHub Release populated, crates.io updated.