### PR TITLE
release: v0.0.10 (scanner: leading BOM transparent to indentation and comments)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "ariadne",
  "bytes",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.9", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.10", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.9", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.10", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.9" }
+noyalib = { path = "../noyalib", version = "0.0.10" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.9", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.10", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/src/parser/scanner.rs
+++ b/crates/noyalib/src/parser/scanner.rs
@@ -777,7 +777,12 @@ impl<'a> Scanner<'a> {
                 // `"value"# bad`) and is not a valid comment indicator.
                 if self.pos > 0 {
                     let prev = self.input[self.pos - 1];
-                    if !Self::is_blank_or_break(prev) {
+                    // A leading BOM is a zero-width stream prefix, so a `#`
+                    // immediately after it is at the start of the input (a valid
+                    // comment start), not an inline `#` adjacent to content.
+                    let after_leading_bom =
+                        self.pos == 3 && self.input.starts_with(&[0xEF, 0xBB, 0xBF]);
+                    if !after_leading_bom && !Self::is_blank_or_break(prev) {
                         return Err(self.error(
                             "comment indicator '#' must be preceded by a space, tab, or line break",
                         ));
@@ -1139,6 +1144,14 @@ impl<'a> Scanner<'a> {
         {
             let bom_start = self.pos;
             self.advance_by(3);
+            // A leading BOM is a zero-width stream marker: the content that
+            // follows it begins at column 0. `advance_by` counts the three BOM
+            // bytes as columns, so without this reset the first node is tracked
+            // at column 3, poisoning the document's indentation baseline — a
+            // later sibling at column 0 is then misread as a dedent below the
+            // document, producing a spurious "stray content after document"
+            // error for any BOM-prefixed input with more than one node.
+            self.col = 0;
             if self.recording {
                 self.trivia.push(Trivia {
                     start: bom_start,
@@ -1741,10 +1754,20 @@ impl<'a> Scanner<'a> {
                 // Roll indent for block mapping.
                 if self.flow_level == 0 {
                     self.reject_block_inline_with_doc_start("':'")?;
-                    let line_start = self.input[..sk.index]
+                    let mut line_start = self.input[..sk.index]
                         .iter()
                         .rposition(|&b| b == b'\n')
                         .map_or(0, |nl| nl + 1);
+                    // A leading BOM occupies the first three bytes of the
+                    // stream but contributes no visual column. Exclude it so a
+                    // first-line key is measured from column 0 (consistent with
+                    // `self.col`, which is reset after the BOM in
+                    // `fetch_stream_start`). Without this the key's indent is
+                    // over-counted by 3, so a following sibling at column 0 is
+                    // misread as a dedent and the mapping is split in two.
+                    if line_start == 0 && self.input.starts_with(&[0xEF, 0xBB, 0xBF]) {
+                        line_start = 3;
+                    }
                     let leading = &self.input[line_start..sk.index];
                     // YAML 1.2.2 §6.1: block-mapping key indentation
                     // must be spaces only. A tab in the leading
@@ -2087,6 +2110,69 @@ mod tests {
                 i < tokens.len() && tokens[i].contains(exp),
                 "Token {i}: expected to contain {exp:?}, got {:?}\nAll tokens: {tokens:#?}",
                 tokens.get(i)
+            );
+        }
+    }
+
+    /// Collect token-kind debug strings for `input`, panicking on the first
+    /// scanner error (so a regression surfaces as a precise failure).
+    fn scan_kinds(input: &str) -> Vec<String> {
+        let mut scanner = Scanner::new(input);
+        let mut tokens = Vec::new();
+        loop {
+            match scanner.next_token() {
+                Ok(t) => {
+                    let is_end = matches!(t.kind, TokenKind::StreamEnd);
+                    tokens.push(format!("{:?}", t.kind));
+                    if is_end {
+                        break;
+                    }
+                }
+                Err(e) => panic!("Scanner error after tokens {tokens:#?}: {e}"),
+            }
+        }
+        tokens
+    }
+
+    /// A leading UTF-8 BOM must be transparent to indentation: a BOM-prefixed
+    /// multi-key mapping has to scan to the same token stream as the same
+    /// document without the BOM. Regression test for the column-tracking bug
+    /// where `advance_by(3)` over the BOM left the first key at column 3, so the
+    /// second key (column 0) was misread as content after the document's end.
+    #[test]
+    fn test_scanner_leading_bom_multi_key_mapping() {
+        let plain = scan_kinds("a: 1\nb: 2\n");
+        let bommed = scan_kinds("\u{FEFF}a: 1\nb: 2\n");
+        assert_eq!(
+            bommed, plain,
+            "BOM-prefixed mapping should scan identically to the BOM-less one",
+        );
+        // Sanity: both keys and the closing BlockEnd are present (i.e. the
+        // mapping did not terminate early after the first key).
+        assert!(
+            bommed.iter().any(|t| t.contains("Scalar(Plain, \"b\")")),
+            "second key `b` missing — document ended prematurely: {bommed:#?}",
+        );
+        assert!(
+            bommed.iter().any(|t| t == "BlockEnd"),
+            "BlockEnd missing — mapping not closed: {bommed:#?}",
+        );
+    }
+
+    /// A leading BOM must be transparent for every top-level construct, not
+    /// just single-line mappings: a BOM-prefixed sequence, a nested mapping,
+    /// and a leading comment must each scan identically to their BOM-less form.
+    #[test]
+    fn test_scanner_leading_bom_is_transparent() {
+        for (bommed, plain) in [
+            ("\u{FEFF}- 1\n- 2\n", "- 1\n- 2\n"),
+            ("\u{FEFF}a:\n  b: 1\n", "a:\n  b: 1\n"),
+            ("\u{FEFF}# header\nname: x\n", "# header\nname: x\n"),
+        ] {
+            assert_eq!(
+                scan_kinds(bommed),
+                scan_kinds(plain),
+                "BOM-prefixed input {bommed:?} should scan identically to {plain:?}",
             );
         }
     }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.9", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.10", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.6"
 clap_mangen   = "0.3"


### PR DESCRIPTION
**v0.0.10 release: single-theme patch — a leading UTF-8 BOM no longer breaks multi-node parsing.**

Rebased from [#118](https://github.com/sebastienrousseau/noyalib/pull/118) by [@zoosky](https://github.com/zoosky) onto post-v0.0.9 \`main\`, with the workspace version bump 0.0.9 → 0.0.10 included so the tag-verify job at release time accepts the tag against every \`Cargo.toml\`. Full credit + commit authorship preserved.

This is a one-theme release in line with the long 0.0.x runway / maturity-over-haste posture: every release tells one story, so any future bisect across v0.0.9 → v0.0.10 lands precisely on the scanner change.

## What's fixed

A leading UTF-8 BOM (\`U+FEFF\`, 3 bytes \`0xEF 0xBB 0xBF\`) made any document with more than one node fail to parse on the strict \`parse_document\` path. The scanner consumed the BOM but counted its three bytes toward the column of the following content, so:

\`\`\`
<BOM>a: 1
b: 2
\`\`\`

→ \`stray content after document — subsequent documents must start with '---'\`

The same failure hit BOM-prefixed sequences, nested mappings, and \`<BOM># comment\`-style first-line comments. Single-node BOM-prefixed documents parsed *by accident* — there was no following sibling to trip the dedent check.

(The lenient \`parse_lenient\` path and the \`tokio_async\` reader already worked correctly — they strip the BOM upstream before parsing. Only the strict scanner path was affected.)

## Root cause

A leading BOM is a zero-width stream prefix: content after it begins at column 0. Three code paths in \`parser/scanner.rs\` instead treated the consumed BOM bytes as content preceding the next token:

1. \`fetch_stream_start\` consumed the BOM with \`advance_by(3)\`, which added 3 to the incremental column counter.
2. The simple-key indent recomputed a key's column from its byte offset (\`sk.index - line_start\`); on the first line \`line_start\` was 0, so the BOM's three bytes counted as indentation. The first key landed at column 3, and a following sibling at column 0 unrolled the mapping — a premature document end (or a split mapping).
3. The block-context comment check rejected a \`#\` whose preceding byte was not whitespace/break — after a BOM that byte is \`0xBF\`.

## Fix

Make the leading BOM transparent in all three places:

- reset the column to 0 after consuming the BOM in \`fetch_stream_start\`;
- skip a leading BOM when computing a simple key's column from its byte offset;
- treat a \`#\` immediately after a leading BOM as a start-of-input comment.

The BOM is still recorded as a \`Bom\` trivia leaf, so the CST round-trip stays byte-faithful: BOM-prefixed files now round-trip (\`parse_document(s).to_string() == s\`) instead of erroring.

Each fix carries a tight \`pos == 3\` or \`line_start == 0 && starts_with(&[0xEF, 0xBB, 0xBF])\` gate so the new behaviour only fires on a *leading* BOM — interior \`0xEF\` bytes in legitimate UTF-8 codepoints are never mistaken for one.

## Behaviour matrix (\`parse_document(...).to_string()\`)

| input | before | after |
|---|---|---|
| \`<BOM>a: 1\\nb: 2\\n\` | parse error | round-trips |
| \`<BOM>- 1\\n- 2\\n\` | parse error | round-trips |
| \`<BOM>a:\\n  b: 1\\n\` | parse error | round-trips |
| \`<BOM>a: 1\\r\\nb: 2\\r\\n\` | parse error | round-trips |
| \`<BOM># c\\nname: x\\n\` | parse error | round-trips |
| \`<BOM>a: 1\\n\` (single node) | round-trips | round-trips |

## Tests

Two new scanner-level regression tests — \`test_scanner_leading_bom_multi_key_mapping\` and \`test_scanner_leading_bom_is_transparent\` — asserting that BOM-prefixed mappings, sequences, nested mappings, and a leading comment scan **identically** to their BOM-less form via a \`scan_kinds\` helper that gives precise diff diagnostics on regression.

## Workspace

- noyalib, noya-cli, noyalib-mcp, noyalib-lsp, noyalib-wasm: 0.0.9 → 0.0.10
- Intra-workspace \`version =\` pins synced
- xtask stays at 0.0.1 (internal tool)

## Test plan
- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test parser::scanner::tests::test_scanner_leading_bom\` — both new tests pass
- [x] \`cargo vet --locked\` — 269 fully audited, 18 exempted
- [ ] CI 100% green on this PR

Closes #118 (superseded — same content, same author, rebased + bumped).

Co-authored-by: Zoo Sky <zoosky@gmail.com>