### PR TITLE
perf(loader): steal mapping keys instead of cloning them

### DIFF
--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -581,22 +581,28 @@ impl<'a> Loader<'a> {
                     if map.len() >= self.config.max_mapping_keys {
                         return Err(Error::Serialize("mapping key limit exceeded".to_owned()));
                     }
+                    // Steal the owned key out of the frame instead of
+                    // cloning it on every insert — the frame is replaced
+                    // (without `key`) immediately below, so the emptied
+                    // slot is discarded. Each branch is the last use of
+                    // `key`, so the move is sound.
+                    let key = core::mem::take(key);
                     match self.config.duplicate_key_policy {
                         DuplicateKeyPolicy::First => {
-                            if !map.contains_key(key) {
-                                let _ = map.insert(key.clone(), value);
+                            if !map.contains_key(&key) {
+                                let _ = map.insert(key, value);
                                 span_entries.push((*key_span, span));
                             }
                         }
                         DuplicateKeyPolicy::Last => {
-                            let _ = map.insert(key.clone(), value);
+                            let _ = map.insert(key, value);
                             span_entries.push((*key_span, span));
                         }
                         DuplicateKeyPolicy::Error => {
-                            if map.contains_key(key) {
-                                return Err(Error::DuplicateKey(key.clone()));
+                            if map.contains_key(&key) {
+                                return Err(Error::DuplicateKey(key));
                             }
-                            let _ = map.insert(key.clone(), value);
+                            let _ = map.insert(key, value);
                             span_entries.push((*key_span, span));
                         }
                     }
@@ -916,7 +922,11 @@ impl<'a> NoSpanLoader<'a> {
                 if is_merge && !merge_treat_as_ordinary {
                     merge_values.push(value);
                 } else {
-                    let _ = map.insert(key.clone(), value);
+                    // Steal the owned key out of the frame instead of
+                    // cloning it — the frame is overwritten (without
+                    // `key`) immediately below, so the emptied slot is
+                    // discarded.
+                    let _ = map.insert(core::mem::take(key), value);
                 }
                 let old_map = core::mem::take(map);
                 let old_anchor = anchor.take();
@@ -976,7 +986,7 @@ fn value_to_key_string(value: Value) -> Option<String> {
                 }
                 let _ = write!(s, "{}", value_to_key_string(v).unwrap_or_default());
             }
-            s.push("]".chars().next().unwrap());
+            s.push(']');
             Some(s)
         }
         Value::Mapping(m) => {
@@ -989,7 +999,7 @@ fn value_to_key_string(value: Value) -> Option<String> {
                 s.push_str(": ");
                 let _ = write!(s, "{}", value_to_key_string(v).unwrap_or_default());
             }
-            s.push("}".chars().next().unwrap());
+            s.push('}');
             Some(s)
         }
     }


### PR DESCRIPTION
First optimization from the perf sweep. Eliminates a per-mapping-key
`String` clone in the event-to-`Value` loader hot path.

### The change
The loader cloned each key on insert (`map.insert(key.clone(), value)`)
in both the span-aware and no-span paths. The key lives in a
`&mut`-borrowed stack frame that is replaced (without `key`) immediately
after the insert, so the owned `String` can be **stolen** with
`core::mem::take(key)` and moved into the map — one fewer heap
allocation + copy per key. (A plain move won't compile here: `key` is
`&mut String` borrowed from the on-stack frame, hence `mem::take`.)

Also swaps two `"]".chars().next().unwrap()` constructs for char literals
in the complex-key formatter.

### Measured (isolated criterion A/B vs a clean `main` baseline)
| Benchmark | Change | Significant? |
|---|---|---|
| `from_str_typed` | **−18.4%** | p<0.05 ✓ |
| `from_slice` | **−14.9%** | p<0.05 ✓ |
| `from_str_with_config_default` | **−13.1%** | p<0.05 ✓ |
| `from_str_value` | **−12.5%** | p<0.05 ✓ |
| `from_str_with_config_strict` | **−8.4%** | p<0.05 ✓ |
| `from_value` (control, bypasses loader) | −2.9% | p=0.08 — **no change** |

The `from_value` control doesn't touch the loader and shows no
significant change, confirming the speedup is the key-clone path, not
measurement noise.

> Note on methodology: an earlier run showed a bogus "regression"
> because a stale baseline benchmark was still running and contending for
> CPU (the loader-independent `from_value` path also "regressed" 39%,
> which is impossible). Re-measured in isolation with criterion's
> `--save-baseline`/`--baseline`.

### Verified
- build · `fmt --check` · `clippy --all-features -D warnings` ✓
- `cargo test -p noyalib --all-features` → **5,217 passed, 0 failed**
  (incl. duplicate-key-policy First/Last/Error + spec suites)

CI runs the full matrix incl. semver-checks, Miri, fuzz-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)