### PR TITLE
docs: add Contributor Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,82 @@
+# Contributor Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation
+in the noyalib community a harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion,
+or identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Behaviour that helps create a positive environment includes:
+
+- Showing empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Taking responsibility, apologising to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the community as a whole
+
+Unacceptable behaviour includes:
+
+- Harassment of any kind, whether public or private
+- Discriminatory, demeaning, or derogatory comments, and personal or
+  political attacks
+- Trolling, insults, or deliberate intimidation
+- Publishing others' private information (such as a physical or email
+  address) without their explicit permission
+- Any other conduct that could reasonably be considered inappropriate in
+  a professional setting
+
+## Enforcement responsibilities
+
+Maintainers are responsible for clarifying and enforcing these standards
+and will take appropriate, fair corrective action in response to any
+behaviour they consider inappropriate, threatening, offensive, or
+harmful. Maintainers may remove, edit, or reject comments, commits, code,
+issues, and other contributions that do not align with this Code of
+Conduct, and will explain moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — the
+repository, issues, pull requests, and Discussions — and also when an
+individual is officially representing the community in public spaces.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may
+be reported privately to the project maintainer at
+**sebastian.rousseau@gmail.com**. All reports will be reviewed and
+investigated promptly and fairly. Maintainers are obligated to respect
+the privacy and security of anyone who reports an incident.
+
+## Enforcement guidelines
+
+Maintainers will follow these guidelines when determining the
+consequences for a violation:
+
+1. **Correction** — a private, written warning explaining the nature of
+   the violation and why it was inappropriate.
+2. **Warning** — consequences for continued behaviour, which may include
+   a period of no interaction with those involved.
+3. **Temporary ban** — a temporary ban from any interaction or public
+   communication with the community.
+4. **Permanent ban** — a permanent ban from any form of community
+   interaction.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+[cc]: https://www.contributor-covenant.org

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -42,6 +42,7 @@ SPDX-License-Identifier = "MIT OR Apache-2.0"
 path = [
     "README.md",
     "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
     "CONTRIBUTING.md",
     "GETTING_STARTED.md",
     "GLOSSARY.md",


### PR DESCRIPTION
Completes the community-health set (follow-up to #101).

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (adapted): pledge,
  standards, scope, private reporting to the maintainer, and the
  enforcement ladder (correction → warning → temporary ban → permanent
  ban). Full Covenant adopted by reference.
- `REUSE.toml` — registered the file in the documentation annotation
  (it's a root-level doc, like CONTRIBUTING.md), so the REUSE gate stays
  green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)