### PR TITLE
fix(release): repair the binary-distribution pipeline

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -534,10 +534,19 @@ jobs:
           targets:    ${{ env.TARGET }}
           components: llvm-tools-preview
 
+      # Configure RUSTFLAGS exactly as build-release does — via
+      # $GITHUB_ENV in a bash run block so $HOME expands to the real
+      # path. A step-level `env:` value leaves $HOME literal, which
+      # remaps nothing and yields a different (non-matching) binary.
+      - name: Configure reproducible build env
+        shell: bash
+        run: |
+          {
+            echo "RUSTFLAGS=--remap-path-prefix=$HOME=~ --remap-path-prefix=${{ github.workspace }}=/build"
+            echo "NOYA_GEN_ASSETS=1"
+          } >> "$GITHUB_ENV"
+
       - name: Rebuild on a clean runner
-        env:
-          RUSTFLAGS: '--remap-path-prefix=$HOME=~ --remap-path-prefix=${{ github.workspace }}=/build'
-          NOYA_GEN_ASSETS: '1'
         shell: bash
         run: |
           cargo build --release --locked --target ${{ env.TARGET }} \

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -277,8 +277,12 @@ jobs:
         run: |
           set -euo pipefail
           cargo install cargo-generate-rpm --locked --version 0.16.0
+          # cargo-generate-rpm's `--package` is the package *directory*
+          # (it opens `<value>/Cargo.toml`), not a workspace member
+          # name. Point it at crates/noya-cli or it looks for
+          # `noya-cli/Cargo.toml` at the repo root and fails.
           cargo generate-rpm --target ${{ matrix.target }} \
-              --package noya-cli \
+              --package crates/noya-cli \
               --output "${{ github.workspace }}/${ARCHIVE_BASE}.rpm"
 
       # ── .msi (Windows MSVC legs only) ──────────────────────────
@@ -293,6 +297,14 @@ jobs:
           mkdir -p target/wix
           sed "s/__VERSION__/${VERSION}/g" pkg/windows/wix/noyalib.wxs \
               > target/wix/noyalib.wxs
+          # The .wxs references `target\release\*.exe`, but a targeted
+          # `--no-build` build leaves the binaries under
+          # `target\<target>\release\`. Stage them where WiX `light`
+          # expects them so the harvest resolves (avoids exit 103).
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/noyafmt.exe" \
+             "target/${{ matrix.target }}/release/noyavalidate.exe" \
+             target/release/
           cargo wix --target ${{ matrix.target }} \
               --package noya-cli \
               --no-build \
@@ -338,10 +350,11 @@ jobs:
                    ${ARCHIVE_BASE}.deb ${ARCHIVE_BASE}.rpm \
                    ${ARCHIVE_BASE}.msi ${ARCHIVE_BASE}-debuginfo.tar.gz; do
             [[ -f "$f" ]] || continue
-            cosign sign-blob \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem" \
-              "$f"
+            # cosign v4 deprecated --output-signature/--output-certificate
+            # (silently ignored, only the bundle is written). Write a
+            # self-contained sigstore bundle; verify with
+            # `cosign verify-blob --bundle <f>.bundle <f>`.
+            cosign sign-blob --bundle "${f}.bundle" "$f"
           done
 
       # ── Upload paths ───────────────────────────────────────────
@@ -436,9 +449,9 @@ jobs:
           COSIGN_YES: 'true'
         run: |
           cd "${{ github.workspace }}"
-          cosign sign-blob \
-            --output-signature "${ARCHIVE_BASE}.tar.gz.sig" \
-            --output-certificate "${ARCHIVE_BASE}.tar.gz.pem" \
+          # cosign v4: write a self-contained bundle (the legacy
+          # --output-signature/--output-certificate flags are ignored).
+          cosign sign-blob --bundle "${ARCHIVE_BASE}.tar.gz.bundle" \
             "${ARCHIVE_BASE}.tar.gz"
 
       - name: Upload to GitHub Release

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -277,10 +277,35 @@ jobs:
         run: |
           set -euo pipefail
           cargo install cargo-generate-rpm --locked --version 0.16.0
