### PR TITLE
chore(release): land rpm metadata + drop missing wxs icon in source

### DIFF
--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -61,3 +61,17 @@ harness = false
 default = ["noyavalidate"]
 noyafmt = ["noyalib/std"]
 noyavalidate = ["noyafmt", "noyalib/noyavalidate", "dep:miette"]
+
+# Package layout for `cargo generate-rpm` (release-binaries.yml).
+# Binary sources use `target/release/...`; the workflow stages the
+# stripped binaries there before packaging, and `--target` rewrites
+# the path for cross builds.
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/noyafmt", dest = "/usr/bin/noyafmt", mode = "0755" },
+    { source = "target/release/noyavalidate", dest = "/usr/bin/noyavalidate", mode = "0755" },
+    { source = "doc/noyafmt.1", dest = "/usr/share/man/man1/noyafmt.1", mode = "0644", doc = true },
+    { source = "doc/noyavalidate.1", dest = "/usr/share/man/man1/noyavalidate.1", mode = "0644", doc = true },
+    { source = "LICENSE-MIT", dest = "/usr/share/licenses/noya-cli/LICENSE-MIT", mode = "0644", doc = true },
+    { source = "LICENSE-APACHE", dest = "/usr/share/licenses/noya-cli/LICENSE-APACHE", mode = "0644", doc = true },
+]

--- a/pkg/windows/wix/noyalib.wxs
+++ b/pkg/windows/wix/noyalib.wxs
@@ -80,8 +80,9 @@ Adds %ProgramFiles%\noyalib to the system PATH so `noyafmt` and
             </Feature>
         </Feature>
 
-        <Icon Id='ProductIcon' SourceFile='pkg\windows\wix\noyalib.ico' />
-        <Property Id='ARPPRODUCTICON' Value='ProductIcon' />
+        <!-- No ARP icon: pkg/windows/wix/noyalib.ico is not in-tree.
+             Add the .ico and restore <Icon>/ARPPRODUCTICON to give the
+             installer a custom Add/Remove Programs icon. -->
         <Property Id='ARPHELPLINK' Value='https://github.com/sebastienrousseau/noyalib' />
         <Property Id='ARPURLINFOABOUT' Value='https://github.com/sebastienrousseau/noyalib' />
     </Product>


### PR DESCRIPTION
Moves the two build-time workarounds from #98 into the source tree, so
the workflow scaffolding becomes a no-op on the next release.

- **`crates/noya-cli/Cargo.toml`**: add `[package.metadata.generate-rpm]`
  with the binary/man-page/license assets. `release-binaries.yml` only
  injects this when it's absent, so this makes the injection a no-op.
- **`pkg/windows/wix/noyalib.wxs`**: drop the `<Icon>`/`ARPPRODUCTICON`
  lines that referenced `pkg/windows/wix/noyalib.ico`, which has never
  been in-tree. The workflow already strips them at render; this makes
  that a no-op. To get a custom installer icon later, add the `.ico` and
  restore both lines.

No behaviour change for the published crates (metadata only); verified
`cargo verify-project` and the `.wxs` stays valid XML.

Refs #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)