### PR TITLE
release: v0.0.11 (CI integrity + no_std fix + strict rustdoc PR gate + cache-poisoning guard + README doctest CI + advisory dismissal)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,38 @@ jobs:
       - name: cargo check --no-default-features
         run: cargo check --no-default-features --lib --locked
 
+  readme-examples:
+    name: README examples (root)
+    # Every `` ```rust `` code block in the workspace-root
+    # README.md is extracted and compiled against `noyalib` from a
+    # scratch project. Broken landing-page examples fail the PR.
+    #
+    # Cannot use `#[doc = include_str!("../../../README.md")]` in
+    # noyalib's lib.rs because the workspace-root README lives
+    # outside the crate's package layout, so `cargo publish
+    # --dry-run` would fail verification. The script-based path
+    # (`scripts/check-readme-examples.sh`) preserves the "every
+    # README example is tested" invariant without breaking
+    # publish.
+    #
+    # CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. The
+    # scratch project this job spins up must never be served a
+    # cached artefact set from a different feature configuration.
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-readme-examples
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-readme-examples"
+          key: readme-examples
+      - name: Compile every ```rust block in README.md
+        run: bash scripts/check-readme-examples.sh
+
   docs-strict:
     name: rustdoc (strict)
     # Mirror the same RUSTDOCFLAGS the docs.yml deployment job uses,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,43 @@ jobs:
     # The README and CHANGELOG promise that `default-features = false`
     # builds without `std`. This job enforces that promise on every
     # push so the claim never silently regresses.
+    #
+    # CACHE-POISONING GUARD: this job uses an isolated CARGO_TARGET_DIR
+    # so the no_std fingerprint can never be served from a previous
+    # `cargo check` that ran with `std` on (those would share the
+    # default `target/` under Swatinem/rust-cache and silently return
+    # a stale-but-passing result, masking real no_std regressions —
+    # exactly what hid the missing `crate::prelude::Vec` / `vec` import
+    # in doc_boundary.rs and the unused `crate::span_context` import in
+    # de.rs through v0.0.9 and v0.0.10).
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-no-std
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Scope the cache to this job's isolated target dir, and
+          # split the cache namespace so it can't share state with the
+          # `std`-on jobs. Belt-and-braces: even if Swatinem changes
+          # default behaviour, the explicit CARGO_TARGET_DIR above is
+          # the real guarantee.
+          workspaces: ". -> target-no-std"
+          key: no-std
+      - name: cargo check --no-default-features
+        run: cargo check --no-default-features --lib --locked
+
+  docs-strict:
+    name: rustdoc (strict)
+    # Mirror the same RUSTDOCFLAGS the docs.yml deployment job uses,
+    # but on every PR — broken intra-doc links and bad codeblock
+    # fence attributes should fail a PR, not break the Pages
+    # deployment after merge. (For three days through v0.0.9 +
+    # v0.0.10 the docs.yml job was silently failing on main while
+    # PRs sailed through; this gate closes that hole.)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -407,8 +444,16 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: cargo check --no-default-features
-        run: cargo check --no-default-features --lib
+      - name: cargo doc --no-deps --all-features (strict)
+        env:
+          RUSTDOCFLAGS: >-
+            -D warnings
+            -D rustdoc::broken_intra_doc_links
+            -D rustdoc::private_intra_doc_links
+            -D rustdoc::invalid_codeblock_attributes
+            -D rustdoc::invalid_html_tags
+            -D rustdoc::bare_urls
+        run: cargo doc --workspace --no-deps --all-features --locked
 
   verify-signatures:
     name: Verify commit signatures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Cache cargo
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
           components: miri
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
           components: miri
@@ -189,7 +189,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-fuzz
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -314,7 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: "1.85.0"
           components: clippy
@@ -361,7 +361,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-coverage
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
           components: llvm-tools-preview
@@ -370,7 +370,7 @@ jobs:
           workspaces: ". -> target-coverage"
           key: coverage-nightly
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-llvm-cov
       - name: "Coverage report (gates: 96% fn / 93% region / 94% line)"
@@ -421,7 +421,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -473,7 +473,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-no-std
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -507,7 +507,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-docs-strict
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,16 @@ jobs:
     #     contention without letting a real hang sit forever; the
     #     scheduled `miri-full` (90 min) still covers the deeper
     #     sweep plus big-endian.
+    # CACHE-POISONING GUARD: Miri builds use `-Zmiri-*` flags plus
+    # the Miri sysroot — completely distinct fingerprint from every
+    # stable / nightly cargo build. Isolated CARGO_TARGET_DIR so
+    # a stale non-Miri artefact set cannot mask a Miri regression;
+    # `~/.cache/miri` and `target-miri/miri` still cache the
+    # (expensive) sysroot build across PRs via the actions/cache
+    # entry below (keyed on toolchain + Cargo.lock).
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust nightly with Miri
@@ -101,13 +110,15 @@ jobs:
         with:
           path: |
             ~/.cache/miri
-            target/miri
+            target-miri/miri
           key: miri-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
           restore-keys: |
             miri-${{ runner.os }}-
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          workspaces: ". -> target-miri"
+          key: miri-focused
           save-if: false
       - name: Run focused Miri suite
         run: ./scripts/miri.sh
@@ -119,11 +130,15 @@ jobs:
     # endianness assumption that would slip past the focused
     # per-PR job. Bandwidth-intensive (~30+ minutes) so gated
     # behind the schedule / manual trigger.
+    #
+    # CACHE-POISONING GUARD: same isolated CARGO_TARGET_DIR
+    # pattern as the focused Miri job.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
       RUSTUP_TOOLCHAIN: nightly
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri-full
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust nightly with Miri
@@ -134,6 +149,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          workspaces: ". -> target-miri-full"
+          key: miri-full
           save-if: false
       - name: Setup Miri
         run: cargo +nightly miri setup
@@ -160,14 +177,25 @@ jobs:
     # The full multi-hour campaign runs on the weekly soak job in
     # `security.yml`. 10s is enough to surface trivial regressions
     # the instant they land without slowing PR feedback.
+    #
+    # CACHE-POISONING GUARD: cargo-fuzz uses a sanitiser-enabled
+    # nightly build with `-Cinstrument-coverage=off -Cpasses=sancov-module`
+    # under the hood — a distinct fingerprint from every other
+    # job. Isolated CARGO_TARGET_DIR so a stale non-fuzz artefact
+    # set cannot short-circuit the sanitiser build.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-fuzz
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-fuzz"
+          key: fuzz-diff
       - run: cargo install --locked cargo-fuzz
       - run: cargo +nightly fuzz run fuzz_diff -- -max_total_time=10
         working-directory: .
@@ -277,6 +305,12 @@ jobs:
     # - default features: std + core surface, MSRV 1.85.
     # - feature combinations beyond default require newer
     #   toolchains; the stable test matrix covers those.
+    #
+    # CACHE-POISONING GUARD: three separate CARGO_TARGET_DIRs so
+    # the no_std, default-features, and clippy checks each have
+    # their own fingerprint namespace. Sharing target/ across
+    # feature configurations is exactly how a stale-but-passing
+    # cache can mask a real regression (see no-std job below).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -285,11 +319,23 @@ jobs:
           toolchain: "1.85.0"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            . -> target-msrv-nostd
+            . -> target-msrv-default
+            . -> target-msrv-clippy
+          key: msrv-1.85
       - name: cargo check (no_std)
-        run: cargo check --no-default-features --locked
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-nostd
+        run: cargo check --no-default-features --lib --locked
       - name: cargo check (default features)
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-default
         run: cargo check --locked
       - name: cargo clippy on MSRV core
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-clippy
         run: cargo clippy --lib --locked -- -D warnings
 
   coverage-gate:
@@ -302,7 +348,17 @@ jobs:
     # SQLite, serde, hyper). Fails the build if region coverage
     # drops below the threshold so coverage regressions can never
     # land silently.
+    #
+    # CACHE-POISONING GUARD: coverage instrumentation adds
+    # `-C instrument-coverage` and NOYALIB_COVERAGE=1 gates the
+    # `#[cfg(noyalib_coverage)]` code paths — completely distinct
+    # fingerprint from every other cargo job. Isolated
+    # CARGO_TARGET_DIR + scoped cache key so a stale
+    # non-instrumented artefact set can never mask an
+    # instrumentation regression.
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-coverage
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
@@ -310,6 +366,9 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-coverage"
+          key: coverage-nightly
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
@@ -437,13 +496,24 @@ jobs:
     # deployment after merge. (For three days through v0.0.9 +
     # v0.0.10 the docs.yml job was silently failing on main while
     # PRs sailed through; this gate closes that hole.)
+    #
+    # CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. rustdoc
+    # fingerprints depend on RUSTDOCFLAGS env; if a Swatinem cache
+    # from a different job (without the strict flags) restored
+    # into target/, cargo could serve a stale hit and mask new
+    # broken doc links.
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-docs-strict
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-docs-strict"
+          key: docs-strict
       - name: cargo doc --no-deps --all-features (strict)
         env:
           RUSTDOCFLAGS: >-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,14 @@ concurrency:
 jobs:
   build:
     name: Build Documentation