-          # cargo-generate-rpm's `--package` is the package *directory*
-          # (it opens `<value>/Cargo.toml`), not a workspace member
-          # name. Point it at crates/noya-cli or it looks for
-          # `noya-cli/Cargo.toml` at the repo root and fails.
+          # Stage the (already stripped) binaries where the rpm asset
+          # spec references them. A targeted build leaves them under
+          # target/<target>/release/.
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/noyafmt" \
+             "target/${{ matrix.target }}/release/noyavalidate" \
+             target/release/
+          # cargo-generate-rpm requires a [package.metadata.generate-rpm]
+          # table. The released v0.0.8 tag predates it, so inject one at
+          # build time if the checked-out manifest lacks it (idempotent
+          # once the source carries its own). Use echo-group rather than
+          # a heredoc — a quoted heredoc terminator cannot be reached
+          # inside an indented YAML block scalar.
+          if ! grep -q 'package.metadata.generate-rpm' crates/noya-cli/Cargo.toml; then
+            {
+              echo ""
+              echo "[package.metadata.generate-rpm]"
+              echo "assets = ["
+              echo '  { source = "target/release/noyafmt", dest = "/usr/bin/noyafmt", mode = "0755" },'
+              echo '  { source = "target/release/noyavalidate", dest = "/usr/bin/noyavalidate", mode = "0755" },'
+              echo '  { source = "doc/noyafmt.1", dest = "/usr/share/man/man1/noyafmt.1", mode = "0644", doc = true },'
+              echo '  { source = "doc/noyavalidate.1", dest = "/usr/share/man/man1/noyavalidate.1", mode = "0644", doc = true },'
+              echo '  { source = "LICENSE-MIT", dest = "/usr/share/licenses/noya-cli/LICENSE-MIT", mode = "0644", doc = true },'
+              echo '  { source = "LICENSE-APACHE", dest = "/usr/share/licenses/noya-cli/LICENSE-APACHE", mode = "0644", doc = true },'
+              echo "]"
+            } >> crates/noya-cli/Cargo.toml
+          fi
+          # `--package` is the package *directory* (cargo-generate-rpm
+          # opens `<value>/Cargo.toml`), not a workspace member name.
           cargo generate-rpm --target ${{ matrix.target }} \
               --package crates/noya-cli \
               --output "${{ github.workspace }}/${ARCHIVE_BASE}.rpm"
@@ -297,17 +322,24 @@ jobs:
           mkdir -p target/wix
           sed "s/__VERSION__/${VERSION}/g" pkg/windows/wix/noyalib.wxs \
               > target/wix/noyalib.wxs
-          # The .wxs references `target\release\*.exe`, but a targeted
-          # `--no-build` build leaves the binaries under
-          # `target\<target>\release\`. Stage them where WiX `light`
-          # expects them so the harvest resolves (avoids exit 103).
-          mkdir -p target/release
-          cp "target/${{ matrix.target }}/release/noyafmt.exe" \
-             "target/${{ matrix.target }}/release/noyavalidate.exe" \
-             target/release/
+          # The .wxs harvests `target\release\*.exe` and bare `LICENSE-*`
+          # relative to cargo-wix's working dir (which is not the repo
+          # root), and a targeted --no-build build leaves binaries under
+          # target/<target>/release/. Stage both at every plausible
+          # cwd-relative location so `light` resolves them regardless;
+          # `--nocapture` surfaces the real WiX path on any LGHT0103.
+          SRC="target/${{ matrix.target }}/release"
+          for d in target/release crates/noya-cli/target/release target/wix/target/release; do
+            mkdir -p "$d"
+            cp "${SRC}/noyafmt.exe" "${SRC}/noyavalidate.exe" "$d/"
+          done
+          for d in crates/noya-cli target/wix; do
+            cp LICENSE-MIT LICENSE-APACHE "$d/"
+          done
           cargo wix --target ${{ matrix.target }} \
               --package noya-cli \
               --no-build \
+              --nocapture \
               --include target/wix/noyalib.wxs \
               --output "${{ github.workspace }}/${ARCHIVE_BASE}.msi"
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -530,8 +530,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: stable
-          targets:   ${{ env.TARGET }}
+          toolchain:  stable
+          targets:    ${{ env.TARGET }}
+          components: llvm-tools-preview
 
       - name: Rebuild on a clean runner
         env:
@@ -542,6 +543,23 @@ jobs:
           cargo build --release --locked --target ${{ env.TARGET }} \
               --manifest-path crates/noya-cli/Cargo.toml \
               --bin noyafmt --bin noyavalidate
