### PR TITLE
refactor: use serde_core as a direct dependency instead of serde with derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_bytes",
+ "serde_core",
  "serde_ignored",
  "serde_json",
  "serde_path_to_error",

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -297,7 +297,8 @@ path = "examples/tokio_async_reader.rs"
 required-features = ["tokio"]
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde_core = { version = "1.0", default-features = false, features = ["alloc"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
 rustc-hash = ">=2, <3"
 itoa = { version = "1", optional = true }
@@ -364,6 +365,7 @@ tokio-util = { version = "0.7", optional = true, default-features = false, featu
 bytes = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 criterion = "0.8"
@@ -472,10 +474,10 @@ minimal = ["std"]
 # trait's `StdError` super-trait resolves consistently. With this
 # wired, `cargo build --no-default-features` truly compiles in
 # no_std and serde's de::Error does not require `std::error::Error`.
-std = ["serde/std"]
+std = ["serde_core/std", "serde?/std"]
 miette = ["dep:miette"]
 ariadne = ["dep:ariadne"]
-robotics = []
+robotics = ["dep:serde"]
 # `!include` directive — post-parse walk that consults a
 # user-supplied `crate::include::IncludeResolver` for every
 # `Value::Tagged(!include, _)` node and substitutes the

--- a/crates/noyalib/src/anchors.rs
+++ b/crates/noyalib/src/anchors.rs
@@ -19,7 +19,6 @@ use std::rc::{Rc, Weak as RcWeak};
 use std::sync::Weak as ArcWeak;
 
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
 
 /// Thread-local identity tracking for automatic anchor/alias emission.
 ///
@@ -183,10 +182,10 @@ impl<T> RcAnchor<T> {
     }
 }
 
-impl<T: Serialize> Serialize for RcAnchor<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for RcAnchor<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         #[cfg(feature = "std")]
         {
@@ -211,10 +210,10 @@ impl<T: Serialize> Serialize for RcAnchor<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for RcAnchor<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for RcAnchor<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(|v| RcAnchor(Rc::new(v)))
     }
@@ -276,10 +275,10 @@ impl<T> ArcAnchor<T> {
     }
 }
 
-impl<T: Serialize> Serialize for ArcAnchor<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for ArcAnchor<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         #[cfg(feature = "std")]
         {
@@ -304,10 +303,10 @@ impl<T: Serialize> Serialize for ArcAnchor<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for ArcAnchor<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for ArcAnchor<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(|v| ArcAnchor(Arc::new(v)))
     }
@@ -385,10 +384,10 @@ impl<T> From<RcWeak<T>> for RcWeakAnchor<T> {
     }
 }
 
-impl<T: Serialize> Serialize for RcWeakAnchor<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for RcWeakAnchor<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match self.0.upgrade() {
             Some(v) => {
@@ -411,14 +410,14 @@ impl<T: Serialize> Serialize for RcWeakAnchor<T> {
     }
 }
 
-impl<'de, T> Deserialize<'de> for RcWeakAnchor<T> {
+impl<'de, T> serde_core::Deserialize<'de> for RcWeakAnchor<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         // Always deserialize as a dangling weak — there's no registry to look up.
         // We consume the value to avoid errors.
-        let _ = serde::de::IgnoredAny::deserialize(deserializer)?;
+        let _ = serde_core::de::IgnoredAny::deserialize(deserializer)?;
         Ok(RcWeakAnchor(RcWeak::new()))
     }
 }
@@ -495,10 +494,10 @@ impl<T> From<ArcWeak<T>> for ArcWeakAnchor<T> {
     }
 }
 
-impl<T: Serialize> Serialize for ArcWeakAnchor<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for ArcWeakAnchor<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match self.0.upgrade() {
             Some(v) => {
@@ -518,12 +517,12 @@ impl<T: Serialize> Serialize for ArcWeakAnchor<T> {
     }
 }
 
-impl<'de, T> Deserialize<'de> for ArcWeakAnchor<T> {
+impl<'de, T> serde_core::Deserialize<'de> for ArcWeakAnchor<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        let _ = serde::de::IgnoredAny::deserialize(deserializer)?;
+        let _ = serde_core::de::IgnoredAny::deserialize(deserializer)?;
         Ok(ArcWeakAnchor(ArcWeak::new()))
     }
 }
@@ -914,10 +913,10 @@ impl<T> RcRecursive<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Serialize> Serialize for RcRecursive<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for RcRecursive<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match &*self.borrow() {
             Some(v) => v.serialize(serializer),
@@ -927,10 +926,10 @@ impl<T: Serialize> Serialize for RcRecursive<T> {
 }
 
 #[cfg(feature = "std")]
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for RcRecursive<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for RcRecursive<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(RcRecursive::new)
     }
@@ -1070,10 +1069,10 @@ impl<T> ArcRecursive<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Serialize> Serialize for ArcRecursive<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for ArcRecursive<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match &*self.lock() {
             Some(v) => v.serialize(serializer),
@@ -1083,10 +1082,10 @@ impl<T: Serialize> Serialize for ArcRecursive<T> {
 }
 
 #[cfg(feature = "std")]
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for ArcRecursive<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for ArcRecursive<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(ArcRecursive::new)
     }

--- a/crates/noyalib/src/borrowed.rs
+++ b/crates/noyalib/src/borrowed.rs
@@ -25,7 +25,6 @@ use crate::prelude::*;
 use core::hash::{Hash, Hasher};
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use serde::Serialize;
 
 /// Why a YAML scalar could not be borrowed directly from the input
 /// buffer and had to be materialised into an owned `String`.
@@ -376,10 +375,10 @@ impl Hash for BorrowedValue<'_> {
     }
 }
 
-impl Serialize for BorrowedValue<'_> {
+impl serde_core::Serialize for BorrowedValue<'_> {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match self {
             Self::Null => serializer.serialize_none(),
@@ -391,7 +390,7 @@ impl Serialize for BorrowedValue<'_> {
             Self::String(s) => serializer.serialize_str(s),
             Self::Sequence(seq) => seq.serialize(serializer),
             Self::Mapping(map) => {
-                use serde::ser::SerializeMap;
+                use serde_core::ser::SerializeMap;
                 let mut m = serializer.serialize_map(Some(map.len()))?;
                 for (k, v) in map {
                     m.serialize_entry(k.as_ref(), v)?;

--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -403,9 +403,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         name: String,
         port: u16,

--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -175,8 +175,6 @@
 //! that flow through unchanged for the typed-deserialise path.
 
 use crate::prelude::*;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
 // ── Types — re-exported under the serde_yaml names ───────────────────
 
@@ -252,7 +250,7 @@ pub mod with {
 /// ```
 pub fn from_str<T>(s: &str) -> Result<T>
 where
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     crate::from_str(s)
 }
@@ -268,7 +266,7 @@ where
 /// ```
 pub fn from_slice<T>(bytes: &[u8]) -> Result<T>
 where
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     crate::from_slice(bytes)
 }
@@ -291,7 +289,7 @@ where
 pub fn from_reader<R, T>(reader: R) -> Result<T>
 where
     R: std::io::Read,
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     crate::from_reader(reader)
 }
@@ -313,7 +311,7 @@ where
 /// ```
 pub fn from_value<T>(value: Value) -> Result<T>
 where
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     crate::from_value(&value)
 }
@@ -331,7 +329,7 @@ where
 /// ```
 pub fn to_string<T>(value: &T) -> Result<String>
 where
-    T: Serialize,
+    T: serde_core::Serialize,
 {
     crate::to_string(value)
 }
@@ -350,7 +348,7 @@ where
 pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: std::io::Write,
-    T: Serialize,
+    T: serde_core::Serialize,
 {
     crate::to_writer(writer, value)
 }
@@ -369,7 +367,7 @@ where
 /// ```
 pub fn to_value<T>(value: T) -> Result<Value>
 where
-    T: Serialize,
+    T: serde_core::Serialize,
 {
     crate::to_value(&value)
 }
@@ -395,7 +393,7 @@ where
 /// ```
 pub fn from_str_multi<T>(s: &str) -> Result<Vec<T>>
 where
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     crate::load_all_as::<T>(s)
 }
@@ -403,7 +401,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
+    use serde_core::Deserialize;
 
     #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -1071,9 +1071,8 @@ where
 ///
 /// ```
 /// use noyalib::from_str_borrowing;
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Person<'a> {
 ///     name: &'a str,
 ///     role: &'a str,
@@ -1206,9 +1205,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }
@@ -1270,9 +1267,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }
@@ -1306,9 +1301,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -17,8 +17,7 @@ use crate::parser::{self};
 use crate::prelude::*;
 use crate::span_context;
 use crate::value::{Number, Value};
-use serde::Deserialize;
-use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use serde_core::de::IntoDeserializer;
 #[cfg(feature = "std")]
 use std::io;
 
@@ -1039,7 +1038,7 @@ pub enum DuplicateKeyPolicy {
 /// ```
 pub fn from_str<T>(s: &str) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     from_str_with_config(s, &ParserConfig::default())
 }
@@ -1085,7 +1084,7 @@ where
 /// ```
 pub fn from_str_borrowing<'a, T>(s: &'a str) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: serde_core::Deserialize<'a>,
 {
     from_str_borrowing_with_config(s, &ParserConfig::default())
 }
@@ -1108,7 +1107,7 @@ where
 /// ```
 pub fn from_str_borrowing_with_config<'a, T>(s: &'a str, config: &ParserConfig) -> Result<T>
 where
