### PR TITLE
release: v0.0.8 (FlowStyle fix + batched deps)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -21,4 +21,10 @@ ignore = [
     # libyml — `libyml::string::yaml_string_extend` is unsound;
     # transitive via serde_yml. Same bench-only justification.
     "RUSTSEC-2025-0067",
+    # proc-macro-error2 is unmaintained (author confirmed). Build-time
+    # only via validator_derive -> validator (the `validate` feature);
+    # never ships in a release artefact. No maintained drop-in exists
+    # yet. Mirrors the same ignore in `deny.toml`. Revisit when
+    # validator releases off proc-macro-error2.
+    "RUSTSEC-2026-0173",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         toolchain: [stable, nightly]
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -86,7 +86,7 @@ jobs:
     #     sweep plus big-endian.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -125,7 +125,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust nightly with Miri
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
@@ -150,7 +150,7 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
   fuzz-diff:
@@ -163,7 +163,7 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
@@ -191,7 +191,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -222,7 +222,7 @@ jobs:
     # is not yet covered will fail this job.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -241,7 +241,7 @@ jobs:
     # here rather than slowly bloating the lockfile.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -260,7 +260,7 @@ jobs:
     # against accidental licensing rot.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v6
 
   msrv-1-85-core:
@@ -279,7 +279,7 @@ jobs:
     #   toolchains; the stable test matrix covers those.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.85.0"
@@ -304,14 +304,14 @@ jobs:
     # land silently.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with:
           tool: cargo-llvm-cov
       - name: "Coverage report (gates: 96% fn / 93% region / 94% line)"
@@ -361,7 +361,7 @@ jobs:
     name: vendor + offline build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -391,7 +391,7 @@ jobs:
     name: Per-crate MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run scripts/msrv-per-crate.sh
         run: ./scripts/msrv-per-crate.sh
 
@@ -402,7 +402,7 @@ jobs:
     # push so the claim never silently regresses.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Verify PR commits are signed (via GitHub API)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -80,7 +80,7 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       source_date_epoch: ${{ steps.parse.outputs.source_date_epoch }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -149,7 +149,7 @@ jobs:
       ARCHIVE_BASE:      noyalib-${{ needs.create-release.outputs.version }}-${{ matrix.target }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -380,7 +380,7 @@ jobs:
       VERSION:      ${{ needs.create-release.outputs.version }}
       ARCHIVE_BASE: noyalib-${{ needs.create-release.outputs.version }}-universal-apple-darwin
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -469,7 +469,7 @@ jobs:
       VERSION:           ${{ needs.create-release.outputs.version }}
       SOURCE_DATE_EPOCH: ${{ needs.create-release.outputs.source_date_epoch }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -532,7 +532,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -590,7 +590,7 @@ jobs:
     permissions:
       contents: read  # external AUR push via AUR_SSH_PRIVATE_KEY
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -613,7 +613,7 @@ jobs:
               pkg/arch/PKGBUILD.template > /tmp/PKGBUILD
 
       - name: Push to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@a97f56a8425a7a7f3b8c58607f769c69b089cadb # v3
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v3
         with:
           pkgname:        noyalib-bin
           pkgbuild:       /tmp/PKGBUILD
@@ -631,7 +631,7 @@ jobs:
     permissions:
       contents: read  # external bucket push via SCOOP_BUCKET_TOKEN
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -666,7 +666,7 @@ jobs:
     env:
       VERSION: ${{ needs.create-release.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -729,7 +729,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -769,7 +769,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
@@ -807,13 +807,13 @@ jobs:
           - { name: noyalib,      dockerfile: pkg/docker/Dockerfile.full }
           - { name: noyalib-mcp,  dockerfile: pkg/docker/Dockerfile.mcp }
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag }}
 
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -89,7 +89,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -194,7 +194,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable
@@ -211,7 +211,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -264,7 +264,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: stable

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
         with:
           fail-on-severity: high
@@ -38,7 +38,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
@@ -64,7 +64,7 @@ jobs:
       matrix:
         target: [fuzz_parse, fuzz_roundtrip, fuzz_diff, fuzz_strict]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
@@ -100,7 +100,7 @@ jobs:
       contents: read
     timeout-minutes: 1440  # 24h ceiling
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.7]` is the cut.)
+(Nothing yet - `[v0.0.8]` is the cut.)
+
+## [v0.0.8] - 2026-06-17
+
+The **FlowStyle Fix** cut. Honors `SerializerConfig::flow_style` in the
+serializer so `FlowStyle::Flow` and `FlowStyle::Auto` finally emit
+inline collections (#84), folds in the batched Dependabot backlog
+(cargo, GitHub Actions, Docker base images), and updates the
+supply-chain gates for the new `proc-macro-error2` unmaintained
+advisory.
+
+No public API change. No MSRV change (still 1.85). The only behavior
+change is the FlowStyle fix: callers setting `Flow` or `Auto` now get
+inline output instead of silently getting block output.
+
+### Fixed
+
+- **`SerializerConfig::flow_style` is now honored.** `flow_style` and
+  `flow_threshold` were stored but never read by the emit path, so all
+  collections rendered as block regardless of config. `write_sequence`
+  and `write_mapping` now dispatch to the flow emitters: `Flow` is
+  always inline, `Auto` is inline within `flow_threshold` (default 4)
+  with a safe block fall-back for oversized subtrees, and `Block` is
+  unchanged. Adds four regression tests. [#84]
+
+### Changed
+
+- **Batched Dependabot bumps.** cargo: `clap_complete` 4.6.3 to 4.6.5,
+  `smallvec` 1.15.1 to 1.15.2, `memchr` 2.8.0 to 2.8.2. github-actions:
+  `actions/checkout` 6.0.2 to 6.0.3, `taiki-e/install-action` 2.81.1 to
+  2.81.8, `KSXGitHub/github-actions-deploy-aur` 3.0.1 to 4.1.3,
+  `docker/setup-buildx-action` 3.12.0 to 4.1.0, `docker/login-action`
+  3.7.0 to 4.2.0. docker: `rust:1.96-bookworm`, `debian:bookworm-slim`,
+  and `distroless/cc-debian12` digests re-pinned. [#85 to #96]
+
+### Security
+
+- **RUSTSEC-2026-0173** (`proc-macro-error2` unmaintained) ignored in
+  `deny.toml` and `.cargo/audit.toml`. Build-time only via
+  `validator_derive` to `validator`; never ships in an artefact.
+  Revisit when `validator` releases off `proc-macro-error2`.
 
 ## [v0.0.7] — 2026-06-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "ariadne",
  "bytes",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1102,9 +1102,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -1968,9 +1968,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ wants to *use* the library. The full reference is the
 
 ```toml
 [dependencies]
-noyalib = "0.0.7"
+noyalib = "0.0.8"
 ```
 
 `no_std` (alloc-only) and lean profiles are documented in the

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.7"
+noyalib = "0.0.8"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.7", default-features = false }
+noyalib = { version = "0.0.8", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -175,7 +175,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.7", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.8", features = ["miette", "validate-schema"] }
 ```
 
 ---
@@ -280,7 +280,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.7"
++noyalib = "0.0.8"
 ```
 
 ```diff

--- a/RELEASE-NOTES-v0.0.8.md
+++ b/RELEASE-NOTES-v0.0.8.md
@@ -1,0 +1,86 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.8 Release Notes
+
+The **FlowStyle Fix** cut. The headline is a real bug fix:
+`SerializerConfig::flow_style` is now honored by the serializer, so
+`FlowStyle::Flow` and `FlowStyle::Auto` finally produce the inline
+collections they always advertised. Alongside it ships the routine
+Dependabot backlog (cargo, GitHub Actions, and Docker base images) and
+a pair of supply-chain gate updates for a new upstream advisory.
+
+No public API change. No MSRV change (still 1.85). The one behavior
+change is the FlowStyle fix itself: callers who set `FlowStyle::Flow`
+or `FlowStyle::Auto` will now get inline output where before they
+silently got block output. Callers on the default (`FlowStyle::Block`)
+see identical output and can upgrade with no code edits.
+
+## Highlights
+
+* **`FlowStyle::Flow` and `FlowStyle::Auto` now work (#84).** The
+  `flow_style` and `flow_threshold` fields were stored on
+  `SerializerConfig` but never read by the emit path, so every
+  collection rendered as block style regardless of config. The
+  serializer now routes through the flow emitters:
+  * `Flow` always renders inline: `[0, 1, 2, 3, 4]`, `{a: 1, b: 2}`.
+  * `Auto` renders inline when the collection and its whole subtree
+    stay within `flow_threshold` (default 4), and falls back to block
+    otherwise. A block child nested inside a flow collection would be
+    invalid YAML, so `Auto` is deliberately conservative.
+  * `Block` is unchanged and remains the default.
+* **Batched Dependabot backlog.** Eleven open bot PRs (#85 to #96)
+  folded into one cut: three cargo bumps, five GitHub Actions bumps,
+  and three Docker base-image digest bumps.
+* **Supply-chain gates updated for RUSTSEC-2026-0173.**
+  `proc-macro-error2` was marked unmaintained upstream. It reaches the
+  tree build-time only via `validator_derive` and never ships in a
+  release artefact, so it is ignored in both `deny.toml` and
+  `.cargo/audit.toml` with a note to revisit once `validator` releases
+  off it.
+
+## What ships
+
+### Fixed: SerializerConfig::flow_style is honored (#84)
+
+`write_sequence` and `write_mapping` now consult `config.flow_style`
+and dispatch to the existing `write_flow_sequence` /
+`write_flow_mapping` emitters. Previously those emitters were only
+reachable through the explicit `Flow(..)` value wrapper, so the global
+config knob was dead. A new `auto_flow_eligible` helper enforces the
+"flow is sticky downward" rule for `Auto` mode so the serializer never
+emits an invalid block-inside-flow document. Four regression tests
+cover `Flow`, the `Auto` threshold, the `Auto` nested fall-back, and
+the unchanged `Block` default.
+
+### Dependencies: batched Dependabot bumps (#85 to #96)
+
+* cargo: `clap_complete` 4.6.3 to 4.6.5, `smallvec` 1.15.1 to 1.15.2,
+  `memchr` 2.8.0 to 2.8.2.
+* github-actions: `actions/checkout` 6.0.2 to 6.0.3,
+  `taiki-e/install-action` 2.81.1 to 2.81.8,
+  `KSXGitHub/github-actions-deploy-aur` 3.0.1 to 4.1.3,
+  `docker/setup-buildx-action` 3.12.0 to 4.1.0,
+  `docker/login-action` 3.7.0 to 4.2.0.
+* docker: `rust:1.96-bookworm`, `debian:bookworm-slim`, and
+  `gcr.io/distroless/cc-debian12` digests re-pinned.
+
+### CI: supply-chain gates
+
+* `supply-chain/config.toml`: `safe-to-deploy` exemptions added for
+  `clap_complete` 4.6.5, `memchr` 2.8.2, and `smallvec` 1.15.2, since
+  the patch bumps outran the pinned `imports.lock`.
+* `deny.toml` and `.cargo/audit.toml`: `RUSTSEC-2026-0173`
+  (`proc-macro-error2` unmaintained) ignored, build-time-only via
+  `validator_derive`.
+
+## Upgrading
+
+```toml
+[dependencies]
+noyalib = "0.0.8"
+```
+
+Default-configuration callers need no changes. If you were setting
+`FlowStyle::Flow` or `FlowStyle::Auto` and working around the missing
+inline output, you can now drop the workaround and rely on the config.

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.7", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.8", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.7", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.8", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.7" }
+noyalib = { path = "../noyalib", version = "0.0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.7", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.8", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.7"
+noyalib = "0.0.8"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.7", default-features = false }
+noyalib = { version = "0.0.8", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -1026,12 +1026,10 @@ fn write_block_scalar(output: &mut String, s: &str, indent: usize, config: &Seri
 fn auto_flow_eligible(value: &Value, config: &SerializerConfig) -> bool {
     match value {
         Value::Sequence(s) => {
-            s.len() <= config.flow_threshold
-                && s.iter().all(|v| auto_flow_eligible(v, config))
+            s.len() <= config.flow_threshold && s.iter().all(|v| auto_flow_eligible(v, config))
         }
         Value::Mapping(m) => {
-            m.len() <= config.flow_threshold
-                && m.iter().all(|(_, v)| auto_flow_eligible(v, config))
+            m.len() <= config.flow_threshold && m.iter().all(|(_, v)| auto_flow_eligible(v, config))
         }
         Value::Tagged(_) => false,
         _ => true,

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -1014,6 +1014,45 @@ fn write_block_scalar(output: &mut String, s: &str, indent: usize, config: &Seri
     }
 }
 
+/// Whether a value can be safely rendered inside an `Auto`-mode flow
+/// collection. A flow collection may only contain scalars and other flow
+/// collections — a nested *block* collection would produce invalid YAML
+/// (`[a, - x]`). So in `Auto` mode the whole subtree must stay within the
+/// flow threshold for any ancestor to flow; otherwise we fall back to block.
+///
+/// `Tagged` values are conservatively treated as block-only: they carry
+/// anchors, custom tags, and the internal block-scalar/anchor magic tags that
+/// have no valid flow representation here.
+fn auto_flow_eligible(value: &Value, config: &SerializerConfig) -> bool {
+    match value {
+        Value::Sequence(s) => {
+            s.len() <= config.flow_threshold
+                && s.iter().all(|v| auto_flow_eligible(v, config))
+        }
+        Value::Mapping(m) => {
+            m.len() <= config.flow_threshold
+                && m.iter().all(|(_, v)| auto_flow_eligible(v, config))
+        }
+        Value::Tagged(_) => false,
+        _ => true,
+    }
+}
+
+/// Decide whether a collection of `len` items holding `values` should render
+/// in flow style under the active `config`.
+fn use_flow<'a, I>(len: usize, values: impl Fn() -> I, config: &SerializerConfig) -> bool
+where
+    I: Iterator<Item = &'a Value>,
+{
+    match config.flow_style {
+        FlowStyle::Block => false,
+        FlowStyle::Flow => true,
+        FlowStyle::Auto => {
+            len <= config.flow_threshold && values().all(|v| auto_flow_eligible(v, config))
+        }
+    }
+}
+
 fn write_sequence(
     output: &mut String,
     seq: &Sequence,
@@ -1025,6 +1064,10 @@ fn write_sequence(
     if seq.is_empty() {
         output.push_str("[]");
         return Ok(());
+    }
+
+    if use_flow(seq.len(), || seq.iter(), config) {
+        return write_flow_sequence(output, seq, config, depth);
     }
 
     for (i, value) in seq.iter().enumerate() {
@@ -1101,6 +1144,10 @@ fn write_mapping(
     if map.is_empty() {
         output.push_str("{}");
         return Ok(());
+    }
+
+    if use_flow(map.len(), || map.iter().map(|(_, v)| v), config) {
+        return write_flow_mapping(output, map, config, depth);
     }
 
     for (i, (key, value)) in map.iter().enumerate() {
@@ -1805,5 +1852,82 @@ mod tests {
             Err(Error::RecursionLimitExceeded { depth }) => assert!(depth > 128),
             _ => panic!("Expected RecursionLimitExceeded error, got {:?}", result),
         }
+    }
+
+    // Regression for #84: `flow_style` was stored but never consulted by the
+    // emit path, so `FlowStyle::Flow` / `Auto` silently produced block output.
+    #[test]
+    fn test_flow_style_flow_emits_inline_collections() {
+        let seq = Value::Sequence(vec![
+            Value::from(0),
+            Value::from(1),
+            Value::from(2),
+            Value::from(3),
+            Value::from(4),
+        ]);
+        let mut map = Mapping::new();
+        let _ = map.insert("a", Value::from(1));
+        let _ = map.insert("b", Value::from(2));
+        let _ = map.insert("c", Value::from(3));
+        let map = Value::Mapping(map);
+
+        let config = SerializerConfig::new().flow_style(FlowStyle::Flow);
+        assert_eq!(
+            to_string_with_config(&seq, &config).unwrap().trim_end(),
+            "[0, 1, 2, 3, 4]"
+        );
+        assert_eq!(
+            to_string_with_config(&map, &config).unwrap().trim_end(),
+            "{a: 1, b: 2, c: 3}"
+        );
+    }
+
+    #[test]
+    fn test_flow_style_auto_respects_threshold() {
+        let small = Value::Sequence((0..3).map(Value::from).collect());
+        let large = Value::Sequence((0..10).map(Value::from).collect());
+
+        let config = SerializerConfig::new()
+            .flow_style(FlowStyle::Auto)
+            .flow_threshold(4);
+
+        // Small collection (<= threshold) flows inline.
+        assert_eq!(
+            to_string_with_config(&small, &config).unwrap().trim_end(),
+            "[0, 1, 2]"
+        );
+        // Large collection (> threshold) stays block.
+        assert!(
+            to_string_with_config(&large, &config)
+                .unwrap()
+                .starts_with("- 0")
+        );
+    }
+
+    #[test]
+    fn test_flow_style_auto_falls_back_when_child_exceeds_threshold() {
+        // Outer has 2 items (<= threshold) but the inner sequence has 10
+        // (> threshold). Flowing the outer would emit an invalid block child
+        // inside flow, so Auto must keep the outer in block style.
+        let inner = Value::Sequence((0..10).map(Value::from).collect());
+        let outer = Value::Sequence(vec![Value::from(0), inner]);
+
+        let config = SerializerConfig::new()
+            .flow_style(FlowStyle::Auto)
+            .flow_threshold(4);
+        let out = to_string_with_config(&outer, &config).unwrap();
+        assert!(out.starts_with("- 0"), "outer should stay block: {out:?}");
+    }
+
+    #[test]
+    fn test_flow_style_block_is_default_unchanged() {
+        let seq = Value::Sequence((0..3).map(Value::from).collect());
+        // Default config (Block) and the no-config helper both stay block.
+        assert!(to_string(&seq).unwrap().starts_with("- 0"));
+        assert!(
+            to_string_with_config(&seq, &SerializerConfig::new())
+                .unwrap()
+                .starts_with("- 0")
+        );
     }
 }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.7", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.8", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.6"
 clap_mangen   = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,15 @@ yanked = "warn"
 # to be benched too — they were retired in v0.0.6 so `cargo
 # audit` and the OpenSSF Scorecard Vulnerabilities check stay
 # clean without needing per-advisory exemptions.
-ignore = []
+ignore = [
+    # proc-macro-error2 is unmaintained (author confirmed). It reaches
+    # us only at build time via validator_derive -> validator (the
+    # `validate` feature); it never ships in a release artefact, so the
+    # advisory is informational for us. No maintained drop-in exists yet
+    # (validator has not migrated off it). Revisit when validator cuts a
+    # release that drops proc-macro-error2.
+    "RUSTSEC-2026-0173",
+]
 
 [licenses]
 allow = [

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -483,7 +483,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.7", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.8", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -506,7 +506,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.7", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.8", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -530,7 +530,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.7", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.8", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```

--- a/pkg/docker/Dockerfile
+++ b/pkg/docker/Dockerfile
@@ -26,7 +26,7 @@
 # when the edition bumped to 2024). Digest pinned for OpenSSF
 # Scorecard Pinned-Dependencies; Dependabot's `docker` ecosystem
 # bumps it on its weekly cadence.
-FROM rust:1.96-bookworm@sha256:13c186980fa33cc12759b429662a1322939dbe697484b7c33b47dd2698d28460 AS build
+FROM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS build
 
 WORKDIR /src
 COPY . .
@@ -43,7 +43,7 @@ RUN cargo build --release --locked \
     --bin noyafmt --bin noyavalidate
 
 # ── Runtime stage ────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985
 
 LABEL org.opencontainers.image.title="noyafmt"
 LABEL org.opencontainers.image.description="Pure-Rust YAML 1.2 formatter (lossless CST). See ghcr.io/sebastienrousseau/noyalib-mcp for the MCP server image."

--- a/pkg/docker/Dockerfile.full
+++ b/pkg/docker/Dockerfile.full
@@ -12,7 +12,7 @@
 #
 # Otherwise prefer the slimmer distroless variant in `Dockerfile`.
 
-FROM rust:1.96-bookworm@sha256:13c186980fa33cc12759b429662a1322939dbe697484b7c33b47dd2698d28460 AS build
+FROM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS build
 
 WORKDIR /src
 COPY . .
@@ -27,7 +27,7 @@ RUN cargo build --release --locked \
     --bin noyafmt --bin noyavalidate
 
 # ── Runtime stage ────────────────────────────────────────────────
-FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 
 LABEL org.opencontainers.image.title="noyalib"
 LABEL org.opencontainers.image.description="Pure-Rust YAML 1.2 toolchain (noyafmt + noyavalidate, full miette diagnostics)."

--- a/pkg/docker/Dockerfile.mcp
+++ b/pkg/docker/Dockerfile.mcp
@@ -16,7 +16,7 @@
 #                                          binary from a GitHub
 #                                          Release on first run)
 
-FROM rust:1.96-bookworm@sha256:13c186980fa33cc12759b429662a1322939dbe697484b7c33b47dd2698d28460 AS build
+FROM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS build
 
 WORKDIR /src
 COPY . .
@@ -29,7 +29,7 @@ RUN cargo build --release --locked \
     --manifest-path crates/noyalib-mcp/Cargo.toml
 
 # ── Runtime stage ────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985
 
 LABEL org.opencontainers.image.title="noyalib-mcp"
 LABEL org.opencontainers.image.description="MCP server for noyalib YAML tools — parse, format, get, set, validate over JSON-RPC stdio."

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -43,6 +43,10 @@ version = "1.11.1"
 criteria = "safe-to-deploy"
 suggest = false
 
+[[exemptions.clap_complete]]
+version = "4.6.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.clap_mangen]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
@@ -90,6 +94,10 @@ suggest = false
 version = "0.13.0"
 criteria = "safe-to-run"
 
+[[exemptions.memchr]]
+version = "2.8.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.page_size]]
 version = "0.6.0"
 criteria = "safe-to-run"
@@ -115,6 +123,10 @@ criteria = "safe-to-deploy"
 version = "1.0.150"
 criteria = "safe-to-deploy"
 suggest = false
+
+[[exemptions.smallvec]]
+version = "1.15.2"
+criteria = "safe-to-deploy"
 
 [[exemptions.sval]]
 version = "2.20.0"


### PR DESCRIPTION
Release branch for **v0.0.8**. Headlined by a real serializer bug fix
(`SerializerConfig::flow_style` is now honored, #84), plus the batched
Dependabot backlog and the supply-chain gate updates needed to keep CI
green on a new upstream advisory.

No public API change. No MSRV change (still 1.85). The only behavior
change is the FlowStyle fix itself.

## Changes since `main`

### Fixed: `SerializerConfig::flow_style` is honored (`35086c3`, Closes #84)

`flow_style` / `flow_threshold` were stored on `SerializerConfig` but
never read by the emit path, so every collection rendered block-style
regardless of config. `write_sequence` / `write_mapping` now dispatch
to the existing flow emitters:

- **Flow** always inline: `[0, 1, 2, 3, 4]`, `{a: 1, b: 2, c: 3}`
- **Auto** inline when the collection and its whole subtree stay within
  `flow_threshold` (default 4), else block (a block child inside a flow
  collection would be invalid YAML, so `Auto` is conservative)
- **Block** unchanged, still the default

New `auto_flow_eligible` helper enforces the downward-sticky rule.
Adds 4 regression tests (Flow, Auto threshold, Auto nested fall-back,
Block default).

### Changed: batched Dependabot bumps (`ceec264`, supersedes #85 to #96)

- **cargo:** clap_complete 4.6.3 to 4.6.5, smallvec 1.15.1 to 1.15.2, memchr 2.8.0 to 2.8.2
- **github-actions:** actions/checkout 6.0.2 to 6.0.3, taiki-e/install-action 2.81.1 to 2.81.8, KSXGitHub/github-actions-deploy-aur 3.0.1 to 4.1.3, docker/setup-buildx-action 3.12.0 to 4.1.0, docker/login-action 3.7.0 to 4.2.0
- **docker:** rust:1.96-bookworm, debian:bookworm-slim, distroless/cc-debian12 digests re-pinned

### Release prep: version bump to 0.0.8 (`76431a0`)

All six workspace crates plus internal path-dep versions bumped 0.0.7 to
0.0.8, `Cargo.lock` refreshed, install snippets updated in `README.md`,
`crates/noyalib/README.md`, `GETTING_STARTED.md`, `doc/USER-GUIDE.md`.

### CI: supply-chain gates (`68f1cb6`, `cec3a24`)

- **cargo-vet:** `safe-to-deploy` exemptions for the three patch bumps,
  which outran the pinned `imports.lock` (`supply-chain/config.toml`)
- **cargo-deny + cargo-audit:** RUSTSEC-2026-0173 (`proc-macro-error2`
  unmaintained, build-time-only via `validator_derive`) ignored in
  `deny.toml` and `.cargo/audit.toml`. This advisory was red on `main`
  too, so the release also unblocks `main`.

### Style (`1c46a40`)

rustfmt the new flow-style helpers (no behavior change).

### Docs (`be2d24f`)

`RELEASE-NOTES-v0.0.8.md` added; `CHANGELOG.md` v0.0.8 section.

## Diffstat

```
24 files changed, 227 insertions(+), 79 deletions(-)
 crates/noyalib/src/ser.rs              | 122 +++++  (flow fix + tests)
 .github/workflows/*.yml                |  82 +-     (action pin bumps)
 pkg/docker/Dockerfile*                 |  12 +-     (base-image digests)
 supply-chain/config.toml, deny.toml,
 .cargo/audit.toml                      |  28 +      (gate updates)
 Cargo.{toml,lock} x6 + docs            |  ...       (0.0.8 bump)
 RELEASE-NOTES-v0.0.8.md, CHANGELOG.md  | 127 +      (release notes)
```

## Verification

- `cargo test -p noyalib --all-features` 527 passed, 0 failed
- `cargo clippy --all-targets --all-features -D warnings` clean
- `cargo fmt --check` clean
- `cargo vet --locked` Vetting Succeeded; `cargo deny check` advisories ok
- Full CI green (matrix + Miri + no_std + MSRV + cargo-vet/deny/audit)
- Reproduced the #84 snippet against the patched lib: now emits `[0, 1, 2, 3, 4]` / `{a: 1, b: 2, c: 3}`

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)