+
+      - name: Strip to match the release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          # build-release strips the gnu binaries (debug-symbol split)
+          # before archiving, so the reproducibility comparison must
+          # strip identically or it compares stripped vs unstripped.
+          SYSROOT=$(rustc --print sysroot)
+          HOST_TUPLE=$(rustc --print host-tuple)
+          OBJCOPY="$SYSROOT/lib/rustlib/$HOST_TUPLE/bin/llvm-objcopy"
+          for bin in noyafmt noyavalidate; do
+            BIN="target/${TARGET}/release/${bin}"
+            "$OBJCOPY" --only-keep-debug "${BIN}" "${BIN}.debug"
+            "$OBJCOPY" --strip-debug --strip-unneeded "${BIN}"
+            "$OBJCOPY" --add-gnu-debuglink="${BIN}.debug" "${BIN}"
+          done
 
       - name: Compute local SHA256
         id: local

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -349,12 +349,22 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ github.workspace }}"
+          # macOS ships `shasum` but not `sha256sum`; the Windows Git
+          # bash ships `sha256sum`/`sha512sum` (coreutils) but not
+          # `shasum`. Pick whichever exists.
+          checksum() {
+            if command -v shasum >/dev/null 2>&1; then
+              shasum -a "$1" "$2"
+            else
+              "sha${1}sum" "$2"
+            fi
+          }
           for f in ${ARCHIVE_BASE}.tar.gz ${ARCHIVE_BASE}.zip \
                    ${ARCHIVE_BASE}.deb ${ARCHIVE_BASE}.rpm \
                    ${ARCHIVE_BASE}.msi ${ARCHIVE_BASE}-debuginfo.tar.gz; do
             [[ -f "$f" ]] || continue
-            shasum -a 256 "$f" > "${f}.sha256"
-            shasum -a 512 "$f" > "${f}.sha512"
+            checksum 256 "$f" > "${f}.sha256"
+            checksum 512 "$f" > "${f}.sha512"
           done
 
       - name: Attest build provenance (SLSA L3)

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -317,28 +317,25 @@ jobs:
         run: |
           set -euo pipefail
           cargo install cargo-wix --locked --version 0.3.9
-          # Render WiX source with the resolved version number, then
-          # invoke cargo-wix using the rendered file.
+          # Render the WiX source: substitute the version and strip the
+          # <Icon>/ARPPRODUCTICON lines. The referenced
+          # pkg/windows/wix/noyalib.ico is not in-tree (the .msi has
+          # never built), so drop the cosmetic ARP icon rather than fail
+          # `light` with LGHT0103. cargo-wix runs `light` from the repo
+          # root, so all other Source paths resolve from there.
           mkdir -p target/wix