-    T: Deserialize<'a>,
+    T: serde_core::Deserialize<'a>,
 {
     let parse_config = parser::ParseConfig::from(config);
     if s.len() > parse_config.max_document_length {
@@ -1157,7 +1156,7 @@ fn is_value_target<T: 'static + ?Sized>() -> bool {
 #[cfg(all(feature = "std", feature = "figment"))]
 pub(crate) fn from_str_typed_no_tag_preserve<T>(s: &str, config: &ParserConfig) -> Result<T>
 where
-    T: for<'de> Deserialize<'de>,
+    T: for<'de> serde_core::Deserialize<'de>,
 {
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
@@ -1219,7 +1218,7 @@ where
 #[cfg(all(feature = "std", feature = "strict-deserialise"))]
 pub fn from_str_strict<T>(s: &str) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let unknown = std::sync::Mutex::new(Vec::<String>::new());
     let value: Value = from_str_with_config(s, &ParserConfig::default())?;
@@ -1279,7 +1278,7 @@ where
 #[cfg(all(feature = "std", feature = "strict-deserialise"))]
 pub fn from_slice_strict<T>(b: &[u8]) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let s = core::str::from_utf8(b).map_err(|e| Error::Deserialize(e.to_string()))?;
     from_str_strict(s)
@@ -1314,7 +1313,7 @@ where
 pub fn from_reader_strict<R, T>(mut reader: R) -> Result<T>
 where
     R: io::Read,
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let mut s = String::new();
     let _ = reader.read_to_string(&mut s).map_err(Error::Io)?;
@@ -1354,7 +1353,7 @@ where
 /// ```
 pub fn from_str_with_config<T>(s: &str, config: &ParserConfig) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     // Try streaming path first (faster, no intermediate Value AST).
     // The streaming path bakes in YAML 1.2 semantics:
@@ -1672,7 +1671,7 @@ fn resolve_includes_recursive(
 /// ```
 pub fn from_slice<T>(b: &[u8]) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let s = core::str::from_utf8(b).map_err(|e| Error::Deserialize(e.to_string()))?;
     from_str(s)
@@ -1695,7 +1694,7 @@ where
 /// ```
 pub fn from_slice_with_config<T>(b: &[u8], config: &ParserConfig) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let s = core::str::from_utf8(b).map_err(|e| Error::Deserialize(e.to_string()))?;
     from_str_with_config(s, config)
@@ -1729,7 +1728,7 @@ where
 pub fn from_reader<R, T>(reader: R) -> Result<T>
 where
     R: io::Read,
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     from_reader_with_config(reader, &ParserConfig::default())
 }
@@ -1756,7 +1755,7 @@ where
 pub fn from_reader_with_config<R, T>(mut reader: R, config: &ParserConfig) -> Result<T>
 where
     R: io::Read,
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let mut s = String::new();
     let _ = reader.read_to_string(&mut s).map_err(Error::Io)?;
@@ -1785,7 +1784,7 @@ where
 /// ```
 pub fn from_value<T>(value: &Value) -> Result<T>
 where
-    T: for<'de> Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     // Zero-rewalk fast path: when T == Value, the answer is just
     // `value.clone()`. The default `T::deserialize(de)` route
@@ -1950,12 +1949,12 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-impl<'de> de::Deserializer<'de> for Deserializer<'de> {
+impl<'de> serde_core::de::Deserializer<'de> for Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Null => self.wrap_err(visitor.visit_none()),
@@ -1990,7 +1989,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Bool(b) => self.wrap_err(visitor.visit_bool(*b)),
@@ -2003,28 +2002,28 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_i64(visitor)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_i64(visitor)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_i64(visitor)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Number(Number::Integer(n)) => self.wrap_err(visitor.visit_i64(*n)),
@@ -2045,28 +2044,28 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_u64(visitor)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_u64(visitor)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_u64(visitor)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Number(Number::Integer(n)) if *n >= 0 => {
@@ -2086,14 +2085,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_f64(visitor)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Number(Number::Float(n)) => self.wrap_err(visitor.visit_f64(*n)),
@@ -2107,7 +2106,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::String(s) if s.chars().count() == 1 => {
@@ -2122,7 +2121,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::String(s) => self.wrap_err(visitor.visit_str(s)),
@@ -2153,14 +2152,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_str(visitor)
     }
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::String(s) => self.wrap_err(visitor.visit_bytes(s.as_bytes())),
@@ -2187,14 +2186,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_bytes(visitor)
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Null => self.wrap_err(visitor.visit_none()),
@@ -2204,7 +2203,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Null => self.wrap_err(visitor.visit_unit()),
@@ -2217,14 +2216,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_unit(visitor)
     }
 
     fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         if name == crate::spanned::SPANNED_TYPE_NAME {
             return visitor.visit_map(SpannedMapAccess::new(self.value, self.span_ctx));
@@ -2234,7 +2233,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Sequence(seq) => {
@@ -2254,7 +2253,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_seq(visitor)
     }
@@ -2266,14 +2265,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_seq(visitor)
     }
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::Mapping(map) => {
@@ -2299,7 +2298,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         if name == crate::spanned::SPANNED_TYPE_NAME {
             return visitor.visit_map(SpannedMapAccess::new(self.value, self.span_ctx));
@@ -2314,11 +2313,11 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::String(variant) => {
-                let de: de::value::StrDeserializer<'de, Error> =
+                let de: serde_core::de::value::StrDeserializer<'de, Error> =
                     variant.as_str().into_deserializer();
                 self.wrap_err(visitor.visit_enum(de))
             }
@@ -2339,7 +2338,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self.value {
             Value::String(s) => self.wrap_err(visitor.visit_str(s)),
@@ -2349,7 +2348,7 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.wrap_err(visitor.visit_unit())
     }
@@ -2376,12 +2375,12 @@ impl<'de> ValueSeqAccess<'de> {
     }
 }
 
-impl<'de> SeqAccess<'de> for ValueSeqAccess<'de> {
+impl<'de> serde_core::de::SeqAccess<'de> for ValueSeqAccess<'de> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
     where
-        T: DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         match self.iter.next() {
             Some(value) => {
@@ -2405,7 +2404,7 @@ pub(crate) struct ValueMapAccess<'de> {
     ignore_binary_tag_for_string: bool,
     /// Mirror of the parent [`Deserializer::preserve_tags`] so
     /// nested `Value::Tagged(...)` nodes inside a mapping survive
-    /// the data-binding return path. See `de::Deserializer` docs.
+    /// the data-binding return path. See [`serde_core::de::Deserializer`] docs.
     preserve_tags: bool,
 }
 
@@ -2433,18 +2432,18 @@ impl<'de> ValueMapAccess<'de> {
     }
 }
 
-impl<'de> MapAccess<'de> for ValueMapAccess<'de> {
+impl<'de> serde_core::de::MapAccess<'de> for ValueMapAccess<'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
-        K: DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         match self.iter.next() {
             Some((key, value)) => {
                 self.value = Some(value);
                 let de = self.child_de(value);
-                let key_de: de::value::StrDeserializer<'de, Error> =
+                let key_de: serde_core::de::value::StrDeserializer<'de, Error> =
                     key.as_str().into_deserializer();
                 de.wrap_err(seed.deserialize(key_de).map(Some))
             }
@@ -2454,7 +2453,7 @@ impl<'de> MapAccess<'de> for ValueMapAccess<'de> {
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         match self.value.take() {
             Some(value) => {
@@ -2462,7 +2461,7 @@ impl<'de> MapAccess<'de> for ValueMapAccess<'de> {
                 let res = seed.deserialize(de);
                 de.wrap_err(res)
             }
-            None => Err(de::Error::custom("value is missing")),
+            None => Err(serde_core::de::Error::custom("value is missing")),
         }
     }
 }
@@ -2473,15 +2472,16 @@ struct EnumAccess<'de> {
     span_ctx: Option<&'de span_context::SpanContext>,
 }
 
-impl<'de> de::EnumAccess<'de> for EnumAccess<'de> {
+impl<'de> serde_core::de::EnumAccess<'de> for EnumAccess<'de> {
     type Error = Error;
     type Variant = VariantAccess<'de>;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
-        let de: de::value::StrDeserializer<'de, Error> = self.variant.into_deserializer();
+        let de: serde_core::de::value::StrDeserializer<'de, Error> =
+            self.variant.into_deserializer();
         let variant = seed.deserialize(de)?;
         let visitor = VariantAccess {
             value: self.value,
@@ -2496,10 +2496,11 @@ struct VariantAccess<'de> {
     span_ctx: Option<&'de span_context::SpanContext>,
 }
 
-impl<'de> de::VariantAccess<'de> for VariantAccess<'de> {
+impl<'de> serde_core::de::VariantAccess<'de> for VariantAccess<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
+        use serde_core::Deserialize;
         let de = if let Some(ctx) = self.span_ctx {
             Deserializer::with_span_context(self.value, ctx)
         } else {
@@ -2510,7 +2511,7 @@ impl<'de> de::VariantAccess<'de> for VariantAccess<'de> {
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
-        T: DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         let de = if let Some(ctx) = self.span_ctx {
             Deserializer::with_span_context(self.value, ctx)
@@ -2522,26 +2523,26 @@ impl<'de> de::VariantAccess<'de> for VariantAccess<'de> {
 
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         let de = if let Some(ctx) = self.span_ctx {
             Deserializer::with_span_context(self.value, ctx)
         } else {
             Deserializer::new(self.value)
         };
-        de::Deserializer::deserialize_seq(de, visitor)
+        serde_core::de::Deserializer::deserialize_seq(de, visitor)
     }
 
     fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         let de = if let Some(ctx) = self.span_ctx {
             Deserializer::with_span_context(self.value, ctx)
         } else {
             Deserializer::new(self.value)
         };
-        de::Deserializer::deserialize_map(de, visitor)
+        serde_core::de::Deserializer::deserialize_map(de, visitor)
     }
 }
 
@@ -2561,16 +2562,16 @@ impl<'de> SpannedMapAccess<'de> {
     }
 }
 
-impl<'de> MapAccess<'de> for SpannedMapAccess<'de> {
+impl<'de> serde_core::de::MapAccess<'de> for SpannedMapAccess<'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
-        K: DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         match self.fields.next() {
             Some(field) => {
-                use serde::de::value::BorrowedStrDeserializer;
+                use serde_core::de::value::BorrowedStrDeserializer;
                 let de: BorrowedStrDeserializer<'_, Error> = BorrowedStrDeserializer::new(field);
                 seed.deserialize(de).map(Some)
             }
@@ -2580,7 +2581,7 @@ impl<'de> MapAccess<'de> for SpannedMapAccess<'de> {
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         use crate::spanned::*;
         let last_field = SPANNED_FIELDS[SPANNED_FIELDS.len() - 1 - (self.fields.len())];

--- a/crates/noyalib/src/diagnostic.rs
+++ b/crates/noyalib/src/diagnostic.rs
@@ -8,9 +8,8 @@
 //!
 //! ```
 //! use noyalib::{from_str, Spanned, diagnostic::spanned_error};
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize)]
+//! #[derive(serde::Deserialize)]
 //! struct Cfg { port: Spanned<u16> }
 //! let yaml = "port: 80\n";
 //! let cfg: Cfg = from_str(yaml).unwrap();
@@ -72,9 +71,8 @@ impl miette::Diagnostic for SpannedDiagnostic {
 ///
 /// ```
 /// use noyalib::{from_str, Spanned, diagnostic::spanned_error};
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Cfg { port: Spanned<u16> }
 /// let yaml = "port: 80\n";
 /// let cfg: Cfg = from_str(yaml).unwrap();
@@ -108,8 +106,7 @@ pub fn spanned_error<T, M: fmt::Display>(
 ///
 /// ```rust,no_run
 /// # use noyalib::{from_str, Spanned, diagnostic::spanned_error_with_context};
-/// # use serde::Deserialize;
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Cfg {
 ///     anchor: Spanned<String>,
 ///     alias: Spanned<String>,

--- a/crates/noyalib/src/document.rs
+++ b/crates/noyalib/src/document.rs
@@ -205,9 +205,8 @@ pub fn try_load_all(input: &str) -> Result<DocumentIterator> {
 ///
 /// ```rust
 /// use noyalib::document::load_all_as;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, PartialEq)]
+/// #[derive(Debug, serde::Deserialize, PartialEq)]
 /// struct Doc {
 ///     name: String,
 /// }
@@ -366,9 +365,8 @@ impl<T> ExactSizeIterator for DocumentReadIterator<T> where
 ///
 /// ```
 /// use std::io::Cursor;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, PartialEq)]
+/// #[derive(Debug, serde::Deserialize, PartialEq)]
 /// struct Doc { id: u32 }
 ///
 /// let yaml = "id: 1\n---\nid: 2\n---\nid: 3\n";

--- a/crates/noyalib/src/document.rs
+++ b/crates/noyalib/src/document.rs
@@ -229,7 +229,7 @@ pub fn try_load_all(input: &str) -> Result<DocumentIterator> {
 /// deserialized into the target type.
 pub fn load_all_as<T>(input: &str) -> Result<Vec<T>>
 where
-    T: for<'de> serde::Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let parse_config = parser::ParseConfig::from(&ParserConfig::default());
 
@@ -325,7 +325,7 @@ impl<T> DocumentReadIterator<T> {
 #[cfg(feature = "std")]
 impl<T> Iterator for DocumentReadIterator<T>
 where
-    T: for<'de> serde::Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     type Item = Result<T>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -339,7 +339,7 @@ where
 
 #[cfg(feature = "std")]
 impl<T> ExactSizeIterator for DocumentReadIterator<T> where
-    T: for<'de> serde::Deserialize<'de> + 'static
+    T: for<'de> serde_core::Deserialize<'de> + 'static
 {
 }
 
@@ -380,7 +380,7 @@ impl<T> ExactSizeIterator for DocumentReadIterator<T> where
 pub fn read<R, T>(reader: R) -> Result<DocumentReadIterator<T>>
 where
     R: std::io::Read,
-    T: for<'de> serde::Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     read_with_config(reader, &ParserConfig::default())
 }
@@ -412,7 +412,7 @@ pub fn read_with_config<R, T>(
 ) -> Result<DocumentReadIterator<T>>
 where
     R: std::io::Read,
-    T: for<'de> serde::Deserialize<'de> + 'static,
+    T: for<'de> serde_core::Deserialize<'de> + 'static,
 {
     let mut buf = String::new();
     let _read_bytes = reader

--- a/crates/noyalib/src/error.rs
+++ b/crates/noyalib/src/error.rs
@@ -1306,13 +1306,13 @@ fn colorize_render(plain: &str) -> String {
     out
 }
 
-impl serde::ser::Error for Error {
+impl serde_core::ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Custom(msg.to_string())
     }
 }
 
-impl serde::de::Error for Error {
+impl serde_core::de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Custom(msg.to_string())
     }

--- a/crates/noyalib/src/figment.rs
+++ b/crates/noyalib/src/figment.rs
@@ -20,9 +20,8 @@
 //! use figment::providers::Format;
 //! use figment::Figment;
 //! use noyalib::figment::Yaml;
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize)]
+//! #[derive(serde::Deserialize)]
 //! struct Config {
 //!     name: String,
 //!     port: u16,

--- a/crates/noyalib/src/figment.rs
+++ b/crates/noyalib/src/figment.rs
@@ -66,7 +66,7 @@ impl Format for Yaml {
 
     const NAME: &'static str = "YAML";
 
-    fn from_str<T: serde::de::DeserializeOwned>(s: &str) -> Result<T, Self::Error> {
+    fn from_str<T: serde_core::de::DeserializeOwned>(s: &str) -> Result<T, Self::Error> {
         // figment's `Format::from_str` constrains `T:
         // DeserializeOwned` only — no `'static`. Bypass noyalib's
         // public `from_str` (which adds `'static` to enable the

--- a/crates/noyalib/src/flattened.rs
+++ b/crates/noyalib/src/flattened.rs
@@ -41,14 +41,13 @@ use crate::value::Value;
 ///
 /// ```
 /// use noyalib::{from_str, Flattened, Value};
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Inner {
 ///     port: u16,
 /// }
 ///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     name: String,
 ///     // Capture both the typed view and the raw mapping so the

--- a/crates/noyalib/src/flattened.rs
+++ b/crates/noyalib/src/flattened.rs
@@ -132,13 +132,13 @@ impl<T> core::ops::Deref for Flattened<T> {
     }
 }
 
-impl<'de, T> serde::Deserialize<'de> for Flattened<T>
+impl<'de, T> serde_core::Deserialize<'de> for Flattened<T>
 where
-    T: for<'a> serde::Deserialize<'a> + 'static,
+    T: for<'a> serde_core::Deserialize<'a> + 'static,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         // Step 1: capture the source as a typed `Value` tree —
         // every key the source supplied is preserved.
@@ -146,18 +146,18 @@ where
         // Step 2: re-run `T::deserialize` against the captured
         // value via `from_value`. The HRTB on `T` lets the
         // returned `T` outlive the temporary `&raw` borrow.
-        let value = crate::from_value::<T>(&raw).map_err(serde::de::Error::custom)?;
+        let value = crate::from_value::<T>(&raw).map_err(serde_core::de::Error::custom)?;
         Ok(Flattened { value, raw })
     }
 }
 
-impl<T> serde::Serialize for Flattened<T>
+impl<T> serde_core::Serialize for Flattened<T>
 where
-    T: serde::Serialize,
+    T: serde_core::Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         // Round-trip transparency: serializing a `Flattened<T>`
         // is equivalent to serializing the typed view alone. This

--- a/crates/noyalib/src/fmt.rs
+++ b/crates/noyalib/src/fmt.rs
@@ -23,8 +23,6 @@
 use crate::prelude::*;
 use core::ops::Deref;
 
-use serde::{Deserialize, Serialize};
-
 // Magic names used as newtype struct sentinels.
 // The serializer intercepts these to apply formatting hints.
 pub(crate) const MAGIC_FLOW_SEQ: &str = "__noya_flow_seq";
@@ -84,19 +82,19 @@ impl<T> FlowSeq<T> {
     }
 }
 
-impl<T: Serialize> Serialize for FlowSeq<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for FlowSeq<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_FLOW_SEQ, &self.0)
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for FlowSeq<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for FlowSeq<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(FlowSeq)
     }
@@ -156,19 +154,19 @@ impl<T> FlowMap<T> {
     }
 }
 