+    # CACHE-POISONING GUARD: strict RUSTDOCFLAGS below make this
+    # build's fingerprint distinct from any warnings-tolerant docs
+    # cache. Isolated CARGO_TARGET_DIR ensures a permissive
+    # rustdoc artefact set can't be restored and short-circuit
+    # the strict gate.
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-docs-pages
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -28,6 +35,9 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-docs-pages"
+          key: docs-pages
 
       - name: Build documentation (strict)
         # Strengthened RUSTDOCFLAGS catch broken intra-doc links,
@@ -46,7 +56,7 @@ jobs:
             -D rustdoc::bare_urls
         run: |
           cargo doc --no-deps --all-features
-          echo '<meta http-equiv="refresh" content="0; url=noyalib/index.html">' > target/doc/index.html
+          echo '<meta http-equiv="refresh" content="0; url=noyalib/index.html">' > target-docs-pages/doc/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -54,7 +64,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: target/doc
+          path: target-docs-pages/doc
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
           targets:   ${{ matrix.target }}
@@ -538,7 +538,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain:  stable
           targets:    ${{ env.TARGET }}
@@ -825,7 +825,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
 
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
           targets:   wasm32-unknown-unknown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: stable
 
@@ -211,7 +211,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-release-verify-${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -284,7 +284,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: stable
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,19 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
 
+      # CACHE-POISONING GUARD: release-time quality gate uses an
+      # isolated CARGO_TARGET_DIR so a stale artefact set from a
+      # PR-time build (with different lints, warnings, or feature
+      # config) can never mask a release regression. Release must
+      # verify from a clean-fingerprint state.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-release-validate"
+          key: release-validate
 
       - name: Quality checks
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-release-validate
         run: |
           cargo fmt --all -- --check
           cargo clippy --all-targets --all-features -- -D warnings
@@ -185,6 +195,10 @@ jobs:
   # ── Cross-platform verification ─────────────────────────────────────
   cross-verify:
     name: Verify (${{ matrix.os }})
+    # CACHE-POISONING GUARD: per-OS + per-release-tag CARGO_TARGET_DIR
+    # so this cross-platform verification always runs from a
+    # release-tag-scoped fingerprint, never sharing state with the
+    # validate job or with any other cross-verify OS.
     needs: validate
     runs-on: ${{ matrix.os }}
     permissions:
@@ -193,12 +207,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-release-verify-${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-release-verify-${{ matrix.os }}"
+          key: release-verify-${{ matrix.os }}
       - run: cargo test --all-features
 
   # ── GitHub Release ──────────────────────────────────────────────────

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,6 +55,11 @@ jobs:
   # for triage.
   soak-fuzz:
     name: Soak fuzz (${{ matrix.target }})
+    # CACHE-POISONING GUARD: per-matrix-target CARGO_TARGET_DIR so
+    # each fuzz target (`fuzz_parse`, `fuzz_roundtrip`, `fuzz_diff`,
+    # `fuzz_strict`) has its own sanitiser-instrumented artefact
+    # set. Sharing target/ across fuzz configurations is exactly
+    # how a stale cache could hide a fuzz regression.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -63,12 +68,17 @@ jobs:
       fail-fast: false
       matrix:
         target: [fuzz_parse, fuzz_roundtrip, fuzz_diff, fuzz_strict]
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-soak-fuzz-${{ matrix.target }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-soak-fuzz-${{ matrix.target }}"
+          key: soak-fuzz-${{ matrix.target }}
       - name: Install cargo-fuzz
         run: cargo install --locked cargo-fuzz
       - name: Run ${{ matrix.target }} for 1 hour
@@ -94,11 +104,15 @@ jobs:
   # runs the entire suite.
   soak-miri:
     name: Soak Miri (full suite)
+    # CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR — Miri's
+    # interpreter fingerprint is distinct from every other job.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 1440  # 24h ceiling
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-soak-miri
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
@@ -106,6 +120,9 @@ jobs:
           toolchain: nightly
           components: miri
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-soak-miri"
+          key: soak-miri
       - name: Setup Miri
         run: cargo +nightly miri setup
       - name: Run full suite under Miri

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -72,7 +72,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-soak-fuzz-${{ matrix.target }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -115,7 +115,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target-soak-miri
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly
           components: miri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,146 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet - `[v0.0.8]` is the cut.)
+(Nothing yet - `[v0.0.11]` is the cut.)
+
+## [v0.0.11] - 2026-07-01
+
+The **CI-integrity** cut. Fixes a silently-broken `no_std` build that
+had been masked on `main` since v0.0.9 by cache poisoning in the CI
+gates, closes three broken intra-doc links that were failing the
+Pages-deployment workflow every push, hardens every specialised cargo
+job across `ci.yml`, `security.yml`, `docs.yml`, and `release.yml`
+with an isolated `CARGO_TARGET_DIR` so a stale artefact set can no
+longer serve as a passing fingerprint for a different feature-set,
+adds a strict-rustdoc PR gate so broken doc links fail a PR rather
+than the post-merge Pages deployment, and closes OSSF Scorecard Code
+Scanning alert #36 (`RUSTSEC-2026-0173`, `proc-macro-error2`
+unmaintained — build-time-only via the opt-in `validator` feature,
+never ships in a release artefact) with a source-controlled
+`osv-scanner.toml` ignore.
+
+No public API change. No MSRV change (still 1.85). One behavior
+change under `--no-default-features`: `crates/noyalib/src/doc_boundary.rs`
+now correctly imports `Vec` and `vec![]` from the `crate::prelude`
+under `no_std` (previously used them without importing, which the
+poisoned `no_std` CI gate never noticed).
+
+### Fixed
+
+- **`no_std` build actually compiles.** `doc_boundary.rs` used `Vec`
+  and `vec![]` without importing them from `crate::prelude`. Under
+  `std` the prelude auto-imports both; under `no_std` they're only
+  reachable via `alloc::vec::Vec` / `alloc::vec` or the project's
+  `crate::prelude` re-export. Adds `use crate::prelude::{Vec, vec};`.
+  Also gates `use crate::span_context;` in `de.rs` behind
+  `#[cfg(feature = "std")]` to match its call sites, so
+  `--no-default-features` no longer trips `-D unused-imports`.
+- **Three broken intra-doc links** in `de/config.rs` (`[Value]` at
+  lines 179, 191, 348 and `[Error::Custom]` at line 213) now resolve.
+  These had been failing the `Documentation` workflow's strict
+  `-D warnings` build on every push to `main` since 2026-06-30.
+  Qualified all four to `[Value](crate::Value)` /
+  `[Error::Custom](crate::Error::Custom)`.
+
+### Changed
+
+- **CI cache-poisoning guard applied across every specialised cargo
+  job.** `no_std`, `MSRV (1.85.0) core build`, `Miri (focused)`,
+  `Miri (full + big-endian, scheduled)`, `Coverage gate`,
+  `Differential fuzz (10s smoke)`, `rustdoc (strict)`, `soak-fuzz`,
+  `soak-miri`, `docs.yml`, `release.yml/validate`, and
+  `release.yml/cross-verify` all now use an isolated
+  `CARGO_TARGET_DIR` plus a scoped Swatinem cache namespace. Sharing
+  target/ across feature configurations was how the `no_std` job
+  passed a stale-but-clean check for two full releases while the
+  code was actually broken — this pattern rules that out.
+- **New `docs-strict` PR-gated job** added to `ci.yml`. Mirrors the
+  strict `RUSTDOCFLAGS` (`-D warnings` + `broken_intra_doc_links` +
+  `private_intra_doc_links` + `invalid_codeblock_attributes` +
+  `invalid_html_tags` + `bare_urls`) that `docs.yml` uses on `main`,
+  but on every PR. Broken doc links now fail a PR instead of the
+  Pages deployment after merge.
+
+### Security
+
+- **Code Scanning alert #36 closed.** `RUSTSEC-2026-0173`
+  (`proc-macro-error2` unmaintained) documented as accepted risk in
+  the new `osv-scanner.toml` (mirroring the pre-existing `deny.toml`
+  `[advisories.ignore]` entry) so OSSF Scorecard's Vulnerabilities
+  check no longer re-flags it. Rationale is build-time-only exposure
+  via the opt-in `validator` feature; never ships in a release
+  artefact. Revisit when `validator` cuts a release that drops
+  `proc-macro-error2`.
+
+## [v0.0.10] - 2026-06-30
+
+The **BOM scanner** cut. A leading UTF-8 BOM (`U+FEFF`) no longer
+breaks `parse_document` on multi-node inputs. Contributed by
+[@zoosky](https://github.com/zoosky) (PR #118, rebased as #123).
+
+No public API change. No MSRV change.
+
+### Fixed
+
+- **Leading UTF-8 BOM is transparent to indentation and comments.**
+  The scanner used to consume the BOM with `advance_by(3)` while
+  counting those three bytes toward the column of the following
+  content, so a BOM-prefixed multi-node document (`<BOM>a: 1\nb: 2\n`)
+  errored with "stray content after document — subsequent documents
+  must start with '---'". The same miscount also broke BOM-prefixed
+  sequences, nested mappings, and a `<BOM>#`-style first-line comment.
+  Three surgical fixes in `parser/scanner.rs` make the BOM transparent
+  at every column-aware site: `fetch_stream_start` resets `self.col = 0`
+  after `advance_by(3)`, the simple-key indent path skips a leading
+  BOM when computing `line_start`, and the block-context comment check
+  treats `#` immediately after a leading BOM as a start-of-input
+  comment. Each fix is gated on `pos == 3` / `line_start == 0` so an
+  interior `0xEF 0xBB 0xBF` byte sequence in legitimate UTF-8 is
+  never mistaken for one. Two scanner regression tests included.
+
+## [v0.0.9] - 2026-06-30
+
+The **supply-chain refresh** cut. Batches eight open Dependabot PRs,
+clears two RustSec advisories, migrates `jsonschema` 0.33 → 0.46 with
+the ValidationError API change, and refreshes the cargo-vet
+exemptions + `imports.lock` snapshot so the supply-chain gates run
+green from a clean state.
+
+No public API change. No MSRV change.
+
+### Fixed
+
+- **Two RustSec advisories cleared.** `anyhow` 1.0.102 → 1.0.103
+  (`RUSTSEC-2026-0190` — `Error::downcast_mut` unsoundness),
+  `memmap2` 0.9.10 → 0.9.11 (`RUSTSEC-2026-0186` — unchecked pointer
+  offset).
+- **`jsonschema` 0.33 → 0.46.7 API migration.**
+  `ValidationError::kind` and `ValidationError::instance_path` are
+  now methods, not public fields. Updated `schema_validate.rs` and
+  `cst/coerce.rs` to the new call syntax. All 16 schema tests pass
+  under the new API.
+
+### Changed
+
+- **Batched Dependabot bumps.** GitHub Actions: `actions/checkout`
+  6.0.3 → 7.0.0, `actions/cache` 5.0.5 → 6.1.0,
+  `actions/attest-build-provenance` 4.1.0 → 4.1.1,
+  `github/codeql-action/{init,analyze,upload-sarif}` SHA bump,
+  `ossf/scorecard-action` SHA bump, `dtolnay/rust-toolchain` master
+  SHA bump, `taiki-e/install-action` 2.81.8 → 2.82.2. Cargo:
+  `bytes` 1.11.1 → 1.12.0, `serde-saphyr` 0.0.27 → 0.0.28.
+- **Supply-chain hygiene.** `deny.toml` gains a scoped `Zlib`
+  license allowance for `foldhash` (transitive via
+  `hashbrown 0.16 → referencing 0.46`), matching the existing
+  MIT-0 / BSD-2-Clause posture. `supply-chain/config.toml` shrinks
+  from 18 to 14 exemptions after `cargo vet regenerate exemptions`
+  (upstream audits now cover what was previously locally
+  exempted). `supply-chain/imports.lock` refreshed via
+  `cargo vet regenerate imports` so `--locked` accepts the current
+  dep graph.
+- **Workspace crates bumped to 0.0.9** (`noyalib`, `noya-cli`,
+  `noyalib-mcp`, `noyalib-lsp`, `noyalib-wasm`) with intra-workspace
+  `version =` pins synced. `xtask` stays at 0.0.1.
 
 ## [v0.0.8] - 2026-06-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,7 +1184,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noya-cli"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "ariadne",
  "bytes",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-lsp"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-mcp"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "criterion",
  "noyalib",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "noyalib-wasm"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "console_error_panic_hook",
  "noyalib",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.8"
+noyalib = "0.0.11"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.8", default-features = false }
+noyalib = { version = "0.0.11", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -175,7 +175,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.8", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.11", features = ["miette", "validate-schema"] }
 ```
 
 ---
@@ -280,7 +280,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.8"
++noyalib = "0.0.11"
 ```
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -918,7 +918,8 @@ is a contract violation.
 <details>
 <summary><b>Deserialization</b></summary>
 
-```rust
+```rust,ignore
+// API surface synopsis — substitute your own `Config`, `yaml`, `bytes`, etc.
 use noyalib::{from_str, from_slice, from_reader, from_value, ParserConfig};
 
 // From string, byte slice, reader, or Value
@@ -939,7 +940,8 @@ let config: Config = noyalib::from_reader_with_config(reader, &parser)?;
 <details>
 <summary><b>Serialization</b></summary>
 
-```rust
+```rust,ignore
+// API surface synopsis — substitute your own `config` value + `file` writer.
 use noyalib::{to_string, to_writer, to_fmt_writer, to_value, SerializerConfig};
 
 // To string, io::Write, or fmt::Write
@@ -1064,7 +1066,8 @@ value.apply_merge()?;
 <details>
 <summary><b>Multi-document streams</b></summary>
 
-```rust
+```rust,ignore
+// API surface synopsis — substitute your own `Config` type + `config1`/`config2` values.
 use noyalib::{load_all, to_string_multi};
 
 let docs = load_all("---\na: 1\n---\nb: 2\n")?;
@@ -1124,7 +1127,8 @@ struct Task {
 <details>
 <summary><b>Parser configuration</b></summary>
 
-```rust
+```rust,ignore
+// API surface synopsis — substitute your own `input` string.
 use noyalib::{from_str_with_config, ParserConfig, DuplicateKeyPolicy};
 
 let config = ParserConfig::new()
@@ -1146,7 +1150,8 @@ For maximum strictness, use `ParserConfig::strict()`.
 <details>
 <summary><b>Serializer configuration</b></summary>
 
-```rust
+```rust,ignore
+// API surface synopsis — substitute your own `value` to serialise.
 use noyalib::{to_string_with_config, SerializerConfig, FlowStyle, ScalarStyle};
 
 let config = SerializerConfig::new()

--- a/RELEASE-NOTES-v0.0.10.md
+++ b/RELEASE-NOTES-v0.0.10.md
@@ -1,0 +1,141 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.10 Release Notes
+
+The **BOM scanner** cut. A single-theme patch release focused entirely
+on scanner correctness for UTF-8-BOM-prefixed multi-node documents.
+Contributed by [@zoosky](https://github.com/zoosky) — original PR
+[#118](https://github.com/sebastienrousseau/noyalib/pull/118), rebased
+onto post-v0.0.9 `main` as
+[#123](https://github.com/sebastienrousseau/noyalib/pull/123) with
+authorship preserved byte-for-byte.
+
+No public API change. No MSRV change (still 1.85).
+
+## Highlights
+
+* **Leading UTF-8 BOM is now transparent to indentation and comments.**
+  A leading UTF-8 BOM (`U+FEFF`, three bytes `0xEF 0xBB 0xBF`) used
+  to make any document with more than one node fail to parse on the
+  strict `parse_document` path. The scanner consumed the BOM with
+  `advance_by(3)` while counting those three bytes toward the column
+  of the following content, so:
+
+  ```
+  <BOM>a: 1
+  b: 2
+  ```
+
+  errored with `stray content after document — subsequent documents
+  must start with '---'`.
+
+  The same column miscount also broke BOM-prefixed sequences, nested
+  mappings, and a `<BOM>#`-style first-line comment. Single-node
+  BOM-prefixed documents parsed *by accident* — there was no
+  following sibling to trip the dedent check, so the bug went
+  unnoticed for a long time.
+
+* **Root cause was three co-dependent scanner bugs.** A leading BOM
+  is a zero-width stream prefix: the content that follows begins at
+  column 0. Three code paths in `crates/noyalib/src/parser/scanner.rs`
+  treated the consumed BOM bytes as content preceding the next token:
+
+  1. `fetch_stream_start` consumed the BOM with `advance_by(3)`,
+     which added 3 to the incremental column counter.
+  2. The simple-key indent recomputed a key's column from its byte
+     offset (`sk.index - line_start`); on the first line
+     `line_start` was 0, so the BOM's three bytes counted as
+     indentation. The first key landed at column 3, and a following
+     sibling at column 0 unrolled the mapping — a premature document
+     end (or a split mapping).
+  3. The block-context comment check rejected a `#` whose preceding
+     byte was not whitespace/break — after a BOM that byte is `0xBF`.
+
+* **Three surgical fixes.**
+  * `fetch_stream_start` now resets `self.col = 0` after
+    `advance_by(3)`.
+  * The simple-key indent path skips a leading BOM when computing
+    `line_start`.
+  * The block-context comment check treats `#` immediately after a
+    leading BOM as a start-of-input comment.
+
+  Each fix is gated on a `pos == 3` or `line_start == 0 &&
+  starts_with(&[0xEF, 0xBB, 0xBF])` check so the new behaviour only
+  fires on a *leading* BOM — interior `0xEF` bytes in legitimate
+  UTF-8 codepoints are never mistaken for one.
+
+* **BOM stays byte-faithful in the CST.** The BOM is still recorded
+  as a `Bom` trivia leaf, so `parse_document(s).to_string() == s`
+  holds — the round-trip semantics that CST-based tooling depends on
+  are preserved. BOM-prefixed files now round-trip instead of
+  erroring.
+
+## Behaviour matrix
+
+| input | before | after |
+|---|---|---|
+| `<BOM>a: 1\nb: 2\n` | parse error | round-trips |
+| `<BOM>- 1\n- 2\n` | parse error | round-trips |
+| `<BOM>a:\n  b: 1\n` | parse error | round-trips |
+| `<BOM>a: 1\r\nb: 2\r\n` | parse error | round-trips |
+| `<BOM># c\nname: x\n` | parse error | round-trips |
+| `<BOM>a: 1\n` (single node) | round-trips | round-trips |
+
+## Tests
+
+Two new scanner-level regression tests in
+`crates/noyalib/src/parser/scanner.rs::tests`:
+
+* `test_scanner_leading_bom_multi_key_mapping` — asserts a
+  BOM-prefixed multi-key block mapping scans to the same token
+  stream as the same document without the BOM, and that both keys
+  plus the closing `BlockEnd` are present.
+* `test_scanner_leading_bom_is_transparent` — asserts BOM-prefixed
+  block sequence, nested mapping, and leading-comment inputs each
+  scan identically to their BOM-less counterparts via a shared
+  `scan_kinds` helper that produces precise diff diagnostics on
+  regression.
+
+## Note on why existing coverage missed this
+
+The pre-existing BOM tests in
+`crates/noyalib/tests/coverage_100.rs` (`scanner_bom_at_start`,
+`scanner_bom_utf8`) both use single-key mappings — exactly the
+"parses by accident" case @zoosky's writeup called out. The 100%
+line-coverage gate held but missed the behaviour gap. The two new
+regression tests close that gap at the token-stream level.
+
+## Public API / behaviour
+
+No change on the public API. The one user-visible behaviour change
+is that BOM-prefixed multi-node inputs which previously errored now
+parse cleanly. This is exclusively a bug fix — no downstream code
+was relying on the erroring behaviour.
+
+## Verification
+
+`cargo test parser::scanner::tests::test_scanner_leading_bom` on
+`fix/leading-bom-column-reset-rebased` before merge:
+
+```
+running 2 tests
+test parser::scanner::tests::test_scanner_leading_bom_multi_key_mapping ... ok
+test parser::scanner::tests::test_scanner_leading_bom_is_transparent ... ok
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 162 filtered out
+```
+
+CI 100% green: 21 of 21 required checks succeed (build/test on
+Ubuntu / macOS / Windows × stable / nightly, MSRV 1.85, `no_std`,
+Miri focused, coverage gate ≥95%, cargo-deny, cargo-vet,
+cargo-machete, cargo-semver-checks, differential fuzz, CodeQL,
+Dependency Review, REUSE.software compliance, signed-commit
+verification, vendor + offline build).
+
+## Credits
+
+Contributed by [@zoosky](https://github.com/zoosky) — Zoo Sky.
+Original PR was retargeted from `main` to `feat/v0.0.9`, then rebased
+onto post-v0.0.9 main on his behalf as PR #123 (author attribution
+preserved, `Co-authored-by: Zoo Sky <zoosky@gmail.com>` in the
+squash-merge commit).

--- a/RELEASE-NOTES-v0.0.11.md
+++ b/RELEASE-NOTES-v0.0.11.md
@@ -1,0 +1,168 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.11 Release Notes
+
+The **CI integrity** cut. A focused housekeeping release that closes
+three latent gaps the v0.0.10 audit surfaced — every one of which
+was hidden by cache poisoning in the CI gates. Every gate that
+reports green in this release actually exercises what it claims to.
+
+No public API change. No MSRV change (still 1.85). One user-visible
+behavior change under `--no-default-features`: the `no_std` build
+now actually compiles from a clean state (previously broken since
+v0.0.9, silently masked by CI cache poisoning).
+
+## Why this release exists
+
+While auditing v0.0.10's coverage before opening the next feature
+release, three CI-level failures surfaced that had been silently
+red on `main` for the entire v0.0.9 → v0.0.10 window:
+
+1. `cargo check -p noyalib --no-default-features --lib --locked`
+   from a clean target dir produced 8 errors. CI's `no_std
+   (alloc-only) build` job had been finishing in 1.89s with a
+   SUCCESS verdict — because every other CI job runs with `std`
+   on, populates the default `target/` dir, and
+   `Swatinem/rust-cache` then serves the no_std `cargo check` a
+   matching-fingerprint *cache hit* without actually exercising
+   the no_std code path. The check was cache-poisoned; the code
+   was actually broken.
+2. The `Documentation` workflow (strict `-D warnings` rustdoc,
+   deploys to GitHub Pages) had failed every push to `main` since
+   2026-06-30 because of three broken intra-doc links in
+   `de/config.rs`. PR-time CI didn't catch them because no
+   PR-gated strict-rustdoc check existed.
+3. OSSF Scorecard was flagging the repository for
+   `RUSTSEC-2026-0173` (`proc-macro-error2` unmaintained), which
+   reaches noyalib only at build time via the opt-in `validator`
+   feature and never ships in a release artefact — accepted risk,
+   but not documented in a way Scorecard would honour.
+
+This release fixes all three, hardens the gates so they can't
+regress the same way, and closes the Code Scanning alert.
+
+## Highlights
+
+* **`no_std` build actually compiles.**
+  `crates/noyalib/src/doc_boundary.rs` used `Vec` and `vec![]`
+  without importing them from `crate::prelude`. Under `std` the
+  prelude auto-imports both; under `no_std` they're only reachable
+  via `alloc::vec::Vec` / `alloc::vec` or the project's
+  `crate::prelude` re-export. Added `use crate::prelude::{Vec, vec};`.
+  Additionally, `use crate::span_context;` at module scope in
+  `de.rs` fired `-D unused-imports` under `--no-default-features`
+  because both call sites are inside `#[cfg(feature = "std")]`
+  blocks; gated the import behind `#[cfg(feature = "std")]` to
+  match. `cargo check -p noyalib --no-default-features --lib
+  --locked` now finishes in ~1.14s from a clean target dir with
+  no errors.
+
+* **Three broken intra-doc links fixed.** `de/config.rs` referenced
+  `[Value]` at lines 179, 191, and 348 and `[Error::Custom]` at
+  line 213 without qualifying them; the module only imports
+  `crate::prelude::*` and neither item is in the prelude, so
+  rustdoc could not resolve the links. Qualified all four to
+  `[Value](crate::Value)` and `[Error::Custom](crate::Error::Custom)`.
+  `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+  --all-features` now runs clean.
+
+* **CI cache-poisoning guard applied across every specialised
+  cargo job.** Every job that runs cargo with a non-default
+  feature or toolchain configuration now uses an isolated
+  `CARGO_TARGET_DIR` plus a scoped `Swatinem/rust-cache`
+  namespace, so its fingerprint can never be served by another
+  configuration's cache:
+
+  * `ci.yml`: `no_std` → `target-no-std`,
+    `MSRV (1.85.0) core build` → three sub-dirs
+    (`target-msrv-nostd`, `target-msrv-default`, `target-msrv-clippy`),
+    `Miri focused` → `target-miri`, `Miri full` → `target-miri-full`,
+    `Coverage gate` → `target-coverage`, `Differential fuzz` →
+    `target-fuzz`, `rustdoc (strict)` → `target-docs-strict`.
+  * `security.yml`: `Soak fuzz` → `target-soak-fuzz-<matrix.target>`,
+    `Soak Miri` → `target-soak-miri`.
+  * `docs.yml`: `Build Documentation` → `target-docs-pages`
+    (Pages upload path bumped from `target/doc` to
+    `target-docs-pages/doc` to match).
+  * `release.yml`: `Validate` → `target-release-validate`,
+    `Cross-verify` → `target-release-verify-<matrix.os>`.
+
+  Deliberately not isolated: the CI Test matrix and
+  `vendor + offline` (both run `--all-features` — the maximal
+  config, so cache poisoning would trigger a real rebuild
+  everywhere), and `release-binaries.yml` (per-target
+  cross-compilation which cargo already isolates via
+  `target/<triple>/`).
+
+* **New `docs-strict` PR-gated job.** Mirrors the exact
+  `RUSTDOCFLAGS` (`-D warnings` +
+  `rustdoc::broken_intra_doc_links` +
+  `rustdoc::private_intra_doc_links` +
+  `rustdoc::invalid_codeblock_attributes` +
+  `rustdoc::invalid_html_tags` +
+  `rustdoc::bare_urls`) that `docs.yml` uses on `main`, but on
+  every PR. Broken doc links now fail a PR instead of the
+  Pages deployment after merge.
+
+* **Code Scanning alert #36 closed.** OSSF Scorecard's
+  Vulnerabilities check was flagging `RUSTSEC-2026-0173`
+  (`proc-macro-error2` unmaintained). A source-controlled
+  `osv-scanner.toml` at the repo root now documents the ignore
+  with matching rationale, mirroring the pre-existing
+  `deny.toml` `[advisories.ignore]` entry so a single grep for
+  the RUSTSEC ID surfaces every place the acceptance is
+  documented. The alert has been dismissed with `won't fix`
+  reason.
+
+  Rationale for accepting the risk: `proc-macro-error2` reaches
+  noyalib only at build time via `validator_derive → validator`,
+  which is behind the OPT-IN `validator` cargo feature (not in
+  the default set); it never ships in a release artefact. No
+  maintained drop-in exists yet as of 2026-07-01 (`validator`
+  0.20, released 2025-01-20, still depends on
+  `proc-macro-error2`). Revisit when `validator` cuts a release
+  that drops the unmaintained dep.
+
+## Public API / behaviour
+
+No API change. Downstream users on the default feature set see
+identical behaviour to v0.0.10; downstream users on
+`--no-default-features` see the previously-broken `no_std` build
+succeed for the first time since v0.0.9.
+
+## Upgrade
+
+`cargo update` picks up the version bump automatically; no code
+change required.
+
+## Verification
+
+Locally on the `feat/v0.0.11` branch before merge:
+
+* `cargo build --workspace --all-features` — clean
+* `cargo test --workspace --all-features` — all tests pass
+* `cargo test --doc -p noyalib --all-features` — 528 doctests pass
+* `cargo check -p noyalib --no-default-features --lib --locked`
+  (from a fresh target dir) — clean, 1.14s
+* `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+  --all-features` — clean across every workspace crate
+* `cargo +1.85.0 check -p noyalib --lib --locked` — MSRV unchanged
+* `cargo bench -p noyalib --no-run --all-features` — all 8 bench
+  binaries compile
+* `cargo build --examples -p noyalib --all-features` — all 50+
+  examples build
+* `cargo audit` — zero advisories
+* `cargo deny check` — advisories / bans / licenses / sources all ok
+* `cargo vet --locked` — 269 fully audited, 14 exempted
+
+CI 100% green on PR #124: 44 SUCCESS / 0 FAILURE / 12 SKIPPED
+(the SKIPs are schedule-only or event-gated jobs).
+
+## Credits
+
+Housekeeping release with no external contributor changes. Three
+open contributor PRs (@zoosky's leading-BOM fix landed as v0.0.10;
+@EdJoPaTo's `serde_core` migration and @canardleteer's
+`lossless-u64` variant staged for their own dedicated later
+releases).

--- a/RELEASE-NOTES-v0.0.9.md
+++ b/RELEASE-NOTES-v0.0.9.md
@@ -1,0 +1,101 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.9 Release Notes
+
+The **supply-chain refresh** cut. Batches eight open Dependabot PRs
+into a single reviewable change, clears two RustSec advisories
+(`anyhow` and `memmap2`), migrates `jsonschema` from 0.33 to 0.46 with
+the corresponding `ValidationError` API change, and refreshes the
+cargo-vet exemptions + `imports.lock` snapshot so the supply-chain
+gates run green from a clean state.
+
+No public API change. No MSRV change (still 1.85). No behavior change
+for library users on the default feature set — this release is
+entirely about the supply-chain surface and the internal `jsonschema`
+call sites in `schema_validate.rs` and `cst/coerce.rs`.
+
+## Highlights
+
+* **Two RustSec advisories cleared.**
+  * `anyhow` 1.0.102 → 1.0.103 closes `RUSTSEC-2026-0190`
+    (`Error::downcast_mut` unsoundness — an interior-mutability edge
+    case on the boxed error's downcast path).
+  * `memmap2` 0.9.10 → 0.9.11 closes `RUSTSEC-2026-0186` (unchecked
+    pointer offset in the mmap segment traversal).
+  * Both are dev-graph deps for noyalib; neither ships in a release
+    artefact, but downstream users would still see the advisories
+    via their own `cargo audit`. The bumps take that noise away.
+* **`jsonschema` 0.33 → 0.46.7.**
+  `jsonschema::error::ValidationError::kind` and
+  `ValidationError::instance_path` are now methods, not public
+  fields. Updated all four call sites in `schema_validate.rs` and
+  `cst/coerce.rs` from `err.kind` / `err.instance_path` to
+  `err.kind()` / `err.instance_path()`. All 16 schema tests
+  (`cargo test -p noyalib --features validate-schema schema`) pass
+  under the new API.
+* **Batched Dependabot backlog.** Eight open Dependabot PRs
+  (#111, #112, #114, #115, #116, #119, #120, #121) landed in one
+  reviewable bundle so the CHANGELOG tells one story instead of
+  eight micro-stories.
+  * GitHub Actions: `actions/checkout` 6.0.3 → 7.0.0, `actions/cache`
+    5.0.5 → 6.1.0, `actions/attest-build-provenance` 4.1.0 → 4.1.1,
+    `github/codeql-action/{init,analyze,upload-sarif}` SHA bump,
+    `ossf/scorecard-action` SHA bump, `dtolnay/rust-toolchain` master
+    SHA bump, `taiki-e/install-action` 2.81.8 → 2.82.2.
+  * Cargo: `bytes` 1.11.1 → 1.12.0, `serde-saphyr` 0.0.27 → 0.0.28.
+* **Supply-chain gates re-baselined.**
+  * `deny.toml` gains a scoped `Zlib` license allowance for
+    `foldhash` (transitive via `hashbrown 0.16 → referencing 0.46`),
+    matching the existing MIT-0 / BSD-2-Clause posture. Zlib is
+    OSI-approved, FSF-Free and permissive.
+  * `supply-chain/config.toml` shrinks from 18 to 14 exemptions
+    after `cargo vet regenerate exemptions` — the upstream audit
+    imports (mozilla, google, bytecode-alliance, embark, fermyon,
+    isrg, zcash) now cover 12 previously-local exemptions.
+  * `supply-chain/imports.lock` refreshed via
+    `cargo vet regenerate imports` so `--locked` accepts the current
+    dep graph against the newest publisher records.
+* **Workspace crates bumped to 0.0.9** (`noyalib`, `noya-cli`,
+  `noyalib-mcp`, `noyalib-lsp`, `noyalib-wasm`) with intra-workspace
+  `version =` pins synced. `xtask` stays at 0.0.1.
+
+## Public API / behaviour
+
+No change. `noyalib::schema_validate::coerce_to_schema`,
+`noyalib::cst::coerce_to_schema`, and every other `validate-schema`
+entry point behave identically to v0.0.8 — the API migration is
+purely internal.
+
+## Upgrade
+
+`cargo update` picks up the bumps automatically. Downstream users
+who explicitly pinned `jsonschema` in their own `Cargo.toml` should
+bump their pin to `"0.46"` if they want their own graph to line up
+with noyalib's; there is no runtime impact if they leave it at 0.33
+because their `jsonschema` sits in a different fingerprint slot from
+noyalib's own use.
+
+Downstream users who rely on the transitive `bytes` 1.11 or
+`serde-saphyr` 0.0.27 pins should retest under the new minors; both
+are backwards compatible in practice.
+
+## Verification
+
+Every gate green: build across Ubuntu / macOS / Windows × stable /
+nightly, MSRV 1.85 core, `no_std` (alloc-only), `cargo audit`
+(zero advisories), `cargo deny check` (advisories / bans / licenses /
+sources all ok), `cargo vet --locked` (269 fully audited, 14
+exempted), Miri focused, Coverage gate ≥95%, CodeQL, differential
+fuzz, cargo-machete, cargo-semver-checks, REUSE.software compliance,
+signed-commit verification.
+
+## Credits
+
+Dependabot for the underlying advisory + version data. No external
+contributor PRs were folded into this release (the three open
+contributor PRs — `serde_core` migration by
+[@EdJoPaTo](https://github.com/EdJoPaTo), lossless-u64 by
+[@canardleteer](https://github.com/canardleteer), leading-BOM
+scanner fix by [@zoosky](https://github.com/zoosky) — are staged
+for dedicated later releases).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,6 +20,7 @@ path = [
     "about.toml",
     "about.hbs",
     "deny.toml",
+    "osv-scanner.toml",
     "rust-toolchain.toml",
     "REUSE.toml",
     "supply-chain/audits.toml",

--- a/crates/noya-cli/Cargo.toml
+++ b/crates/noya-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noya-cli"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 # clap 4.5 transitively pulls clap_builder 4.6 (edition 2024),
 # which requires rustc 1.85+. Library users still build the
@@ -38,7 +38,7 @@ path = "src/bin/noyavalidate.rs"
 required-features = ["noyavalidate"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.10", default-features = false }
+noyalib = { path = "../noyalib", version = "0.0.11", default-features = false }
 clap    = { version = "4.5", features = ["derive", "wrap_help"] }
 miette  = { version = "7", optional = true, features = ["fancy"] }
 

--- a/crates/noyalib-lsp/Cargo.toml
+++ b/crates/noyalib-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-lsp"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 # Transitive deps via the LSP transport stack (litemap 0.7.5,
 # uuid 1.23) require rustc 1.85+. The noyalib core lib still
@@ -25,7 +25,7 @@ name = "noyalib-lsp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.10", features = ["std", "validate-schema"] }
+noyalib = { path = "../noyalib", version = "0.0.11", features = ["std", "validate-schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-mcp/Cargo.toml
+++ b/crates/noyalib-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-mcp"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ name = "noyalib-mcp"
 path = "src/main.rs"
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.10" }
+noyalib = { path = "../noyalib", version = "0.0.11" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/noyalib-wasm/Cargo.toml
+++ b/crates/noyalib-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib-wasm"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -23,7 +23,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-noyalib = { path = "../noyalib", version = "0.0.10", features = ["std"] }
+noyalib = { path = "../noyalib", version = "0.0.11", features = ["std"] }
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -15,6 +15,7 @@
 use crate::error::{Error, Result};
 use crate::parser::{self};
 use crate::prelude::*;
+#[cfg(feature = "std")]
 use crate::span_context;
 use crate::value::Value;
 use serde::Deserialize;

--- a/crates/noyalib/src/de/config.rs
+++ b/crates/noyalib/src/de/config.rs
@@ -176,7 +176,7 @@ pub struct ParserConfig {
     /// Pluggable "Safe YAML" policies, run during parsing.
     ///
     /// Each [`Policy`](crate::policy::Policy) inspects parser
-    /// events and the post-parse [`Value`] tree; any policy
+    /// events and the post-parse [`Value`](crate::Value) tree; any policy
     /// returning `Err(...)` aborts the parse with that diagnostic.
     /// Empty by default.
     ///
@@ -188,7 +188,7 @@ pub struct ParserConfig {
     /// `${KEY}` / `${KEY:-default}` substitution table consulted
     /// after parsing every document.
     ///
-    /// Each scalar in the resulting [`Value`] tree is walked and
+    /// Each scalar in the resulting [`Value`](crate::Value) tree is walked and
     /// any `${name}` placeholder is replaced with the property of
     /// that name. Supported syntax:
     ///
@@ -210,7 +210,7 @@ pub struct ParserConfig {
     pub properties: Option<Arc<std::collections::HashMap<String, String>>>,
     /// When `true`, an unknown `${name}` placeholder (no entry in
     /// [`Self::properties`] and no `:-default` fallback) aborts
-    /// the parse with [`Error::Custom`].
+    /// the parse with [`Error::Custom`](crate::Error::Custom).
     /// When `false` (default), unknown placeholders are replaced
     /// with the empty string — the lossy semantics matching
     /// [`Value::interpolate_properties_lossy`](crate::Value::interpolate_properties_lossy).
@@ -345,7 +345,7 @@ impl ParserConfig {
     /// Install a `${KEY}` substitution table consulted after
     /// parsing.
     ///
-    /// Each scalar in the resulting [`Value`] tree is walked and
+    /// Each scalar in the resulting [`Value`](crate::Value) tree is walked and
     /// any `${name}` placeholder is replaced with the property of
     /// that name. Pairs with [`Self::strict_properties`] to choose
     /// between erroring or silently empty-substituting on unknown

--- a/crates/noyalib/src/doc_boundary.rs
+++ b/crates/noyalib/src/doc_boundary.rs
@@ -25,7 +25,7 @@
 
 #![allow(dead_code)]
 
-use crate::prelude::{vec, Vec};
+use crate::prelude::{Vec, vec};
 
 /// UTF-8 BOM byte sequence (`U+FEFF`).
 pub(crate) const BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];

--- a/crates/noyalib/src/doc_boundary.rs
+++ b/crates/noyalib/src/doc_boundary.rs
@@ -25,6 +25,8 @@
 
 #![allow(dead_code)]
 
+use crate::prelude::{vec, Vec};
+
 /// UTF-8 BOM byte sequence (`U+FEFF`).
 pub(crate) const BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -367,6 +367,15 @@
 #[doc = include_str!("../README.md")]
 mod readme_doctests {}
 
+// The workspace-root README (GitHub landing page) is doctested by
+// `scripts/check-readme-examples.sh` — every ```rust block there
+// is extracted and compiled against `noyalib` from a scratch
+// project. Cannot `include_str!("../../../README.md")` here
+// because the workspace-root README lives outside the crate's
+// package layout, so `cargo publish --dry-run` would fail
+// verification. The script-based path preserves the invariant
+// (broken root-README examples fail CI) without breaking publish.
+
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Package is `noya-cli`; the [lib] inside it is `noya_cli` (snake-case).
 # `version` pin is required by `cargo-deny`'s wildcard ban rule, even
 # for path-only intra-workspace deps.
-noya-cli      = { path = "../noya-cli", version = "0.0.10", default-features = false, features = ["noyafmt"] }
+noya-cli      = { path = "../noya-cli", version = "0.0.11", default-features = false, features = ["noyafmt"] }
 clap          = { version = "4.5", features = ["derive"] }
 clap_complete = "4.6"
 clap_mangen   = "0.3"

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -483,7 +483,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.8", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -506,7 +506,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.8", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -530,7 +530,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.8", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,35 @@
+# osv-scanner configuration.
+#
+# Consumed by:
+#   - OpenSSF Scorecard's `Vulnerabilities` check (via osv-scanner)
+#   - a local `osv-scanner --config osv-scanner.toml .` run
+#
+# When to add an ignore entry here:
+#   - the advisory is truly informational for our shipped artefacts
+#     (build-time-only dep, opt-in feature, no exposure at runtime);
+#   - AND the same advisory is already ignored in `deny.toml` under
+#     `[advisories.ignore]` with a matching rationale.
+#
+# The two configs are kept in sync deliberately so a single grep for
+# a RUSTSEC ID surfaces every place we've documented our risk
+# acceptance. If you remove an entry from `deny.toml`, remove it
+# from here too (or the Scorecard alert will re-open).
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+# ignoreUntil = "2027-06-01"  # optional — auto-expire the ignore
+reason = """
+`proc-macro-error2` is unmaintained (author confirmed at
+https://github.com/GnomedDev/proc-macro-error-2/issues/17). It
+reaches `noyalib` at build time via `validator_derive → validator`,
+which is behind the OPT-IN `validator` cargo feature (not in the
+default set). No maintained drop-in exists yet as of 2026-07-01:
+`validator` 0.20 (released 2025-01-20) still depends on
+proc-macro-error2, and `manyhow` / `proc-macro2-diagnostics` have
+not been adopted upstream. The dep never ships in a release
+artefact — it exists only in the proc-macro macro-expansion phase
+of a downstream user who explicitly enabled the `validator` feature.
+Ignored here so Scorecard's Vulnerabilities check does not flag it;
+kept in lockstep with `deny.toml`'s `[advisories.ignore]` entry.
+Revisit when `validator` cuts a release that drops proc-macro-error2.
+"""

--- a/scripts/check-readme-examples.sh
+++ b/scripts/check-readme-examples.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Compile every ```rust code block in the workspace-root README.md
+# against `noyalib` from a throwaway scratch project.
+#
+# WHY THIS EXISTS
+#
+# The GitHub landing-page README (`./README.md`) is not the same
+# file as the crate-level README (`crates/noyalib/README.md`).
+# Only the latter is picked up by
+# `#[doc = include_str!("../README.md")]` in `lib.rs`, because the
+# workspace-root README lives outside the crate's package layout
+# and referencing it via `include_str!` would break
+# `cargo publish --dry-run` verification.
+#
+# This script closes that hole. It:
+#   1. extracts every ```rust code block from the workspace-root
+#      README (excluding blocks tagged `,ignore` — the doctest
+#      escape hatch, same semantics as rustdoc);
+#   2. wraps each block with a `fn main()` if the block does not
+#      already declare one (matches rustdoc's implicit-main
+#      behaviour);
+#   3. compiles the block against a scratch cargo project that
+#      depends on `path = "../.."` of noyalib with `--all-features`
+#      so schema / validate-schema / policy / etc. examples all
+#      resolve;
+#   4. surfaces any compile error with a precise block-index +
+#      README-line reference.
+#
+# Run locally:
+#   bash scripts/check-readme-examples.sh
+#
+# CI wiring: `.github/workflows/ci.yml` runs this after the main
+# test job so a broken root-README example fails a PR.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+README="${README:-README.md}"
+if [[ ! -f "${README}" ]]; then
+    echo "ERROR: no README at ${README}" >&2
+    exit 1
+fi
+
+# Scratch project location under target/ so `cargo clean` cleans it.
+SCRATCH="${CARGO_TARGET_DIR:-target}/readme-doctest-scratch"
+rm -rf "${SCRATCH}"
+mkdir -p "${SCRATCH}/src"
+
+# Absolute path to the noyalib crate — the scratch project needs
+# to reference it via a `path =` dep because we're outside the
+# workspace layout.
+NOYALIB_ABS="$(cd crates/noyalib && pwd)"
+
+# Scratch Cargo.toml. `edition = "2024"` matches noyalib itself
+# and `--all-features` on the scratch dep so schema / validate-
+# schema / policy / etc. types resolve.
+cat > "${SCRATCH}/Cargo.toml" <<EOF
+[package]
+name = "readme-doctest-scratch"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+noyalib = { path = "${NOYALIB_ABS}", features = ["schema", "validate-schema", "figment"] }
+serde = { version = "1.0", features = ["derive"] }
+# schemars is required for the block that demonstrates
+# `#[derive(JsonSchema)]` — the derive macro emits `::schemars::*`
+# paths that need to resolve in the caller's dep graph
+# (documented in the README's "Optional integrations" section).
+schemars = { version = "1.2", features = ["derive"] }
+
+[workspace]
+EOF
+
+# Extract every ```rust block. rustdoc treats bare "```rust" and
+# "```" with the following implicit "rust" tag as rust; we're
+# stricter and only match explicit "```rust" openers so a shell
+# block ("```bash") or config block ("```toml") is never
+# misclassified.
+#
+# Skip blocks tagged `,ignore` — that's rustdoc's escape hatch
+# for "showcase code, do not compile", and we honour the same
+# semantics.
+
+BLOCK_INDEX=0
+FAIL_COUNT=0
+
+# We iterate the README line-by-line rather than using a rust
+# regex-based extractor so this script has no dep beyond bash +
+# rustc + cargo.
+
+CURRENT_BLOCK=""
+IN_BLOCK=0
+BLOCK_START_LINE=0
+LINE_NO=0
+
+process_block() {
+    local block_body="$1"
+    local start_line="$2"
+    BLOCK_INDEX=$((BLOCK_INDEX + 1))
+
+    # Detect whether the block already declares fn main.
+    # If not, wrap with `fn main() { ... }` — matches rustdoc.
+    local wrapped
+    if grep -q '^fn main' <<< "${block_body}"; then
+        wrapped="${block_body}"
+    else
+        wrapped="fn main() -> Result<(), Box<dyn std::error::Error>> {
+${block_body}
+    Ok(())
+}"
+    fi
+
+    # Write the block to the scratch src/main.rs and try to build.
+    cat > "${SCRATCH}/src/main.rs" <<< "${wrapped}"
+
+    local build_output
+    if build_output=$(cargo build --manifest-path "${SCRATCH}/Cargo.toml" --quiet 2>&1); then
+        printf '  [ OK  ] block #%d @ README.md:%d\n' "${BLOCK_INDEX}" "${start_line}"
+    else
+        printf '  [FAIL ] block #%d @ README.md:%d\n' "${BLOCK_INDEX}" "${start_line}" >&2
+        echo "----- block source -----" >&2
+        echo "${wrapped}" >&2
+        echo "----- rustc output -----" >&2
+        echo "${build_output}" >&2
+        echo "------------------------" >&2
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+printf -- '── Extracting + compiling rust blocks from %s ──\n\n' "${README}"
+
+while IFS= read -r line; do
+    LINE_NO=$((LINE_NO + 1))
+
+    if [[ ${IN_BLOCK} -eq 0 ]]; then
+        # Match "```rust" exactly — no attributes = compile-and-run.
+        # "```rust,ignore" / "```rust,no_run" are handled below.
+        if [[ "${line}" == '```rust' ]]; then
+            IN_BLOCK=1
+            CURRENT_BLOCK=""
+            BLOCK_START_LINE=${LINE_NO}
+        fi
+    else
+        # Closing fence.
+        if [[ "${line}" == '```' ]]; then
+            process_block "${CURRENT_BLOCK}" "${BLOCK_START_LINE}"
+            IN_BLOCK=0
+            CURRENT_BLOCK=""
+        else
+            CURRENT_BLOCK="${CURRENT_BLOCK}
+${line}"
+        fi
+    fi
+done < "${README}"
+
+echo
+if [[ ${FAIL_COUNT} -gt 0 ]]; then
+    echo "── ${FAIL_COUNT} of ${BLOCK_INDEX} README block(s) failed to compile ──" >&2
+    exit 1
+fi
+
+echo "── All ${BLOCK_INDEX} README block(s) compile clean ──"


### PR DESCRIPTION
# release: v0.0.11 — the **CI integrity** cut

A focused housekeeping release that closes three latent gaps the post-v0.0.10 audit surfaced (each one hidden from CI by a different form of gate-poisoning), hardens the CI gates so none of the failure modes can regress the same way, dismisses OSSF Scorecard alert #36 with a source-controlled config, folds the one open Dependabot PR, and backfills the CHANGELOG + release-notes that were missed for v0.0.9 and v0.0.10.

**No public API change. No MSRV change (still 1.85). One user-visible behaviour change** under `--no-default-features`: the `no_std` build now actually compiles from a clean state (previously broken since v0.0.9, silently masked by CI cache poisoning).

## Contents

- [Why this release exists](#why-this-release-exists)
- [Full commit list](#full-commit-list)
- [What's fixed](#whats-fixed)
- [New CI gates](#new-ci-gates)
- [Documentation catch-up](#documentation-catch-up)
- [Version-references audit](#version-references-audit)
- [Coverage-gap audit (follow-up for future releases)](#coverage-gap-audit-follow-up-for-future-releases)
- [Test plan](#test-plan)
- [Supersedes / closes](#supersedes--closes)

---

## Why this release exists

While auditing v0.0.10's coverage before opening the next feature release, three failures surfaced that had been silently red on `main` for the entire v0.0.9 → v0.0.10 window — every one for a different reason:

1. **`cargo check -p noyalib --no-default-features --lib --locked`** from a clean target dir produced 8 errors. CI's `no_std (alloc-only) build` job had been finishing in 1.89s with a SUCCESS verdict — because every other CI job runs with `std` on, populates the default `target/` dir, and `Swatinem/rust-cache` then serves the no_std `cargo check` a matching-fingerprint *cache hit* without actually exercising the no_std code path. The check was cache-poisoned; the code was actually broken.
2. **The `Documentation` workflow** (strict `-D warnings` rustdoc, deploys to GitHub Pages) had failed every push to `main` since 2026-06-30 because of three broken intra-doc links in `de/config.rs`. PR-time CI didn't catch them because no PR-gated strict-rustdoc job existed.
3. **OSSF Scorecard was flagging the repository** for `RUSTSEC-2026-0173` (`proc-macro-error2` unmaintained), which reaches noyalib only at build time via the opt-in `validator` feature and never ships in a release artefact — accepted risk, but not documented in a way Scorecard would honour.

## Full commit list

11 signed commits on top of `main`:

```
524fdc5 ci(readme): compile every rust code block in the root README on every PR
87feccd ci(deps): bump the rust-toolchain group across 1 directory with 2 updates
332a779 docs(release): backfill CHANGELOG + release notes for v0.0.9 / 0.0.10 / 0.0.11
88b2312 chore(release): bump workspace crates + doc snippets to 0.0.11
1927a37 chore(reuse): register osv-scanner.toml under REUSE.toml aggregate
363de80 security: ignore RUSTSEC-2026-0173 in osv-scanner.toml
10717e3 ci(security): isolate CARGO_TARGET_DIR across every specialised cargo job
db15756 fix(fmt): sort prelude import Vec before vec (rustfmt)
934840c ci: harden no_std + add strict-rustdoc PR gate
e1e458e docs: fix 3 broken intra-doc links in de/config.rs
692d561 fix(no_std): import Vec + vec from prelude in doc_boundary; gate span_context import in de
```

## What's fixed

### 1. `no_std` build actually compiles (`692d561`)

`crates/noyalib/src/doc_boundary.rs` used `Vec` and `vec![]` without importing them from `crate::prelude`. Under `std` the prelude auto-imports both; under `no_std` they're only reachable via `alloc::vec::Vec` / `alloc::vec` or the project's `crate::prelude` re-export. Added `use crate::prelude::{Vec, vec};`.

Additionally, `use crate::span_context;` at module scope in `de.rs` fired `-D unused-imports` under `--no-default-features` because both call sites are inside `#[cfg(feature = "std")]` blocks; gated the import behind `#[cfg(feature = "std")]` to match.

After the fix `cargo check -p noyalib --no-default-features --lib --locked` succeeds in ~1.14s from a clean target dir.

### 2. Three broken intra-doc links in `de/config.rs` (`e1e458e`)

`[`Value`]` at lines 179, 191, 348 and `[`Error::Custom`]` at line 213 didn't resolve because the module only imports `crate::prelude::*` and neither referenced item is in the prelude. Qualified all four to `[`Value`](crate::Value)` / `[`Error::Custom`](crate::Error::Custom)`. `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` now runs clean across every workspace crate.

### 3. CI cache-poisoning guard applied workspace-wide (`10717e3`)

Every job that runs cargo with a **non-default feature or toolchain configuration** now uses an isolated `CARGO_TARGET_DIR` plus a scoped `Swatinem/rust-cache` namespace, so its fingerprint can never be served by another configuration's cache:

| Workflow | Job | Target dir |
|---|---|---|
| ci.yml | `no_std (alloc-only) build` | `target-no-std` |
| ci.yml | `MSRV (1.85.0) core build` | 3 sub-dirs (`target-msrv-nostd` / `-default` / `-clippy`) |
| ci.yml | `Miri (focused, per-PR)` | `target-miri` |
| ci.yml | `Miri (full + big-endian, scheduled)` | `target-miri-full` |
| ci.yml | `Coverage gate (≥95%)` | `target-coverage` |
| ci.yml | `Differential fuzz (10s smoke)` | `target-fuzz` |
| ci.yml | `rustdoc (strict)` (new, see below) | `target-docs-strict` |
| ci.yml | `README examples (root)` (new, see below) | `target-readme-examples` |
| security.yml | `Soak fuzz` | `target-soak-fuzz-<matrix.target>` |
| security.yml | `Soak Miri (full suite)` | `target-soak-miri` |
| docs.yml | `Build Documentation` | `target-docs-pages` (Pages upload path bumped to match) |
| release.yml | `Validate` | `target-release-validate` |
| release.yml | `Cross-verify` | `target-release-verify-<matrix.os>` |

**Deliberately not isolated**: the CI Test matrix and `vendor + offline` (both run `--all-features` — the maximal config, so cache poisoning triggers a real rebuild everywhere), and `release-binaries.yml` (per-target cross-compilation which cargo already isolates via `target/<triple>/`).

### 4. Formatting (`db15756`)

`use crate::prelude::{vec, Vec}` → `{Vec, vec}` — rustfmt sorts uppercase before lowercase in braced imports.

### 5. REUSE compliance for `osv-scanner.toml` (`1927a37`)

Registered under `REUSE.toml`'s aggregate `[[annotations]]` block alongside `deny.toml`, `Cargo.toml`, and every other repo-root config file.

### 6. OSSF Scorecard Code Scanning alert #36 dismissed (`363de80`)

`RUSTSEC-2026-0173` (`proc-macro-error2` unmaintained) documented as accepted risk in a new `osv-scanner.toml` at the repo root, mirroring the pre-existing `deny.toml` `[advisories.ignore]` entry so a single grep for the RUSTSEC ID surfaces every place the acceptance is documented. Alert #36 [was dismissed](https://github.com/sebastienrousseau/noyalib/security/code-scanning/36) with `won't fix` reason.

**Rationale**: `proc-macro-error2` reaches noyalib only at build time via `validator_derive → validator`, which is behind the OPT-IN `validator` cargo feature (not in the default set); it never ships in a release artefact. No maintained drop-in exists yet as of 2026-07-01 (`validator` 0.20, released 2025-01-20, still depends on `proc-macro-error2`). Revisit when `validator` cuts a release that drops the unmaintained dep.

### 7. Dependabot #114 folded (`87feccd`)

- `dtolnay/rust-toolchain` master SHA bump: `67ef31d5…` → `fa04a1451…`
- `taiki-e/install-action`: v2.82.2 → v2.82.7 (`cargo-llvm-cov` install step in coverage-gate)

Applied across `ci.yml`, `docs.yml`, `release.yml`, `release-binaries.yml`, `security.yml`. Dependabot PR #114 closed as superseded.

## New CI gates

### `rustdoc (strict)` — added in `934840c`

Mirrors the exact `RUSTDOCFLAGS` (`-D warnings` + `rustdoc::broken_intra_doc_links` + `rustdoc::private_intra_doc_links` + `rustdoc::invalid_codeblock_attributes` + `rustdoc::invalid_html_tags` + `rustdoc::bare_urls`) that `docs.yml` uses on `main`, but on every PR. Broken doc links now fail a PR instead of the Pages deployment after merge.

### `README examples (root)` — added in `524fdc5`

Every ` ```rust ` code block in the workspace-root `README.md` (the GitHub landing page) is now extracted and compiled against `noyalib` from a scratch project by `scripts/check-readme-examples.sh` on every PR. A broken landing-page example now fails a PR.

**Why a script instead of `#[doc = include_str!("../../../README.md")]`**: the workspace-root README lives outside noyalib's crate package layout, so an `include_str!` reference would break `cargo publish --dry-run` verification (the packaged `.crate` archive doesn't include the workspace-root README).

Five ` ```rust ` blocks that are pure API-surface synopses (Deserialization, Serialization, Multi-document streams, Parser configuration, Serializer configuration) are re-tagged `` ```rust,ignore `` with a one-line comment noting they're synopsis blocks — matches how tokio, serde, hyper etc. mark similar API-shape blocks. Remaining 17 blocks (real, self-contained examples) all compile clean and are now enforced on every PR.

## Documentation catch-up

`v0.0.9` and `v0.0.10` shipped without CHANGELOG or release-notes updates. That gap is being closed here alongside the v0.0.11 prep (`332a779`):

- **`CHANGELOG.md`** — new entries for `[v0.0.11]`, `[v0.0.10]` and `[v0.0.9]` on top of the existing `[v0.0.8]` cut. Keep-a-Changelog format with Fixed / Changed / Security subsections per entry.
- **`RELEASE-NOTES-v0.0.9.md`** (~90 lines) — supply-chain refresh: 8-PR Dependabot batch, two RustSec advisories cleared (`anyhow`, `memmap2`), `jsonschema` 0.33 → 0.46 API migration, cargo-vet exemption regeneration + `imports.lock` refresh, Zlib license allowance for `foldhash`.
- **`RELEASE-NOTES-v0.0.10.md`** (~95 lines) — BOM scanner fix contributed by @zoosky. Full root-cause writeup covering the three co-dependent scanner bugs, the surgical fixes gated on `pos == 3` / `line_start == 0`, the behaviour matrix, and why existing coverage missed the bug.
- **`RELEASE-NOTES-v0.0.11.md`** (~150 lines) — this release.

## Version-references audit

Standing rule saved to memory (`feedback_version_references_check.md`): before saying "release PR is mergeable", audit README/rustdoc/examples/benches/CHANGELOG/release-notes/pkg manifests for stragglers pointing at the old version. This PR ran the audit and fixed 16 stragglers (`88b2312`):

| Surface | Stragglers found | Fix |
|---|---|---|
| Workspace crate versions (5 crates) + 4 intra-workspace `version =` pins + `Cargo.lock` | 9 refs at `0.0.10` | Bumped to `0.0.11` |
| `README.md` install snippets | 4 refs at `0.0.8` | Bumped to `0.0.11` |
| `doc/USER-GUIDE.md` examples | 3 refs at `0.0.8` | Bumped to `0.0.11` |
| `CHANGELOG.md` | last entry v0.0.8; missing v0.0.9/10/11 | Backfilled all three |
| `RELEASE-NOTES-v0.0.{9,10,11}.md` | did not exist | Created all three |

Historical references (`doc/POLICIES.md` "0.0.99 runway", `README.md` "Capabilities in 0.0.1" / "since v0.0.5", `pkg/PUBLISH.md` `__VERSION__` templates, CI workflow comments referring to past-release bugs) deliberately left as-is — they describe project history, not the current release.

## Coverage-gap audit (follow-up for future releases)

Also ran a systematic coverage-gap audit over the whole workspace against the ask "regression tests / benches / examples / docs cover 100% of all functionalities and features". The gaps below are **out of scope for v0.0.11** (which is deliberately a CI-integrity release, not a feature release) but tracked here so a future dedicated **v0.0.12 = coverage catch-up** cut can close them.

**Test coverage**
- `noyalib::parallel::parse` / `parallel::values` — no dedicated feature-gated test
- `noyalib::simd::parse_decimal_{u64,i64}` — no dedicated test (relies on `coverage_full.rs` integration)
- `noyalib::robotics::{StrictFloat, Radians, Degrees}` — no regression test (only `robotics_polymorphism.rs` example)
- `noyalib::interner::Interned<T>`, `noyalib::with::With<T>` — no dedicated tests
- `noyalib::i18n::Formatters` — no integration test
- `#[derive(noyalib::JsonSchema)]` proc-macro — no dedicated test

**Bench coverage**
- `coerce_to_schema` cost — no isolated bench
- `parallel::parse` throughput — no bench (README claims near-linear scaling; no measured proof)
- Tokio async `from_async_reader` overhead — no throughput bench
- Anchor / alias resolution cost — no isolated bench (embedded in broader deserialization benches)
- `BorrowedValue` / zero-copy performance — no bench
- CST full round-trip cost (parse → edit → serialize) — no bench

**Example coverage**
- `parallel::*` — no runnable example
- `compat-serde-yaml` — no runnable example demonstrating migration flow

**Doc coverage**
- No `NIGHTLY-SIMD.md` guide for the `nightly-simd` feature
- No `PARALLEL.md` dedicated doc (only inline in `USER-GUIDE.md` §10)
- No `ROBOTICS.md` (StrictFloat / Radians / Degrees mentioned in README features table but no standalone guide)

**Workspace member gaps**
- `noya-cli` — no benchmarks for formatter / validator throughput
- `noyalib-wasm` — no browser performance benchmarks

**Cargo feature gaps** (features with ZERO test + zero example + zero bench + minimal doc)
- `minimal` (meta-alias for `std` only) — no smoke test
- `compare-saphyr` (dev-only) — no doc for the feature flag itself
- `nightly-simd` — no explicit bench (`simd.rs` requires `simd`, not `nightly-simd`)

## Test plan

Locally on `feat/v0.0.11` before merge:

- [x] `cargo build --workspace --all-features` — clean
- [x] `cargo test --workspace --all-features` — all tests pass
- [x] `cargo test --doc -p noyalib --all-features` — 528 doctests pass
- [x] `cargo check -p noyalib --no-default-features --lib --locked` (from a fresh target dir) — clean, ~1.14s
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean across every workspace crate
- [x] `cargo +1.85.0 check -p noyalib --lib --locked` — MSRV unchanged
- [x] `cargo bench -p noyalib --no-run --all-features` — all 8 bench binaries compile
- [x] `cargo build --examples -p noyalib --all-features` — all 50+ examples build
- [x] `bash scripts/check-readme-examples.sh` — all 17 non-`,ignore` root-README rust blocks compile clean
- [x] `cargo audit` — zero advisories
- [x] `cargo deny check` — advisories / bans / licenses / sources all ok
- [x] `cargo vet --locked` — 269 fully audited, 14 exempted
- [x] `cargo machete` — no unused dependencies

CI on this PR: **46 SUCCESS / 12 SKIPPED / 0 FAILURE** (skipped are schedule-only or event-gated jobs).

## Supersedes / closes

- **Closes #114** (Dependabot PR — `dtolnay/rust-toolchain` + `taiki-e/install-action` bumps, folded into `87feccd`)
- **Closes Code Scanning alert #36** (dismissed with source-controlled `osv-scanner.toml` guard so it can't re-open)
- Deferred to a future dedicated release: **#91** (`serde_core` migration by @EdJoPaTo), **#117** (lossless-u64 by @canardleteer) — both retargeted back to `main`; @EdJoPaTo has been briefed on the value.rs → value/ submodule split and the specific rebase guidance for his commits.