### PR TITLE
chore: community-health files (issue/PR templates, funding, discussions)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Uncomment and fill in to show a "Sponsor" button on the repo.
+# Left commented so GitHub doesn't render a button to an inactive
+# funding target. Docs: https://docs.github.com/sponsors/integrating-with-github-sponsors
+#
+# github: [sebastienrousseau]
+# ko_fi: <username>
+# custom: ["https://www.paypal.me/<username>"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Bug report
+description: Report incorrect parsing, serialization, or tooling behaviour.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A minimal, self-contained reproduction is
+        the single most useful thing you can include.
+  - type: input
+    id: version
+    attributes:
+      label: noyalib version
+      description: The crate version, or the `noyafmt --version` / `noyavalidate --version` output.
+      placeholder: "0.0.8"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      options:
+        - Library (noyalib)
+        - CLI — noyafmt
+        - CLI — noyavalidate
+        - LSP (noyalib-lsp)
+        - MCP (noyalib-mcp)
+        - WASM (noyalib-wasm)
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Minimal YAML input
+      description: The smallest document that triggers the problem. This is rendered as YAML.
+      render: yaml
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How you invoked it
+      description: The Rust snippet (e.g. `from_str::<T>(..)`) or the exact CLI command.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include the full error/diagnostic output if any.
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS + `rustc --version` (and target, if cross-compiling).
+      placeholder: "macOS 15.5, rustc 1.85.0, x86_64-apple-darwin"
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for a duplicate.
+          required: true
+        - label: The reproduction above is minimal and self-contained.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas
+    url: https://github.com/sebastienrousseau/noyalib/discussions
+    about: Ask how to use noyalib, or float an idea before filing a feature request.
+  - name: Security vulnerability
+    url: https://github.com/sebastienrousseau/noyalib/security/advisories/new
+    about: Report a vulnerability privately — please do NOT open a public issue (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Feature request
+description: Suggest a new capability or an improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and where does noyalib fall short today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: The API, flag, or behaviour you'd like. Sketch a signature or example if you can.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      options:
+        - Library (noyalib)
+        - CLI — noyafmt
+        - CLI — noyavalidate
+        - LSP (noyalib-lsp)
+        - MCP (noyalib-mcp)
+        - WASM (noyalib-wasm)
+        - Cross-cutting / not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions for a similar request.
+          required: true
+        - label: This fits a YAML 1.2 toolchain (not a YAML spec change request).
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+## Summary
+
+<!-- What does this change and why? One or two sentences. -->
+
+## Related issue
+
+<!-- e.g. "Closes #123". Use "N/A" if none. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (API or behaviour)
+- [ ] Docs / CI / tooling only
+
+## Checklist
+
+- [ ] `cargo fmt --all --check` is clean
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` is clean
+- [ ] `cargo test --all-features` passes (added/updated tests for the change)
+- [ ] Public API changes are documented and reflected in `CHANGELOG.md`
+- [ ] No new `unsafe` (the workspace is `#![forbid(unsafe_code)]`)
+- [ ] Commits are signed (CI verifies this)
+- [ ] Considered MSRV (1.85) and `no_std` impact, where relevant


### PR DESCRIPTION
Closes the cheap gaps in the community-health category.

- **Issue forms** (`.github/ISSUE_TEMPLATE/bug_report.yml`,
  `feature_request.yml`) tailored to the toolchain: a surface dropdown
  (library / noyafmt / noyavalidate / LSP / MCP / WASM) and a
  YAML-rendered minimal-repro field.
- **`config.yml`** disables blank issues and routes questions to
  **Discussions** (now enabled) and vulnerabilities to a private GitHub
  Security Advisory (per `SECURITY.md`).
- **`PULL_REQUEST_TEMPLATE.md`** with a checklist mirroring the actual
  CI gates (fmt, clippy `-D warnings`, tests, CHANGELOG, signed commits,
  `forbid(unsafe_code)`, MSRV/`no_std`).
- **`FUNDING.yml`** commented template (no dead Sponsor button).

All new files sit under `.github/`, covered by the existing REUSE
`.github/**` blanket annotation, so the compliance gate stays green.

`CODE_OF_CONDUCT.md` was intentionally deferred. **Maturity & adoption**
(the other C+ category) isn't fixable by files — it's a function of age,
downloads, and the 0.0.x→1.0 decision, which is yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)