-impl<T: Serialize> Serialize for FlowMap<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for FlowMap<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_FLOW_MAP, &self.0)
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for FlowMap<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for FlowMap<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(FlowMap)
     }
@@ -233,10 +231,10 @@ impl<'a> LitStr<'a> {
     }
 }
 
-impl Serialize for LitStr<'_> {
+impl serde_core::Serialize for LitStr<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_LIT_STR, self.0)
     }
@@ -294,19 +292,19 @@ impl LitString {
     }
 }
 
-impl Serialize for LitString {
+impl serde_core::Serialize for LitString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_LIT_STR, &self.0)
     }
 }
 
-impl<'de> Deserialize<'de> for LitString {
+impl<'de> serde_core::Deserialize<'de> for LitString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(LitString)
     }
@@ -369,10 +367,10 @@ impl<'a> FoldStr<'a> {
     }
 }
 
-impl Serialize for FoldStr<'_> {
+impl serde_core::Serialize for FoldStr<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_FOLD_STR, self.0)
     }
@@ -429,19 +427,19 @@ impl FoldString {
     }
 }
 
-impl Serialize for FoldString {
+impl serde_core::Serialize for FoldString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_FOLD_STR, &self.0)
     }
 }
 
-impl<'de> Deserialize<'de> for FoldString {
+impl<'de> serde_core::Deserialize<'de> for FoldString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(FoldString)
     }
@@ -520,19 +518,19 @@ impl<T> Deref for Commented<T> {
     }
 }
 
-impl<T: Serialize> Serialize for Commented<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for Commented<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
-        use serde::ser::SerializeTuple;
+        use serde_core::ser::SerializeTuple;
         // Serialize as a tuple (value, comment) wrapped in the magic newtype
         struct Inner<'a, T>(&'a T, &'a str);
 
-        impl<T: Serialize> Serialize for Inner<'_, T> {
+        impl<T: serde_core::Serialize> serde_core::Serialize for Inner<'_, T> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
-                S: serde::Serializer,
+                S: serde_core::Serializer,
             {
                 let mut tup = serializer.serialize_tuple(2)?;
                 tup.serialize_element(self.0)?;
@@ -545,10 +543,10 @@ impl<T: Serialize> Serialize for Commented<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for Commented<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for Commented<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         // Note: comments are serialization-only metadata and cannot survive a
         // roundtrip through YAML. Deserializing always produces an empty comment.
@@ -604,19 +602,19 @@ impl<T> SpaceAfter<T> {
     }
 }
 
-impl<T: Serialize> Serialize for SpaceAfter<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for SpaceAfter<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         serializer.serialize_newtype_struct(MAGIC_SPACE_AFTER, &self.0)
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for SpaceAfter<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for SpaceAfter<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         T::deserialize(deserializer).map(SpaceAfter)
     }

--- a/crates/noyalib/src/fmt.rs
+++ b/crates/noyalib/src/fmt.rs
@@ -9,9 +9,8 @@
 //!
 //! ```rust
 //! use noyalib::fmt::{FlowSeq, LitString};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize)]
+//! #[derive(serde::Serialize, serde::Deserialize)]
 //! struct Config {
 //!     tags: FlowSeq<Vec<String>>,
 //!     script: LitString,
@@ -43,8 +42,7 @@ pub(crate) const MAGIC_ANCHOR_REF: &str = "__noya_anchor_ref";
 ///
 /// ```
 /// use noyalib::{to_string, FlowSeq};
-/// use serde::Serialize;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { v: FlowSeq<Vec<i32>> }
 /// let yaml = to_string(&Doc { v: FlowSeq(vec![1, 2]) }).unwrap();
 /// assert!(yaml.contains("["));