-          sed "s/__VERSION__/${VERSION}/g" pkg/windows/wix/noyalib.wxs \
-              > target/wix/noyalib.wxs
-          # The .wxs harvests `target\release\*.exe` and bare `LICENSE-*`
-          # relative to cargo-wix's working dir (which is not the repo
-          # root), and a targeted --no-build build leaves binaries under
-          # target/<target>/release/. Stage both at every plausible
-          # cwd-relative location so `light` resolves them regardless;
-          # `--nocapture` surfaces the real WiX path on any LGHT0103.
-          SRC="target/${{ matrix.target }}/release"
-          for d in target/release crates/noya-cli/target/release target/wix/target/release; do
-            mkdir -p "$d"
-            cp "${SRC}/noyafmt.exe" "${SRC}/noyavalidate.exe" "$d/"
-          done
-          # crates/noya-cli already symlinks the root LICENSE files, so a
-          # plain cp there is a no-op that errors with "same file" under
-          # set -e — make it non-fatal.
-          for d in crates/noya-cli target/wix; do
-            cp -f LICENSE-MIT LICENSE-APACHE "$d/" 2>/dev/null || true
-          done
+          sed -e "s/__VERSION__/${VERSION}/g" \
+              -e '/<Icon /d' \
+              -e '/ARPPRODUCTICON/d' \
+              pkg/windows/wix/noyalib.wxs > target/wix/noyalib.wxs
+          # The .wxs harvests target\release\*.exe, but a targeted
+          # --no-build build leaves the binaries under
+          # target/<target>/release/. Stage them at the root-relative
+          # path the harvest expects (LICENSE-* already live at root).
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/noyafmt.exe" \
+             "target/${{ matrix.target }}/release/noyavalidate.exe" \
+             target/release/
           cargo wix --target ${{ matrix.target }} \
               --package noya-cli \
               --no-build \

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -408,11 +408,21 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ github.workspace }}"
-          gh release upload "${{ inputs.tag }}" \
-            ${ARCHIVE_BASE}.tar.gz* ${ARCHIVE_BASE}.zip* \
-            ${ARCHIVE_BASE}.deb*    ${ARCHIVE_BASE}.rpm* \
-            ${ARCHIVE_BASE}.msi*    ${ARCHIVE_BASE}-debuginfo.tar.gz* \
-            --clobber 2>/dev/null || true
+          # nullglob: most targets have no .deb/.rpm/.msi, so without it
+          # the unmatched patterns reach `gh` as literal filenames and
+          # fail the whole upload. The old `2>/dev/null || true` then hid
+          # that, so only the single-glob universal upload ever landed.
+          shopt -s nullglob
+          files=( ${ARCHIVE_BASE}.tar.gz* ${ARCHIVE_BASE}.zip* \
+                  ${ARCHIVE_BASE}.deb* ${ARCHIVE_BASE}.rpm* \
+                  ${ARCHIVE_BASE}.msi* ${ARCHIVE_BASE}-debuginfo.tar.gz* )
+          for attempt in 1 2 3; do
+            if gh release upload "${{ inputs.tag }}" "${files[@]}" --clobber; then
+              break
+            fi
+            [ "$attempt" = 3 ] && { echo "::error::release upload failed after 3 attempts"; exit 1; }
+            echo "upload attempt ${attempt} failed; retrying" && sleep $((attempt * 15))
+          done
 
       - name: Upload artefact (always; dry-run consumes it)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -333,8 +333,11 @@ jobs:
             mkdir -p "$d"
             cp "${SRC}/noyafmt.exe" "${SRC}/noyavalidate.exe" "$d/"
           done
+          # crates/noya-cli already symlinks the root LICENSE files, so a
+          # plain cp there is a no-op that errors with "same file" under
+          # set -e — make it non-fatal.
           for d in crates/noya-cli target/wix; do
-            cp LICENSE-MIT LICENSE-APACHE "$d/"
+            cp -f LICENSE-MIT LICENSE-APACHE "$d/" 2>/dev/null || true
           done
           cargo wix --target ${{ matrix.target }} \
               --package noya-cli \


### PR DESCRIPTION
Repairs `release-binaries.yml`, which had never published a binary,
`.deb`, `.rpm`, `.msi`, or container. Verified end-to-end with seven
`dry_run=true` dispatches plus two real publishes against the `v0.0.8`
tag.

## What now works (verified on the real v0.0.8 publish)

- All **14 binary targets** + the macOS **universal** build upload to the
  GitHub Release (27 archive assets), each with cosign bundle + SHA256/512
- `.deb` (gnu), `.rpm` (gnu), `.msi` (Windows) packaging
- **Docker images** (noyalib, noyafmt, noyalib-mcp) pushed to GHCR
- Reproducible-build verification passes (byte-identical rebuild)

## Fixes

1. **cosign**: v4 `--bundle` instead of the deprecated
   `--output-signature`/`--output-certificate` (both sign steps)
2. **.rpm**: `--package crates/noya-cli` (it's a path, not a name) +
   inject the missing `[package.metadata.generate-rpm]` table at build time
3. **.msi**: strip the in-tree-missing `<Icon>`/ARPPRODUCTICON ref, stage
   the targeted exes where `light` expects them
4. **checksums**: fall back to `sha256sum`/`sha512sum` where `shasum`
   is absent (Windows Git bash)
5. **reproducibility**: strip the rebuild like the archive and configure
   `RUSTFLAGS` via `$GITHUB_ENV` so `$HOME` expands identically
6. **binary upload (keystone)**: `nullglob` + matched file list + retry —
   unmatched `.deb/.rpm/.msi` globs were passed literally and failed the
   whole upload, which `2>/dev/null || true` then hid

## Still failing (maintainer-held secrets / accounts, out of scope here)

AUR (SSH key/registration), Scoop (`SCOOP_BUCKET_TOKEN` empty), Homebrew
(dispatch-branch ref + tap token), npm ×2 (package registration /
trusted publishing), VS Code (extension entrypoints + marketplace PAT).
Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)