@@ -110,9 +108,8 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for FlowSeq<T> {
 ///
 /// ```
 /// use noyalib::{to_string, FlowMap};
-/// use serde::Serialize;
 /// use std::collections::BTreeMap;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { m: FlowMap<BTreeMap<String, i32>> }
 /// let mut m = BTreeMap::new();
 /// let _ = m.insert("a".into(), 1);
@@ -462,8 +459,7 @@ impl<'de> Deserialize<'de> for FoldString {
 ///
 /// ```
 /// use noyalib::{to_string, Commented};
-/// use serde::Serialize;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { v: Commented<i32> }
 /// let yaml = to_string(&Doc { v: Commented::new(42, "meaning") }).unwrap();
 /// assert!(yaml.contains("# meaning"));

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -31,9 +31,8 @@
 //!
 //! ```rust
 //! use noyalib::{from_str, to_string};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Config {
 //!     name: String,
 //!     port: u16,

--- a/crates/noyalib/src/parallel.rs
+++ b/crates/noyalib/src/parallel.rs
@@ -192,7 +192,6 @@ pub fn split(input: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
 
     #[test]
     fn split_separates_three_records() {
@@ -250,7 +249,7 @@ mod tests {
 
     #[test]
     fn parse_round_trips_typed_records() {
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Record {
             id: u32,
         }
@@ -273,7 +272,7 @@ mod tests {
 
     #[test]
     fn parse_propagates_first_error() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         #[allow(dead_code)]
         struct Record {
             id: u32,
@@ -294,7 +293,7 @@ mod tests {
             yaml.push_str(&format!("---\nid: {i}\nname: record-{i}\n"));
         }
 
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Record {
             id: u32,
             name: String,

--- a/crates/noyalib/src/parallel.rs
+++ b/crates/noyalib/src/parallel.rs
@@ -66,7 +66,6 @@
 
 use crate::error::Result;
 use rayon::prelude::*;
-use serde::de::DeserializeOwned;
 
 /// Deserialise every YAML document in `input` into `T`, parsing
 /// in parallel via Rayon's global thread pool.
@@ -96,7 +95,7 @@ use serde::de::DeserializeOwned;
 /// ```
 pub fn parse<T>(input: &str) -> Result<Vec<T>>
 where
-    T: DeserializeOwned + Send + 'static,
+    T: serde_core::de::DeserializeOwned + Send + 'static,
 {
     let chunks = split(input);
     chunks

--- a/crates/noyalib/src/robotics.rs
+++ b/crates/noyalib/src/robotics.rs
@@ -18,8 +18,6 @@
 
 use core::fmt;
 
-use serde::Deserialize;
-
 /// A float that rejects values outside f64's precise representation range.
 ///
 /// The round-trip invariant is: if a value loses precision when converted
@@ -81,13 +79,13 @@ impl TryFrom<f64> for StrictFloat {
     }
 }
 
-impl<'de> Deserialize<'de> for StrictFloat {
+impl<'de> serde_core::Deserialize<'de> for StrictFloat {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         let v = f64::deserialize(deserializer)?;
-        StrictFloat::try_from(v).map_err(serde::de::Error::custom)
+        StrictFloat::try_from(v).map_err(serde_core::de::Error::custom)
     }
 }
 
@@ -123,10 +121,10 @@ impl StrictFloat {
 #[serde(transparent)]
 pub struct Radians(pub f64);
 
-impl<'de> Deserialize<'de> for Radians {
+impl<'de> serde_core::Deserialize<'de> for Radians {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         let degrees = f64::deserialize(deserializer)?;
         Ok(Radians(degrees.to_radians()))

--- a/crates/noyalib/src/robotics.rs
+++ b/crates/noyalib/src/robotics.rs
@@ -18,7 +18,7 @@
 
 use core::fmt;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// A float that rejects values outside f64's precise representation range.
 ///
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 /// let result: Result<StrictFloat, _> = noyalib::from_str(".inf");
 /// assert!(result.is_err());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(transparent)]
 pub struct StrictFloat(f64);
 
@@ -119,7 +119,7 @@ impl StrictFloat {
 /// let r: Radians = noyalib::from_str("180.0").unwrap();
 /// assert!((r.0 - std::f64::consts::PI).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(transparent)]
 pub struct Radians(pub f64);
 
@@ -146,7 +146,7 @@ impl<'de> Deserialize<'de> for Radians {
 /// let d: Degrees = noyalib::from_str("90.0").unwrap();
 /// assert!((d.0 - 90.0).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Degrees(pub f64);
 

--- a/crates/noyalib/src/schema_codegen.rs
+++ b/crates/noyalib/src/schema_codegen.rs
@@ -24,9 +24,8 @@
 //!
 //! ```
 //! use noyalib::{schema_for, schema_for_yaml, JsonSchema};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, JsonSchema)]
+//! #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 //! struct ServerConfig {
 //!     /// Port the server binds on.
 //!     port: u16,
@@ -168,9 +167,8 @@ pub fn schema_for_yaml<T: JsonSchema>() -> Result<String> {
 ///
 /// ```
 /// use noyalib::{schema_for, JsonSchema, Value};
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Serialize, Deserialize, JsonSchema)]
+/// #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 /// struct Envelope {
 ///     id: String,
 ///     payload: Value,
@@ -223,9 +221,8 @@ impl JsonSchema for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Cfg {
         port: u16,
@@ -264,7 +261,7 @@ mod tests {
         assert_eq!(port["maximum"].as_i64(), Some(65_535));
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct WithDoc {
         /// Bound TCP port.
@@ -278,7 +275,7 @@ mod tests {
         assert_eq!(desc, Some("Bound TCP port."));
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct WithDefault {
         port: u16,
@@ -301,7 +298,7 @@ mod tests {
         );
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Renamed {
         #[serde(rename = "bind_port")]

--- a/crates/noyalib/src/schema_validate.rs
+++ b/crates/noyalib/src/schema_validate.rs
@@ -418,9 +418,8 @@ properties:
     fn schema_for_codegen_round_trip_validates_self() {
         // Phase 3.1 + 3.2 together — derive JsonSchema, emit, then
         // validate sample data against the emitted schema.
-        use serde::{Deserialize, Serialize};
 
-        #[derive(Serialize, Deserialize, crate::JsonSchema)]
+        #[derive(serde::Serialize, serde::Deserialize, crate::JsonSchema)]
         #[allow(dead_code)]
         struct Cfg {
             port: u16,

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -259,9 +259,7 @@ impl SerializerConfig {
 /// # Examples
 ///
 /// ```rust
-/// use serde::Serialize;
-///
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Config {
 ///     name: String,
 ///     port: u16,
@@ -298,9 +296,8 @@ where
 ///
 /// ```rust
 /// use noyalib::SerializerConfig;
-/// use serde::Serialize;
 ///
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Config {
 ///     name: String,
 ///     port: u16,

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -6,8 +6,6 @@
 use crate::prelude::*;
 use core::fmt::Write as _;
 
-use serde::ser::{self, Serialize};
-
 use crate::error::{Error, Result};
 use crate::value::{Mapping, Number, Sequence, Tag, TaggedValue, Value};
 
@@ -276,7 +274,7 @@ impl SerializerConfig {
 /// ```
 pub fn to_string<T>(value: &T) -> Result<String>
 where
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let v = to_value(value)?;
     value_to_string(&v, &SerializerConfig::default())
@@ -317,7 +315,7 @@ where
 /// ```
 pub fn to_string_with_config<T>(value: &T, config: &SerializerConfig) -> Result<String>
 where
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let v = to_value(value)?;
     value_to_string(&v, config)
@@ -337,7 +335,7 @@ where
 pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: std::io::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     to_writer_with_config(writer, value, &SerializerConfig::default())
 }
@@ -353,7 +351,7 @@ where
 pub fn to_writer_with_config<W, T>(writer: W, value: &T, config: &SerializerConfig) -> Result<()>
 where
     W: std::io::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let s = to_string_with_config(value, config)?;
     let mut writer = writer;
@@ -393,7 +391,7 @@ where
 #[cfg(feature = "std")]
 pub fn to_string_tracking_shared<T>(value: &T) -> Result<String>
 where
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     to_string_tracking_shared_with_config(value, &SerializerConfig::default())
 }
@@ -411,7 +409,7 @@ pub fn to_string_tracking_shared_with_config<T>(
     config: &SerializerConfig,
 ) -> Result<String>
 where
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let _scope = crate::anchors::shared_tracking::AnchorScope::enter();
     to_string_with_config(value, config)
@@ -429,7 +427,7 @@ where
 pub fn to_writer_tracking_shared<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: std::io::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     to_writer_tracking_shared_with_config(writer, value, &SerializerConfig::default())
 }
@@ -450,7 +448,7 @@ pub fn to_writer_tracking_shared_with_config<W, T>(
 ) -> Result<()>
 where
     W: std::io::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let s = to_string_tracking_shared_with_config(value, config)?;
     let mut writer = writer;
@@ -469,7 +467,7 @@ where
 pub fn to_fmt_writer<W, T>(writer: &mut W, value: &T) -> Result<()>
 where
     W: fmt::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     to_fmt_writer_with_config(writer, value, &SerializerConfig::default())
 }
@@ -489,7 +487,7 @@ pub fn to_fmt_writer_with_config<W, T>(
 ) -> Result<()>
 where
     W: fmt::Write,
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     let s = to_string_with_config(value, config)?;
     writer
@@ -522,7 +520,7 @@ where
 ///   conversions that don't fit the structured variants.
 pub fn to_value<T>(value: &T) -> Result<Value>
 where
-    T: ?Sized + Serialize,
+    T: ?Sized + serde_core::Serialize,
 {
     // No tag-preserving fast-path here: the public `to_value` /
     // `to_string` family keeps `T: ?Sized + Serialize` so callers
@@ -1330,7 +1328,7 @@ fn write_folded_block(output: &mut String, s: &str, indent: usize, config: &Seri
 /// let yaml = noyalib::to_string_multi(&docs).unwrap();
 /// assert!(yaml.contains("---"));
 /// ```
-pub fn to_string_multi<T: Serialize>(values: &[T]) -> Result<String> {
+pub fn to_string_multi<T: serde_core::Serialize>(values: &[T]) -> Result<String> {
     to_string_multi_with_config(values, &SerializerConfig::default())
 }
 
@@ -1340,7 +1338,7 @@ pub fn to_string_multi<T: Serialize>(values: &[T]) -> Result<String> {
 /// # Errors
 ///
 /// All variants documented on [`to_string_with_config`].
-pub fn to_string_multi_with_config<T: Serialize>(
+pub fn to_string_multi_with_config<T: serde_core::Serialize>(
     values: &[T],
     config: &SerializerConfig,
 ) -> Result<String> {
@@ -1363,7 +1361,10 @@ pub fn to_string_multi_with_config<T: Serialize>(
 ///
 /// Returns an error if any value cannot be serialized or writing fails.
 #[cfg(feature = "std")]
-pub fn to_writer_multi<W: std::io::Write, T: Serialize>(writer: W, values: &[T]) -> Result<()> {
+pub fn to_writer_multi<W: std::io::Write, T: serde_core::Serialize>(
+    writer: W,
+    values: &[T],
+) -> Result<()> {
     to_writer_multi_with_config(writer, values, &SerializerConfig::default())
 }
 
@@ -1374,7 +1375,7 @@ pub fn to_writer_multi<W: std::io::Write, T: Serialize>(writer: W, values: &[T])
 ///
 /// Returns an error if any value cannot be serialized or writing fails.
 #[cfg(feature = "std")]
-pub fn to_writer_multi_with_config<W: std::io::Write, T: Serialize>(
+pub fn to_writer_multi_with_config<W: std::io::Write, T: serde_core::Serialize>(
     writer: W,
     values: &[T],
     config: &SerializerConfig,
@@ -1389,7 +1390,7 @@ pub fn to_writer_multi_with_config<W: std::io::Write, T: Serialize>(
 #[derive(Debug, Copy, Clone)]
 pub struct Serializer;
 
-impl ser::Serializer for Serializer {
+impl serde_core::ser::Serializer for Serializer {
     type Ok = Value;
     type Error = Error;
 
@@ -1481,7 +1482,7 @@ impl ser::Serializer for Serializer {
 
     fn serialize_some<T>(self, value: &T) -> Result<Value>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         value.serialize(self)
     }
@@ -1505,7 +1506,7 @@ impl ser::Serializer for Serializer {
 
     fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<Value>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         // Intercept formatting hint magic names
         match name {
@@ -1549,7 +1550,7 @@ impl ser::Serializer for Serializer {
         value: &T,
     ) -> Result<Value>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         let mut map = Mapping::new();
         let _ = map.insert(variant.to_owned(), value.serialize(Serializer)?);
@@ -1618,13 +1619,13 @@ pub struct SerializeSeq {
     vec: Vec<Value>,
 }
 
-impl ser::SerializeSeq for SerializeSeq {
+impl serde_core::ser::SerializeSeq for SerializeSeq {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         self.vec.push(value.serialize(Serializer)?);
         Ok(())
@@ -1635,35 +1636,35 @@ impl ser::SerializeSeq for SerializeSeq {
     }
 }
 
-impl ser::SerializeTuple for SerializeSeq {
+impl serde_core::ser::SerializeTuple for SerializeSeq {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
-        ser::SerializeSeq::serialize_element(self, value)
+        serde_core::ser::SerializeSeq::serialize_element(self, value)
     }
 
     fn end(self) -> Result<Value> {
-        ser::SerializeSeq::end(self)
+        serde_core::ser::SerializeSeq::end(self)
     }
 }
 
-impl ser::SerializeTupleStruct for SerializeSeq {
+impl serde_core::ser::SerializeTupleStruct for SerializeSeq {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
-        ser::SerializeSeq::serialize_element(self, value)
+        serde_core::ser::SerializeSeq::serialize_element(self, value)
     }
 
     fn end(self) -> Result<Value> {
-        ser::SerializeSeq::end(self)
+        serde_core::ser::SerializeSeq::end(self)
     }
 }
 
@@ -1674,13 +1675,13 @@ pub struct SerializeTupleVariant {
     vec: Vec<Value>,
 }
 
-impl ser::SerializeTupleVariant for SerializeTupleVariant {
+impl serde_core::ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         self.vec.push(value.serialize(Serializer)?);
         Ok(())
@@ -1700,13 +1701,13 @@ pub struct SerializeMap {
     key: Option<String>,
 }
 
-impl ser::SerializeMap for SerializeMap {
+impl serde_core::ser::SerializeMap for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         let key_value = key.serialize(Serializer)?;
         let key_str = match key_value {
@@ -1721,7 +1722,7 @@ impl ser::SerializeMap for SerializeMap {
 
     fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         let key = self
             .key
@@ -1736,13 +1737,13 @@ impl ser::SerializeMap for SerializeMap {
     }
 }
 
-impl ser::SerializeStruct for SerializeMap {
+impl serde_core::ser::SerializeStruct for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         let _ = self
             .map
@@ -1762,13 +1763,13 @@ pub struct SerializeStructVariant {
     map: Mapping,
 }
 
-impl ser::SerializeStructVariant for SerializeStructVariant {
+impl serde_core::ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = Value;
     type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: ?Sized + Serialize,
+        T: ?Sized + serde_core::Serialize,
     {
         let _ = self
             .map

--- a/crates/noyalib/src/spanned.rs
+++ b/crates/noyalib/src/spanned.rs
@@ -47,9 +47,8 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 ///
 /// ```rust
 /// use noyalib::Spanned;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Serialize, Deserialize, Debug)]
+/// #[derive(serde::Serialize, serde::Deserialize, Debug)]
 /// struct Config {
 ///     port: Spanned<u16>,
 /// }
@@ -71,7 +70,7 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 ///
 /// ```rust,ignore
 /// // Works.
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Config {
 ///     name: String,
 ///     #[serde(flatten)]
@@ -79,7 +78,7 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 /// }
 ///
 /// // Errors with a clear message at deserialize time.
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct AlsoConfig {
 ///     name: String,
 ///     #[serde(flatten)]

--- a/crates/noyalib/src/spanned.rs
+++ b/crates/noyalib/src/spanned.rs
@@ -9,8 +9,6 @@
 use crate::prelude::*;
 use core::ops::Deref;
 
-use serde::{Deserialize, Serialize};
-
 use crate::error::Location;
 
 /// Sentinel struct name used by the deserializer to detect `Spanned<T>`.
@@ -192,20 +190,20 @@ impl<T> From<T> for Spanned<T> {
     }
 }
 
-impl<T: Serialize> Serialize for Spanned<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for Spanned<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         // Transparent: just serialize the inner value
         self.value.serialize(serializer)
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for Spanned<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::Deserialize<'de> for Spanned<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         deserializer.deserialize_struct(
             SPANNED_TYPE_NAME,
@@ -217,7 +215,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Spanned<T> {
 
 struct SpannedVisitor<T>(core::marker::PhantomData<T>);
 
-impl<'de, T: Deserialize<'de>> serde::de::Visitor<'de> for SpannedVisitor<T> {
+impl<'de, T: serde_core::Deserialize<'de>> serde_core::de::Visitor<'de> for SpannedVisitor<T> {
     type Value = Spanned<T>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -226,7 +224,7 @@ impl<'de, T: Deserialize<'de>> serde::de::Visitor<'de> for SpannedVisitor<T> {
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
-        A: serde::de::MapAccess<'de>,
+        A: serde_core::de::MapAccess<'de>,
     {
         let mut start_line: Option<usize> = None;
         let mut start_column: Option<usize> = None;
@@ -257,16 +255,16 @@ impl<'de, T: Deserialize<'de>> serde::de::Visitor<'de> for SpannedVisitor<T> {
                 SPANNED_FIELD_VALUE => value = Some(map.next_value()?),
                 _ => {
                     // Unknown field — skip
-                    let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                    let _ = map.next_value::<serde_core::de::IgnoredAny>()?;
                 }
             }
         }
 
         let value = value.ok_or_else(|| {
             if saw_any_key {
-                serde::de::Error::missing_field(SPANNED_FIELD_VALUE)
+                serde_core::de::Error::missing_field(SPANNED_FIELD_VALUE)
             } else {
-                serde::de::Error::custom(
+                serde_core::de::Error::custom(
                     "Spanned<T> can not be deserialized via `#[serde(flatten)]` — \
                      serde's FlatStructAccess filters residue entries by the field \
                      name list, and Spanned uses internal magic field names that \

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -11,8 +11,7 @@
 use crate::prelude::*;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Deserialize;
-use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
+use serde_core::de::IntoDeserializer;
 use smallvec::SmallVec;
 
 use crate::error::{Error, Result, closest_name};
@@ -603,12 +602,12 @@ impl<'a> StreamingDeserializer<'a> {
     }
 }
 
-impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
+impl<'de> serde_core::de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // `deserialize_any` is used by `Value` and other type-erased
@@ -681,7 +680,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.next_event()? {
@@ -697,7 +696,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.next_event()? {
@@ -724,7 +723,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.next_event()? {
@@ -746,7 +745,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.next_event()? {
@@ -764,7 +763,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // A tag (`!!str`, `!custom`, …) routes through the AST so the
@@ -829,14 +828,14 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_str(visitor)
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.peek_event()? {
@@ -855,7 +854,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, style, .. } = self.next_event()? {
@@ -871,7 +870,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         if name == crate::spanned::SPANNED_TYPE_NAME {
             return Err(self.fallback());
@@ -906,7 +905,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // Tagged sequences route through the AST fallback so the tag is
@@ -941,7 +940,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // Tagged mappings route through the AST fallback so the tag is
@@ -983,7 +982,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Some(t) = self.take_tag_from_current() {
@@ -1026,7 +1025,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         if let Event::Scalar { value, .. } = self.next_event()? {
@@ -1043,7 +1042,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_value()?;
         visitor.visit_unit()
@@ -1051,7 +1050,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // Accept `null` / `~` / empty scalar — delegate to deserialize_unit.
@@ -1065,7 +1064,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
         visitor: V,
     ) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         // `Spanned<T>` is routed through this method by its Deserialize
         // impl. The streaming path does not carry source-span context,
@@ -1078,7 +1077,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.skip_to_content()?;
         // YAML 1.2.2 §10.4: a `!!binary`-tagged scalar carries an
@@ -1138,12 +1137,12 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
 
     fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         self.deserialize_bytes(visitor)
     }
 
-    serde::forward_to_deserialize_any! {
+    serde_core::forward_to_deserialize_any! {
         i8 i16 i32 u8 u16 u32 f32 char
         tuple tuple_struct
     }
@@ -1155,11 +1154,11 @@ struct StreamingSeqAccess<'a, 'de> {
     count: usize,
 }
 
-impl<'de> SeqAccess<'de> for StreamingSeqAccess<'_, 'de> {
+impl<'de> serde_core::de::SeqAccess<'de> for StreamingSeqAccess<'_, 'de> {
     type Error = Error;
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
     where
-        T: DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         // Symmetric guard with `StreamingMapAccess::next_key_seed`
         // — callers that re-invoke `next_element` after the
@@ -1217,11 +1216,11 @@ struct StreamingMapAccess<'a, 'de> {
     seen_keys: FxHashSet<String>,
 }
 
-impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
+impl<'de> serde_core::de::MapAccess<'de> for StreamingMapAccess<'_, 'de> {
     type Error = Error;
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
-        K: DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         // Guard against serde visitors (e.g. `noyalib::Value`'s
         // `ValueVisitor::visit_map`) that call `next_key` again
@@ -1338,7 +1337,7 @@ impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
     }
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         // Symmetric guard with `next_key_seed`. Callers that
         // misuse the MapAccess contract (e.g. invoking
@@ -1382,14 +1381,14 @@ struct StreamingEnumAccess<'a, 'de> {
     de: &'a mut StreamingDeserializer<'de>,
     variant: String,
 }
-impl<'a, 'de> de::EnumAccess<'de> for StreamingEnumAccess<'a, 'de> {
+impl<'a, 'de> serde_core::de::EnumAccess<'de> for StreamingEnumAccess<'a, 'de> {
     type Error = Error;
     type Variant = StreamingVariantAccess<'a, 'de>;
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
-        let de = de::value::StringDeserializer::<Error>::new(self.variant);
+        let de = serde_core::de::value::StringDeserializer::<Error>::new(self.variant);
         let variant = seed.deserialize(de)?;
         Ok((variant, StreamingVariantAccess { de: self.de }))
     }
@@ -1398,7 +1397,7 @@ impl<'a, 'de> de::EnumAccess<'de> for StreamingEnumAccess<'a, 'de> {
 struct StreamingVariantAccess<'a, 'de> {
     de: &'a mut StreamingDeserializer<'de>,
 }
-impl<'de> de::VariantAccess<'de> for StreamingVariantAccess<'_, 'de> {
+impl<'de> serde_core::de::VariantAccess<'de> for StreamingVariantAccess<'_, 'de> {
     type Error = Error;
     fn unit_variant(self) -> Result<()> {
         let ev = self.de.next_event()?;
@@ -1413,7 +1412,7 @@ impl<'de> de::VariantAccess<'de> for StreamingVariantAccess<'_, 'de> {
     }
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
-        T: DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         let res = seed.deserialize(&mut *self.de)?;
         if !matches!(self.de.next_event()?, Event::MappingEnd { .. }) {
@@ -1423,9 +1422,9 @@ impl<'de> de::VariantAccess<'de> for StreamingVariantAccess<'_, 'de> {
     }
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        let res = de::Deserializer::deserialize_seq(&mut *self.de, visitor)?;
+        let res = serde_core::de::Deserializer::deserialize_seq(&mut *self.de, visitor)?;
         if !matches!(self.de.next_event()?, Event::MappingEnd { .. }) {
             return Err(Error::Invalid("expected mapping end".into()));
         }
@@ -1433,9 +1432,9 @@ impl<'de> de::VariantAccess<'de> for StreamingVariantAccess<'_, 'de> {
     }
     fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        let res = de::Deserializer::deserialize_map(&mut *self.de, visitor)?;
+        let res = serde_core::de::Deserializer::deserialize_map(&mut *self.de, visitor)?;
         if !matches!(self.de.next_event()?, Event::MappingEnd { .. }) {
             return Err(Error::Invalid("expected mapping end".into()));
         }
@@ -1449,11 +1448,11 @@ struct StreamingTagMapAccess<'a, 'de> {
     tag: (String, String),
     done: bool,
 }
-impl<'de> MapAccess<'de> for StreamingTagMapAccess<'_, 'de> {
+impl<'de> serde_core::de::MapAccess<'de> for StreamingTagMapAccess<'_, 'de> {
     type Error = Error;
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
-        K: DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         if self.done {
             Ok(None)
@@ -1463,13 +1462,13 @@ impl<'de> MapAccess<'de> for StreamingTagMapAccess<'_, 'de> {
             } else {
                 format!("{}{}", self.tag.0, self.tag.1)
             };
-            let de = de::value::StringDeserializer::<Error>::new(full);
+            let de = serde_core::de::value::StringDeserializer::<Error>::new(full);
             seed.deserialize(de).map(Some)
         }
     }
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         self.done = true;
         seed.deserialize(&mut *self.de)
@@ -1481,19 +1480,19 @@ struct StreamingTagEnumAccess<'a, 'de> {
     de: &'a mut StreamingDeserializer<'de>,
     tag: (String, String),
 }
-impl<'a, 'de> de::EnumAccess<'de> for StreamingTagEnumAccess<'a, 'de> {
+impl<'a, 'de> serde_core::de::EnumAccess<'de> for StreamingTagEnumAccess<'a, 'de> {
     type Error = Error;
     type Variant = StreamingTagVariantAccess<'a, 'de>;
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
     where
-        V: DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         let full = if self.tag.0 == "!" {
             format!("!{}", self.tag.1)
         } else {
             format!("{}{}", self.tag.0, self.tag.1)
         };
-        let de = de::value::StringDeserializer::<Error>::new(full);
+        let de = serde_core::de::value::StringDeserializer::<Error>::new(full);
         let variant = seed.deserialize(de)?;
         Ok((variant, StreamingTagVariantAccess { de: self.de }))
     }
@@ -1503,34 +1502,34 @@ impl<'a, 'de> de::EnumAccess<'de> for StreamingTagEnumAccess<'a, 'de> {
 struct StreamingTagVariantAccess<'a, 'de> {
     de: &'a mut StreamingDeserializer<'de>,
 }
-impl<'de> de::VariantAccess<'de> for StreamingTagVariantAccess<'_, 'de> {
+impl<'de> serde_core::de::VariantAccess<'de> for StreamingTagVariantAccess<'_, 'de> {
     type Error = Error;
     fn unit_variant(self) -> Result<()> {
         self.de.skip_value()
     }
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
-        T: DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         seed.deserialize(self.de)
     }
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        de::Deserializer::deserialize_seq(self.de, visitor)
+        serde_core::de::Deserializer::deserialize_seq(self.de, visitor)
     }
     fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
-        V: Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        de::Deserializer::deserialize_map(self.de, visitor)
+        serde_core::de::Deserializer::deserialize_map(self.de, visitor)
     }
 }
 
 pub(crate) fn from_str_streaming<T>(s: &str, config: &crate::de::ParserConfig) -> Option<Result<T>>
 where
-    T: for<'de> Deserialize<'de>,
+    T: for<'de> serde_core::Deserialize<'de>,
 {
     let parse_config = ParseConfig::from(config);
     if s.len() > parse_config.max_document_length {

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -59,7 +59,7 @@ pub(crate) enum Scalar<'a> {
 /// use noyalib::StreamingDeserializer;
 /// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Doc { k: i32 }
 ///
 /// let mut de = StreamingDeserializer::new("k: 42\n");
@@ -147,7 +147,7 @@ impl<'a> StreamingDeserializer<'a> {
     /// use serde::Deserialize;
     /// use std::sync::Arc;
     ///
-    /// #[derive(Deserialize)]
+    /// #[derive(serde::Deserialize)]
     /// struct Temp(f64);
     ///
     /// let reg = Arc::new(TagRegistry::new().with("!Celsius"));

--- a/crates/noyalib/src/tag_registry.rs
+++ b/crates/noyalib/src/tag_registry.rs
@@ -19,10 +19,9 @@
 //!
 //! ```
 //! use noyalib::{from_str_with_config, ParserConfig, TagRegistry};
-//! use serde::Deserialize;
 //! use std::sync::Arc;
 //!
-//! #[derive(Debug, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Deserialize, PartialEq)]
 //! struct Celsius(f64);
 //!
 //! let registry = Arc::new(TagRegistry::new().with("!Celsius"));

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -357,10 +357,9 @@ fn find_doc_boundary(bytes: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
     use bytes::BytesMut;
-    use serde::Deserialize;
     use tokio::io::BufReader;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Pkg {
         name: String,
         version: String,

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -49,7 +49,6 @@
 
 use bytes::BytesMut;
 use core::marker::PhantomData;
-use serde::de::DeserializeOwned;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::codec::Decoder;
 
@@ -74,7 +73,7 @@ where
     // `from_str_with_config` — async I/O cannot generally hand
     // out a borrowed `&[u8]` that outlives the await point, so
     // dropping the bound here would only paper over the issue.
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     from_async_reader_with_config(reader, &ParserConfig::default()).await
 }
@@ -100,7 +99,7 @@ where
     // `from_str_with_config` — async I/O cannot generally hand
     // out a borrowed `&[u8]` that outlives the await point, so
     // dropping the bound here would only paper over the issue.
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     let buf = drain_bounded(reader, config.max_document_length).await?;
     let buf = strip_bom_owned(buf);
@@ -125,7 +124,7 @@ where
     // `from_str_with_config` — async I/O cannot generally hand
     // out a borrowed `&[u8]` that outlives the await point, so
     // dropping the bound here would only paper over the issue.
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     from_async_reader_multi_with_config(reader, &ParserConfig::default()).await
 }
@@ -156,7 +155,7 @@ where
     // `from_str_with_config` — async I/O cannot generally hand
     // out a borrowed `&[u8]` that outlives the await point, so
     // dropping the bound here would only paper over the issue.
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     let buf = drain_bounded(reader, config.max_document_length).await?;
     let buf = strip_bom_owned(buf);
@@ -274,7 +273,7 @@ where
     // `from_str_with_config` — async I/O cannot generally hand
     // out a borrowed `&[u8]` that outlives the await point, so
     // dropping the bound here would only paper over the issue.
-    T: DeserializeOwned + 'static,
+    T: serde_core::de::DeserializeOwned + 'static,
 {
     type Item = T;
     type Error = Error;

--- a/crates/noyalib/src/validated.rs
+++ b/crates/noyalib/src/validated.rs
@@ -12,9 +12,8 @@
 //! ```rust
 //! use noyalib::Validated;
 //! use garde::Validate;
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize, Validate)]
+//! #[derive(serde::Deserialize, Validate)]
 //! struct Server {
 //!     #[garde(length(min = 1, max = 255))]
 //!     host: String,
@@ -40,9 +39,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// ```
 /// use noyalib::Validated;
 /// use garde::Validate;
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize, Validate)]
+/// #[derive(serde::Deserialize, Validate)]
 /// struct Port {
 ///     #[garde(range(min = 1024))]
 ///     n: u16,
@@ -62,10 +60,9 @@ pub struct Validated<T>(pub T);
 ///
 /// ```
 /// use noyalib::ValidatedValidator;
-/// use serde::Deserialize;
 /// use validator::Validate;
 ///
-/// #[derive(Deserialize, Validate)]
+/// #[derive(serde::Deserialize, Validate)]
 /// struct Port {
 ///     #[validate(range(min = 1024))]
 ///     n: u16,

--- a/crates/noyalib/src/validated.rs
+++ b/crates/noyalib/src/validated.rs
@@ -28,7 +28,6 @@
 
 use crate::prelude::*;
 use core::ops::{Deref, DerefMut};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A newtype that validates its inner value using the [`garde`] crate.
 ///
@@ -159,15 +158,15 @@ impl<T> From<T> for ValidatedValidator<T> {
 }
 
 #[cfg(feature = "garde")]
-impl<'de, T> Deserialize<'de> for Validated<T>
+impl<'de, T> serde_core::Deserialize<'de> for Validated<T>
 where
-    T: Deserialize<'de> + garde::Validate<Context = ()>,
+    T: serde_core::Deserialize<'de> + garde::Validate<Context = ()>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::Error;
+        use serde_core::de::Error;
         let inner = T::deserialize(deserializer)?;
         match inner.validate_with(&()) {
             Ok(()) => Ok(Validated(inner)),
@@ -177,15 +176,15 @@ where
 }
 
 #[cfg(feature = "validator")]
-impl<'de, T> Deserialize<'de> for ValidatedValidator<T>
+impl<'de, T> serde_core::Deserialize<'de> for ValidatedValidator<T>
 where
-    T: Deserialize<'de> + validator::Validate,
+    T: serde_core::Deserialize<'de> + validator::Validate,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::Error;
+        use serde_core::de::Error;
         let inner = T::deserialize(deserializer)?;
         match inner.validate() {
             Ok(()) => Ok(ValidatedValidator(inner)),
@@ -195,20 +194,20 @@ where
 }
 
 #[cfg(feature = "garde")]
-impl<T: Serialize> Serialize for Validated<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for Validated<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde_core::Serializer,
     {
         self.0.serialize(serializer)
     }
 }
 
 #[cfg(feature = "validator")]
-impl<T: Serialize> Serialize for ValidatedValidator<T> {
+impl<T: serde_core::Serialize> serde_core::Serialize for ValidatedValidator<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde_core::Serializer,
     {
         self.0.serialize(serializer)
     }

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -120,9 +120,8 @@ impl miette::Diagnostic for ValidationDiagnostic {
 /// use noyalib::Spanned;
 /// use noyalib::validated_miette::garde_errors_to_miette;
 /// use garde::Validate;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, Validate)]
+/// #[derive(Debug, serde::Deserialize, Validate)]
 /// struct Cfg {
 ///     #[garde(range(min = 1024))]
 ///     port: u16,
@@ -160,10 +159,9 @@ pub fn garde_errors_to_miette<T>(
 /// ```ignore
 /// use noyalib::Spanned;
 /// use noyalib::validated_miette::validator_errors_to_miette;
-/// use serde::Deserialize;
 /// use validator::Validate;
 ///
-/// #[derive(Debug, Deserialize, Validate)]
+/// #[derive(Debug, serde::Deserialize, Validate)]
 /// struct Cfg {
 ///     #[validate(range(min = 1024))]
 ///     port: u16,

--- a/crates/noyalib/src/value.rs
+++ b/crates/noyalib/src/value.rs
@@ -12,7 +12,6 @@ use core::str::FromStr;
 use indexmap::IndexMap;
 use indexmap::map::{IntoIter, Iter, IterMut, Keys, Values, ValuesMut};
 use rustc_hash::FxBuildHasher;
-use serde::{Deserialize, Serialize};
 
 /// Fast IndexMap using FxBuildHasher.
 type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
@@ -798,12 +797,12 @@ impl fmt::Display for Mapping {
     }
 }
 
-impl Serialize for Mapping {
+impl serde_core::Serialize for Mapping {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
-        use serde::ser::SerializeMap;
+        use serde_core::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
             map.serialize_entry(k, v)?;
@@ -812,16 +811,14 @@ impl Serialize for Mapping {
     }
 }
 
-impl<'de> Deserialize<'de> for Mapping {
+impl<'de> serde_core::Deserialize<'de> for Mapping {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::{MapAccess, Visitor};
-
         struct MappingVisitor;
 
-        impl<'de> Visitor<'de> for MappingVisitor {
+        impl<'de> serde_core::de::Visitor<'de> for MappingVisitor {
             type Value = Mapping;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -830,7 +827,7 @@ impl<'de> Deserialize<'de> for Mapping {
 
             fn visit_map<A>(self, mut map: A) -> Result<Mapping, A::Error>
             where
-                A: MapAccess<'de>,
+                A: serde_core::de::MapAccess<'de>,
             {
                 let mut mapping = Mapping::with_capacity(map.size_hint().unwrap_or(0));
                 while let Some((key, value)) = map.next_entry::<String, Value>()? {
@@ -1280,12 +1277,12 @@ impl fmt::Display for MappingAny {
     }
 }
 
-impl Serialize for MappingAny {
+impl serde_core::Serialize for MappingAny {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
-        use serde::ser::SerializeMap;
+        use serde_core::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
             map.serialize_entry(k, v)?;
@@ -1294,16 +1291,14 @@ impl Serialize for MappingAny {
     }
 }
 
-impl<'de> Deserialize<'de> for MappingAny {
+impl<'de> serde_core::Deserialize<'de> for MappingAny {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::{MapAccess, Visitor};
-
         struct MappingAnyVisitor;
 
-        impl<'de> Visitor<'de> for MappingAnyVisitor {
+        impl<'de> serde_core::de::Visitor<'de> for MappingAnyVisitor {
             type Value = MappingAny;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1312,7 +1307,7 @@ impl<'de> Deserialize<'de> for MappingAny {
 
             fn visit_map<A>(self, mut map: A) -> Result<MappingAny, A::Error>
             where
-                A: MapAccess<'de>,
+                A: serde_core::de::MapAccess<'de>,
             {
                 let mut mapping = MappingAny::with_capacity(map.size_hint().unwrap_or(0));
                 while let Some((key, value)) = map.next_entry::<Value, Value>()? {
@@ -2121,28 +2116,26 @@ impl fmt::Display for TaggedValue {
     }
 }
 
-impl Serialize for TaggedValue {
+impl serde_core::Serialize for TaggedValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
-        use serde::ser::SerializeMap;
+        use serde_core::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(1))?;
         map.serialize_entry(self.tag.as_str(), self.value())?;
         map.end()
     }
 }
 
-impl<'de> Deserialize<'de> for TaggedValue {
+impl<'de> serde_core::Deserialize<'de> for TaggedValue {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::{MapAccess, Visitor};
-
         struct TaggedValueVisitor;
 
-        impl<'de> Visitor<'de> for TaggedValueVisitor {
+        impl<'de> serde_core::de::Visitor<'de> for TaggedValueVisitor {
             type Value = TaggedValue;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2151,11 +2144,11 @@ impl<'de> Deserialize<'de> for TaggedValue {
 
             fn visit_map<A>(self, mut map: A) -> Result<TaggedValue, A::Error>
             where
-                A: MapAccess<'de>,
+                A: serde_core::de::MapAccess<'de>,
             {
                 let (tag, value): (String, Value) = map
                     .next_entry()?
-                    .ok_or_else(|| serde::de::Error::custom("expected a single-entry map"))?;
+                    .ok_or_else(|| serde_core::de::Error::custom("expected a single-entry map"))?;
                 Ok(TaggedValue::new(Tag::new(tag), value))
             }
         }
@@ -2164,12 +2157,12 @@ impl<'de> Deserialize<'de> for TaggedValue {
     }
 }
 
-impl<'de> serde::Deserializer<'de> for &'de TaggedValue {
+impl<'de> serde_core::Deserializer<'de> for &'de TaggedValue {
     type Error = crate::Error;
 
     fn deserialize_any<V>(self, visitor: V) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         visitor.visit_map(TaggedValueMapAccess {
             tag: Some(self.tag.as_str()),
@@ -2184,12 +2177,12 @@ impl<'de> serde::Deserializer<'de> for &'de TaggedValue {
         visitor: V,
     ) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         visitor.visit_enum(TaggedValueEnumAccess { tagged: self })
     }
 
-    serde::forward_to_deserialize_any! {
+    serde_core::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
         byte_buf option unit unit_struct newtype_struct seq tuple
         tuple_struct map struct identifier ignored_any
@@ -2201,16 +2194,16 @@ struct TaggedValueMapAccess<'de> {
     value: Option<&'de Value>,
 }
 
-impl<'de> serde::de::MapAccess<'de> for TaggedValueMapAccess<'de> {
+impl<'de> serde_core::de::MapAccess<'de> for TaggedValueMapAccess<'de> {
     type Error = crate::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
     where
-        K: serde::de::DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         match self.tag.take() {
             Some(tag) => seed
-                .deserialize(serde::de::value::BorrowedStrDeserializer::new(tag))
+                .deserialize(serde_core::de::value::BorrowedStrDeserializer::new(tag))
                 .map(Some),
             None => Ok(None),
         }
@@ -2218,11 +2211,11 @@ impl<'de> serde::de::MapAccess<'de> for TaggedValueMapAccess<'de> {
 
     fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
     where
-        V: serde::de::DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         match self.value.take() {
             Some(value) => seed.deserialize(value),
-            None => Err(serde::de::Error::custom("value is missing")),
+            None => Err(serde_core::de::Error::custom("value is missing")),
         }
     }
 }
@@ -2258,18 +2251,18 @@ impl<'de> TagPreservingMapAccess<'de> {
     }
 }
 
-impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
+impl<'de> serde_core::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
     type Error = crate::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
     where
-        K: serde::de::DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         match self.state {
             TagPreservingState::EmitTagKey { tag, value } => {
                 self.state = TagPreservingState::EmitTagValue { tag, value };
                 seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
+                    serde_core::de::value::BorrowedStrDeserializer::<crate::Error>::new(
                         TAGGED_VALUE_FIELD_TAG,
                     ),
                 )
@@ -2278,7 +2271,7 @@ impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
             TagPreservingState::EmitValueKey { value } => {
                 self.state = TagPreservingState::EmitValueValue { value };
                 seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
+                    serde_core::de::value::BorrowedStrDeserializer::<crate::Error>::new(
                         TAGGED_VALUE_FIELD_VALUE,
                     ),
                 )
@@ -2289,7 +2282,7 @@ impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
             // is a serde misuse — surface as a custom error rather
             // than panicking.
             TagPreservingState::EmitTagValue { .. } | TagPreservingState::EmitValueValue { .. } => {
-                Err(serde::de::Error::custom(
+                Err(serde_core::de::Error::custom(
                     "TagPreservingMapAccess: next_key called before next_value",
                 ))
             }
@@ -2298,13 +2291,13 @@ impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
 
     fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
     where
-        V: serde::de::DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         match self.state {
             TagPreservingState::EmitTagValue { tag, value } => {
                 self.state = TagPreservingState::EmitValueKey { value };
                 seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(tag),
+                    serde_core::de::value::BorrowedStrDeserializer::<crate::Error>::new(tag),
                 )
             }
             TagPreservingState::EmitValueValue { value } => {
@@ -2322,7 +2315,7 @@ impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
                     value, None, false,
                 ))
             }
-            _ => Err(serde::de::Error::custom(
+            _ => Err(serde_core::de::Error::custom(
                 "TagPreservingMapAccess: next_value called out of order",
             )),
         }
@@ -2333,19 +2326,17 @@ struct TaggedValueEnumAccess<'de> {
     tagged: &'de TaggedValue,
 }
 
-impl<'de> serde::de::EnumAccess<'de> for TaggedValueEnumAccess<'de> {
+impl<'de> serde_core::de::EnumAccess<'de> for TaggedValueEnumAccess<'de> {
     type Error = crate::Error;
     type Variant = TaggedValueVariantAccess<'de>;
 
     fn variant_seed<V>(self, seed: V) -> crate::Result<(V::Value, Self::Variant)>
     where
-        V: serde::de::DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
-        let variant = seed.deserialize(
-            serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
-                self.tagged.tag.nobang(),
-            ),
-        )?;
+        let variant = seed.deserialize(serde_core::de::value::BorrowedStrDeserializer::<
+            crate::Error,
+        >::new(self.tagged.tag.nobang()))?;
         Ok((
             variant,
             TaggedValueVariantAccess {
@@ -2359,7 +2350,7 @@ struct TaggedValueVariantAccess<'de> {
     value: &'de Value,
 }
 
-impl<'de> serde::de::VariantAccess<'de> for TaggedValueVariantAccess<'de> {
+impl<'de> serde_core::de::VariantAccess<'de> for TaggedValueVariantAccess<'de> {
     type Error = crate::Error;
 
     fn unit_variant(self) -> crate::Result<()> {
@@ -2368,16 +2359,16 @@ impl<'de> serde::de::VariantAccess<'de> for TaggedValueVariantAccess<'de> {
 
     fn newtype_variant_seed<T>(self, seed: T) -> crate::Result<T::Value>
     where
-        T: serde::de::DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         seed.deserialize(self.value)
     }
 
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        serde::Deserializer::deserialize_seq(self.value, visitor)
+        serde_core::Deserializer::deserialize_seq(self.value, visitor)
     }
 
     fn struct_variant<V>(
@@ -2386,9 +2377,9 @@ impl<'de> serde::de::VariantAccess<'de> for TaggedValueVariantAccess<'de> {
         visitor: V,
     ) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
-        serde::Deserializer::deserialize_map(self.value, visitor)
+        serde_core::Deserializer::deserialize_map(self.value, visitor)
     }
 }
 
@@ -4087,16 +4078,14 @@ fn value_type_name(value: &Value) -> &'static str {
     }
 }
 
-impl<'de> Deserialize<'de> for Value {
+impl<'de> serde_core::Deserialize<'de> for Value {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
-        use serde::de::{MapAccess, SeqAccess, Visitor};
-
         struct ValueVisitor;
 
-        impl<'de> Visitor<'de> for ValueVisitor {
+        impl<'de> serde_core::de::Visitor<'de> for ValueVisitor {
             type Value = Value;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -4137,7 +4126,7 @@ impl<'de> Deserialize<'de> for Value {
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Value, A::Error>
             where
-                A: SeqAccess<'de>,
+                A: serde_core::de::SeqAccess<'de>,
             {
                 // Pre-size from the SeqAccess size_hint when
                 // available — saves up to ~11 reallocations on a
@@ -4156,7 +4145,7 @@ impl<'de> Deserialize<'de> for Value {
 
             fn visit_map<A>(self, mut map: A) -> Result<Value, A::Error>
             where
-                A: MapAccess<'de>,
+                A: serde_core::de::MapAccess<'de>,
             {
                 // Tag-preserving fast path: noyalib's own
                 // [`crate::de::Deserializer::deserialize_any`]
@@ -4178,12 +4167,12 @@ impl<'de> Deserialize<'de> for Value {
                     if k == TAGGED_VALUE_FIELD_TAG {
                         let tag_str: String = map.next_value()?;
                         let second_key: String = map.next_key()?.ok_or_else(|| {
-                            <A::Error as serde::de::Error>::custom(
+                            <A::Error as serde_core::de::Error>::custom(
                                 "tag-preserving map missing $__noyalib_value entry",
                             )
                         })?;
                         if second_key != TAGGED_VALUE_FIELD_VALUE {
-                            return Err(<A::Error as serde::de::Error>::custom(format!(
+                            return Err(<A::Error as serde_core::de::Error>::custom(format!(
                                 "tag-preserving map: expected `{}`, got `{}`",
                                 TAGGED_VALUE_FIELD_VALUE, second_key
                             )));
@@ -4219,10 +4208,10 @@ impl<'de> Deserialize<'de> for Value {
     }
 }
 
-impl Serialize for Value {
+impl serde_core::Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         match self {
             Value::Null => serializer.serialize_none(),
@@ -4232,7 +4221,7 @@ impl Serialize for Value {
             Value::String(s) => serializer.serialize_str(s),
             Value::Sequence(s) => s.serialize(serializer),
             Value::Mapping(m) => {
-                use serde::ser::SerializeMap;
+                use serde_core::ser::SerializeMap;
                 let mut map = serializer.serialize_map(Some(m.len()))?;
                 for (k, v) in m {
                     map.serialize_entry(k, v)?;
@@ -4241,7 +4230,7 @@ impl Serialize for Value {
             }
             Value::Tagged(tagged) => {
                 // Serialize as a single-entry map with tag as key
-                use serde::ser::SerializeMap;
+                use serde_core::ser::SerializeMap;
                 let mut map = serializer.serialize_map(Some(1))?;
                 map.serialize_entry(tagged.tag().as_str(), tagged.value())?;
                 map.end()
@@ -4254,7 +4243,7 @@ impl Serialize for Value {
 // Deserializer implementation for &Value
 // ============================================================================
 
-impl<'de> serde::de::IntoDeserializer<'de, crate::Error> for &'de Value {
+impl<'de> serde_core::de::IntoDeserializer<'de, crate::Error> for &'de Value {
     type Deserializer = Self;
 
     fn into_deserializer(self) -> Self::Deserializer {
@@ -4266,12 +4255,12 @@ struct ValueSeqAccess<'de> {
     iter: core::slice::Iter<'de, Value>,
 }
 
-impl<'de> serde::de::SeqAccess<'de> for ValueSeqAccess<'de> {
+impl<'de> serde_core::de::SeqAccess<'de> for ValueSeqAccess<'de> {
     type Error = crate::Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> crate::Result<Option<T::Value>>
     where
-        T: serde::de::DeserializeSeed<'de>,
+        T: serde_core::de::DeserializeSeed<'de>,
     {
         match self.iter.next() {
             Some(value) => seed.deserialize(value).map(Some),
@@ -4285,17 +4274,17 @@ struct ValueMapAccess<'de> {
     value: Option<&'de Value>,
 }
 
-impl<'de> serde::de::MapAccess<'de> for ValueMapAccess<'de> {
+impl<'de> serde_core::de::MapAccess<'de> for ValueMapAccess<'de> {
     type Error = crate::Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
     where
-        K: serde::de::DeserializeSeed<'de>,
+        K: serde_core::de::DeserializeSeed<'de>,
     {
         match self.iter.next() {
             Some((key, value)) => {
                 self.value = Some(value);
-                seed.deserialize(serde::de::value::BorrowedStrDeserializer::new(key))
+                seed.deserialize(serde_core::de::value::BorrowedStrDeserializer::new(key))
                     .map(Some)
             }
             None => Ok(None),
@@ -4304,21 +4293,21 @@ impl<'de> serde::de::MapAccess<'de> for ValueMapAccess<'de> {
 
     fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
     where
-        V: serde::de::DeserializeSeed<'de>,
+        V: serde_core::de::DeserializeSeed<'de>,
     {
         match self.value.take() {
             Some(value) => seed.deserialize(value),
-            None => Err(serde::de::Error::custom("value is missing")),
+            None => Err(serde_core::de::Error::custom("value is missing")),
         }
     }
 }
 
-impl<'de> serde::Deserializer<'de> for &'de Value {
+impl<'de> serde_core::Deserializer<'de> for &'de Value {
     type Error = crate::Error;
 
     fn deserialize_any<V>(self, visitor: V) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self {
             Value::Null => visitor.visit_unit(),
@@ -4333,7 +4322,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
             }),
             Value::Tagged(tagged) => {
                 let tagged_ref: &'de TaggedValue = tagged;
-                serde::Deserializer::deserialize_any(tagged_ref, visitor)
+                serde_core::Deserializer::deserialize_any(tagged_ref, visitor)
             }
         }
     }
@@ -4345,39 +4334,39 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
         visitor: V,
     ) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self {
             Value::Tagged(tagged) => {
                 let tagged_ref: &'de TaggedValue = tagged;
-                serde::Deserializer::deserialize_enum(tagged_ref, name, variants, visitor)
+                serde_core::Deserializer::deserialize_enum(tagged_ref, name, variants, visitor)
             }
             Value::String(s) => visitor
-                .visit_enum(serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(s)),
-            _ => serde::Deserializer::deserialize_any(self, visitor),
+                .visit_enum(serde_core::de::value::BorrowedStrDeserializer::<crate::Error>::new(s)),
+            _ => serde_core::Deserializer::deserialize_any(self, visitor),
         }
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self {
             Value::Sequence(seq) => visitor.visit_seq(ValueSeqAccess { iter: seq.iter() }),
-            _ => serde::Deserializer::deserialize_any(self, visitor),
+            _ => serde_core::Deserializer::deserialize_any(self, visitor),
         }
     }
 
     fn deserialize_map<V>(self, visitor: V) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         match self {
             Value::Mapping(map) => visitor.visit_map(ValueMapAccess {
                 iter: map.iter(),
                 value: None,
             }),
-            _ => serde::Deserializer::deserialize_any(self, visitor),
+            _ => serde_core::Deserializer::deserialize_any(self, visitor),
         }
     }
 
@@ -4388,15 +4377,15 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
         visitor: V,
     ) -> crate::Result<V::Value>
     where
-        V: serde::de::Visitor<'de>,
+        V: serde_core::de::Visitor<'de>,
     {
         if name == crate::spanned::SPANNED_TYPE_NAME {
             return visitor.visit_map(crate::de::SpannedMapAccess::new(self, None));
         }
-        serde::Deserializer::deserialize_map(self, visitor)
+        serde_core::Deserializer::deserialize_map(self, visitor)
     }
 
-    serde::forward_to_deserialize_any! {
+    serde_core::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
         byte_buf option unit unit_struct newtype_struct tuple
         tuple_struct identifier ignored_any

--- a/crates/noyalib/src/with/mod.rs
+++ b/crates/noyalib/src/with/mod.rs
@@ -12,15 +12,14 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Action {
 //!     Start { delay: u32 },
 //!     Stop,
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(with = "singleton_map")]

--- a/crates/noyalib/src/with/singleton_map.rs
+++ b/crates/noyalib/src/with/singleton_map.rs
@@ -8,16 +8,15 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Status {
 //!     Active,
 //!     Pending { reason: String },
 //!     Error { code: i32, message: String },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(with = "singleton_map")]
@@ -54,15 +53,14 @@ use serde::{Deserializer, Serialize, Serializer};
 ///
 /// ```rust
 /// use noyalib::with::singleton_map;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Action {
 ///     Start,
 ///     Stop { graceful: bool },
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Command {
 ///     #[serde(with = "singleton_map")]
 ///     action: Action,
@@ -109,12 +107,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Status { Active }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map")]
 ///     s: Status,
@@ -136,16 +133,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum TestEnum {
         Unit,
         Newtype(i32),
         Struct { value: String },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(with = "crate::with::singleton_map")]
@@ -186,7 +182,7 @@ mod tests {
     #[test]
     fn test_singleton_map_fallback_sequence() {
         // Test the fallback path when value is a Sequence
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct SeqContainer {
             #[serde(with = "crate::with::singleton_map")]
             items: Vec<i32>,
@@ -205,7 +201,7 @@ mod tests {
     #[test]
     fn test_singleton_map_fallback_integer() {
         // Test the fallback path when value is a Number
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct NumContainer {
             #[serde(with = "crate::with::singleton_map")]
             value: i32,

--- a/crates/noyalib/src/with/singleton_map.rs
+++ b/crates/noyalib/src/with/singleton_map.rs
@@ -41,9 +41,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-use serde::de::DeserializeOwned;
-use serde::{Deserializer, Serialize, Serializer};
-
 /// Serialize a value as a singleton map.
 ///
 /// For enums, this serializes the variant as a map where the key is the
@@ -68,13 +65,14 @@ use serde::{Deserializer, Serialize, Serializer};
 /// ```
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: Serialize,
-    S: Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
-    use serde::ser::SerializeMap;
+    use serde_core::Serialize;
+    use serde_core::ser::SerializeMap;
 
     // Serialize to Value to inspect structure
-    let yaml_value = crate::to_value(value).map_err(serde::ser::Error::custom)?;
+    let yaml_value = crate::to_value(value).map_err(serde_core::ser::Error::custom)?;
 
     match yaml_value {
         crate::Value::Mapping(map) => {
@@ -122,13 +120,13 @@ where
 /// ```
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: DeserializeOwned + 'static,
-    D: Deserializer<'de>,
+    T: serde_core::de::DeserializeOwned + 'static,
+    D: serde_core::Deserializer<'de>,
 {
-    use serde::Deserialize;
+    use serde_core::Deserialize;
     // Deserialize as Value first
     let value = crate::Value::deserialize(deserializer)?;
-    crate::from_value(&value).map_err(serde::de::Error::custom)
+    crate::from_value(&value).map_err(serde_core::de::Error::custom)
 }
 
 #[cfg(test)]

--- a/crates/noyalib/src/with/singleton_map_optional.rs
+++ b/crates/noyalib/src/with/singleton_map_optional.rs
@@ -8,15 +8,14 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_optional;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Status {
 //!     Active,
 //!     Pending { reason: String },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(
@@ -54,15 +53,14 @@ use serde::{Deserializer, Serialize, Serializer};
 ///
 /// ```rust
 /// use noyalib::with::singleton_map_optional;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Action {
 ///     Start,
 ///     Stop,
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Command {
 ///     #[serde(
 ///         with = "singleton_map_optional",
@@ -118,12 +116,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map_optional;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Status { Active }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map_optional", default)]
 ///     s: Option<Status>,
@@ -152,15 +149,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum TestEnum {
         Unit,
         Struct { value: String },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(
@@ -220,7 +216,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_fallback() {
         // Test the fallback path when value is a Sequence
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct SeqContainer {
             #[serde(with = "crate::with::singleton_map_optional")]
             items: Option<Vec<i32>>,
@@ -237,7 +233,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_serialize_none() {
         // Test serializing None without skip_serializing_if
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct NoneContainer {
             name: String,
             #[serde(with = "crate::with::singleton_map_optional")]
@@ -257,7 +253,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_deserialize_none() {
         // Test deserializing null as None
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct NoneContainer {
             name: String,
             #[serde(with = "crate::with::singleton_map_optional", default)]

--- a/crates/noyalib/src/with/singleton_map_optional.rs
+++ b/crates/noyalib/src/with/singleton_map_optional.rs
@@ -41,9 +41,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-use serde::de::DeserializeOwned;
-use serde::{Deserializer, Serialize, Serializer};
-
 /// Serialize an optional value as a singleton map.
 ///
 /// For `Some(value)`, this serializes the value using singleton map format.
@@ -72,15 +69,17 @@ use serde::{Deserializer, Serialize, Serializer};
 /// ```
 pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: Serialize,
-    S: Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
+    use serde_core::Serialize;
+
     match value {
         Some(inner) => {
-            use serde::ser::SerializeMap;
+            use serde_core::ser::SerializeMap;
 
             // Serialize to Value to inspect structure
-            let yaml_value = crate::to_value(inner).map_err(serde::ser::Error::custom)?;
+            let yaml_value = crate::to_value(inner).map_err(serde_core::ser::Error::custom)?;
 
             match yaml_value {
                 crate::Value::Mapping(map) => {
@@ -131,16 +130,16 @@ where
 /// ```
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
-    T: DeserializeOwned + 'static,
-    D: Deserializer<'de>,
+    T: serde_core::de::DeserializeOwned + 'static,
+    D: serde_core::Deserializer<'de>,
 {
-    use serde::Deserialize;
+    use serde_core::Deserialize;
     // Deserialize as Option<Value> first
     let opt_value: Option<crate::Value> = Option::deserialize(deserializer)?;
 
     match opt_value {
         Some(value) => {
-            let inner: T = crate::from_value(&value).map_err(serde::de::Error::custom)?;
+            let inner: T = crate::from_value(&value).map_err(serde_core::de::Error::custom)?;
             Ok(Some(inner))
         }
         None => Ok(None),

--- a/crates/noyalib/src/with/singleton_map_recursive.rs
+++ b/crates/noyalib/src/with/singleton_map_recursive.rs
@@ -7,21 +7,20 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_recursive;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Inner {
 //!     A,
 //!     B { value: i32 },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Outer {
 //!     Single(Inner),
 //!     Multiple(Vec<Inner>),
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Config {
 //!     #[serde(with = "singleton_map_recursive")]
 //!     items: Vec<Outer>,
@@ -67,15 +66,14 @@ fn transform_to_singleton_map(value: crate::Value) -> crate::Value {
 ///
 /// ```rust
 /// use noyalib::with::singleton_map_recursive;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Status {
 ///     Active,
 ///     Pending,
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Task {
 ///     #[serde(with = "singleton_map_recursive")]
 ///     statuses: Vec<Status>,
@@ -105,12 +103,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map_recursive;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Inner { A }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map_recursive")]
 ///     items: Vec<Inner>,
@@ -134,15 +131,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Inner {
         A,
         B { value: i32 },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(with = "crate::with::singleton_map_recursive")]
@@ -161,7 +157,7 @@ mod tests {
         assert_eq!(parsed, container);
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Nested {
         #[serde(with = "crate::with::singleton_map_recursive")]
         data: std::collections::BTreeMap<String, Inner>,

--- a/crates/noyalib/src/with/singleton_map_recursive.rs
+++ b/crates/noyalib/src/with/singleton_map_recursive.rs
@@ -31,8 +31,6 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
-use serde::{Deserializer, Serialize, Serializer};
 
 /// Recursively transform a Value to use singleton map representation for enums.
 fn transform_to_singleton_map(value: crate::Value) -> crate::Value {
@@ -81,11 +79,13 @@ fn transform_to_singleton_map(value: crate::Value) -> crate::Value {
 /// ```
 pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
-    T: Serialize,
-    S: Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
 {
+    use serde_core::Serialize;
+
     // Serialize to Value first
-    let yaml_value = crate::to_value(value).map_err(serde::ser::Error::custom)?;
+    let yaml_value = crate::to_value(value).map_err(serde_core::ser::Error::custom)?;
 
     // Transform recursively
     let transformed = transform_to_singleton_map(yaml_value);
@@ -118,15 +118,15 @@ where
 /// ```
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: DeserializeOwned + 'static,
-    D: Deserializer<'de>,
+    T: serde_core::de::DeserializeOwned + 'static,
+    D: serde_core::Deserializer<'de>,
 {
-    use serde::Deserialize;
+    use serde_core::Deserialize;
     // Deserialize as Value first
     let value = crate::Value::deserialize(deserializer)?;
 
     // Convert to target type
-    crate::from_value(&value).map_err(serde::de::Error::custom)
+    crate::from_value(&value).map_err(serde_core::de::Error::custom)
 }
 
 #[cfg(test)]

--- a/crates/noyalib/src/with/singleton_map_with.rs
+++ b/crates/noyalib/src/with/singleton_map_with.rs
@@ -96,8 +96,6 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
-use serde::{Deserializer, Serialize, Serializer};
 
 /// Serialize a value as a singleton map with custom key transformation.
 ///
@@ -130,14 +128,15 @@ use serde::{Deserializer, Serialize, Serializer};
 /// ```
 pub fn serialize_with<T, S, F>(value: &T, serializer: S, transform: F) -> Result<S::Ok, S::Error>
 where
-    T: Serialize,
-    S: Serializer,
+    T: serde_core::Serialize,
+    S: serde_core::Serializer,
     F: Fn(&str) -> String,
 {
-    use serde::ser::SerializeMap;
+    use serde_core::Serialize;
+    use serde_core::ser::SerializeMap;
 
     // Serialize to Value to inspect structure
-    let yaml_value = crate::to_value(value).map_err(serde::ser::Error::custom)?;
+    let yaml_value = crate::to_value(value).map_err(serde_core::ser::Error::custom)?;
 
     match yaml_value {
         crate::Value::Mapping(map) => {
@@ -193,11 +192,11 @@ where
 /// ```
 pub fn deserialize_with<'de, T, D, F>(deserializer: D, transform: F) -> Result<T, D::Error>
 where
-    T: DeserializeOwned + 'static,
-    D: Deserializer<'de>,
+    T: serde_core::de::DeserializeOwned + 'static,
+    D: serde_core::Deserializer<'de>,
     F: Fn(&str) -> String,
 {
-    use serde::Deserialize;
+    use serde_core::Deserialize;
 
     // Deserialize as Value first
     let value = crate::Value::deserialize(deserializer)?;
@@ -205,7 +204,7 @@ where
     // Transform the keys in the value
     let transformed = transform_value_keys(value, &transform);
 
-    crate::from_value(&transformed).map_err(serde::de::Error::custom)
+    crate::from_value(&transformed).map_err(serde_core::de::Error::custom)
 }
 
 /// Transform all string keys in a Value according to the provided function.

--- a/crates/noyalib/src/with/singleton_map_with.rs
+++ b/crates/noyalib/src/with/singleton_map_with.rs
@@ -15,7 +15,6 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_with;
-//! use serde::{Deserialize, Serialize};
 //!
 //! // Define custom serialize/deserialize functions
 //! mod snake_case {
@@ -73,14 +72,14 @@
 //!     }
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum HttpMethod {
 //!     GetRequest,
 //!     PostData,
 //!     DeleteItem,
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct ApiCall {
 //!     #[serde(with = "snake_case")]
 //!     method: HttpMethod,
@@ -453,9 +452,7 @@ mod tests {
 
     #[test]
     fn test_serialize_with_directly() {
-        use serde::Serialize;
-
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct TestStruct {
             name: String,
         }


### PR DESCRIPTION
This removes serde as a direct dependency. As this crate takes some seconds to compile it can now be compiled in parallel to crates like serde_derive and everything depending on it speeding up the build. See the [docs of serde_core](https://docs.rs/serde_core/1.0.228/serde_core/) for an example of this.

robotics is the only feature that still requires serde for its derive types so it sadly can not be fully removed from the dependencies.

This also migrates all derives to fully qualified `#[derive(serde::` so it's easier to locate whether it's an imported trait or a used derive.

What are your thoughts on this?