### PR TITLE
chore(workspace-split): crates.io ownership harness + ADR-0005 (closes #125, #126)

### DIFF
--- a/.github/workflows/crates-io-ownership.yml
+++ b/.github/workflows/crates-io-ownership.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: crates.io ownership drift
+
+# Daily + on every workspace-split PR: assert that the crates.io
+# owner of each satellite name is still `sebastienrousseau`. If a
+# name is force-transferred, silently yanked, or delisted-and-re-
+# registered by a third party mid-split, this workflow fails and
+# the maintainer is alerted before any further split PR merges.
+#
+# Guards issue #125 acceptance criterion #5 — "a follow-up
+# regression test MUST land … that fails CI if any of the four
+# crates.io namespaces changes owner between planning and the
+# split PR — so a mid-split squat cannot silently succeed."
+#
+# The script itself lives at scripts/check-crates-io-ownership.sh
+# and can be invoked locally with no dependencies beyond curl + jq.
+
+on:
+  # Daily at 04:00 UTC — well before the OpenSSF Scorecard run at
+  # Monday 04:00, so a drift caught here has time to be triaged
+  # before Scorecard picks it up too.
+  schedule:
+    - cron: '0 4 * * *'
+  # Every PR carrying the workspace-split label re-runs the check
+  # so a mid-split PR cannot merge on stale ownership data.
+  pull_request:
+    types: [opened, synchronize, labeled, reopened]
+  # Manual re-trigger from the Actions UI.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crates-io-ownership-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ownership:
+    name: crates.io ownership drift
+    # Only run on PR events when the workspace-split label is set.
+    # (schedule + workflow_dispatch always run.)
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'workspace-split')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check ownership of every satellite name on crates.io
+        run: bash scripts/check-crates-io-ownership.sh

--- a/doc/adr/0005-workspace-split.md
+++ b/doc/adr/0005-workspace-split.md
@@ -1,0 +1,328 @@
+# 0005. Split the noyalib workspace into 4 satellite repositories with strict-lockstep versioning
+
+- **Status:** proposed
+- **Date:** 2026-07-01
+- **Authors:** Sebastien Rousseau
+
+## Context
+
+Since v0.0.1 (2026-05-04) noyalib has shipped as a Cargo workspace
+containing five publishable crates:
+
+- `noyalib` — the core YAML 1.2 library
+- `noya-cli` — the `noyafmt` + `noyavalidate` CLI binaries
+- `noyalib-lsp` — the Language Server Protocol implementation
+- `noyalib-mcp` — the Model Context Protocol server
+- `noyalib-wasm` — the browser / WebAssembly bindings
+
+The monorepo shape has served the launch phase well. Every
+cross-cutting hardening pass (CI cache-poisoning guard in v0.0.11,
+supply-chain refresh in v0.0.9, no_std fix in v0.0.11) lands as
+one PR touching every crate that needs to change. Every release
+is a single tag that publishes five crates in lockstep. Every
+issue and pull request lands in one tracker with one label
+taxonomy.
+
+The forces now pushing back on the monorepo shape:
+
+- **Contributor surface confusion.** A contributor filing a bug
+  against the LSP has to know that the LSP lives under
+  `crates/noyalib-lsp/` in a bigger repo whose root README talks
+  primarily about the core library. Different downstream
+  audiences (LSP consumers via editor plugin marketplaces, MCP
+  consumers via AI-agent frameworks, WASM consumers via npm,
+  CLI consumers via Homebrew / apt / snap) each want their own
+  repo home for issue triage and release cadence visibility.
+- **Downstream dependency surface.** Even though noyalib's
+  packaged `.crate` archive on crates.io does not include the
+  satellite source (per `include = [...]` in
+  `crates/noyalib/Cargo.toml`), a downstream user cloning the
+  git repo to audit or contribute pulls in the whole workspace.
+  For downstream security scanners that trace repo provenance
+  as part of the supply-chain graph, the repo-level footprint
+  matters.
+- **Independent release visibility.** All five crates ship at
+  the same version because that's the shape lockstep in a
+  workspace enforces. A downstream user who consumes only
+  `noyalib-wasm` from npm has no visible signal that a v0.0.11
+  release happened because the wasm crate itself changed; every
+  noyalib patch bumps their wasm dep even when the wasm source
+  was untouched.
+- **Repository-level metrics.** Per-satellite stars, watchers,
+  forks, Scorecard scores, and issue-triage SLAs are useful
+  signals to satellite maintainers (once the satellites have
+  co-maintainers) and to downstream consumers evaluating the
+  health of the specific component they depend on. The monorepo
+  aggregates all of these under one number.
+
+Against those forces sit the **counter-arguments** that were
+weighed and rejected (see Alternatives):
+
+- The technical "footprint" argument for downstream users of
+  `noyalib` is already addressed by `include = [...]`. Splitting
+  does not shrink the packaged `.crate` archive.
+- Cross-cutting hardening becomes N-PR coordination unless it is
+  factored into shared reusable workflows before the first split.
+- Lockstep coordination becomes N-repo release orchestration
+  unless it is factored into a shared release workflow.
+
+The forces balance in favour of splitting **only if** the
+shared-workflow scaffolding lands **before** the pilot, and only
+if the versioning contract is chosen to preserve the audit
+clarity that lockstep provides today. The remainder of this ADR
+formalises both.
+
+## Decision
+
+We WILL split the noyalib workspace into 5 repositories under
+the `sebastienrousseau/` org:
+
+- `sebastienrousseau/noyalib` — the core library (this repo, kept
+  as-is after the split, with the satellite `crates/*/`
+  directories removed)
+- `sebastienrousseau/noyalib-wasm` — WebAssembly bindings
+- `sebastienrousseau/noyalib-mcp` — Model Context Protocol server
+- `sebastienrousseau/noyalib-lsp` — Language Server Protocol
+- `sebastienrousseau/noya-cli` — CLI binaries (`noyafmt`,
+  `noyavalidate`)
+
+The split proceeds as a **staged pilot** over four release
+windows to catch failure modes early:
+
+- **v0.0.12** — pilot: `noyalib-wasm`. Smallest satellite, no
+  intra-workspace dependents on it, cleanest split.
+- **v0.0.13** — `noyalib-mcp`. Same playbook.
+- **v0.0.14** — `noyalib-lsp`.
+- **v0.0.15** — `noya-cli` (bundled with `xtask`). Largest
+  satellite. Core is officially single-crate after this ships.
+
+Each split window includes a **14-day soak review** at its close.
+No subsequent split begins until the prior window records a GO
+signal. If any window records a NO-GO, the **rollback recipe**
+(see below) restores the monorepo shape and the split project is
+paused pending a full retrospective.
+
+### Versioning contract
+
+We WILL use **strict lockstep versioning** across all 5
+repositories. Every satellite version equals `noyalib`'s version
+at the moment of release. All 5 crates release simultaneously
+with a single coordinated tag push in the release-orchestration
+workflow.
+
+Cross-repo dependencies MUST use exact-match syntax:
+
+```toml
+# In noyalib-lsp/Cargo.toml — required
+noyalib = "=0.0.42"
+```
+
+A regression check MUST fail CI if a caret (`^`), tilde (`~`),
+or floating-range (`>=`, `<`) spec appears on any published
+branch of any satellite.
+
+### Cross-repo dependency posture
+
+Satellites MUST NOT use `path = "../noyalib"` overrides on any
+published branch. Local development against an unpublished
+noyalib requires a `[patch.crates-io]` block in the satellite's
+`Cargo.toml`, gated by a `[cfg(local-dev)]` convention that is
+never merged to `main`.
+
+### Shared reusable workflows
+
+Every satellite's `.github/workflows/` MUST consume the parent
+repo's shared workflows via `uses:` references — never by copy.
+Shared workflows are added to this repo under
+`.github/workflows/shared-<name>.yml` with a `workflow_call`
+trigger and pinned by SHA in each satellite. A hardening pass
+lands as one PR in this repo plus N (small, Dependabot-managed)
+SHA-bump PRs in the satellites.
+
+### Rollback recipe
+
+The rollback recipe MUST be executable in **≤60 minutes** of
+maintainer time from a clean scratch clone. Concretely:
+
+1. `git clone` this repo at the pre-split tag (`v0.0.11` or the
+   most recent monorepo tag)
+2. `git remote add satellite-<name> <split-repo-url>` for each
+   split satellite
+3. `git fetch --tags satellite-<name>` for each
+4. `git subtree add --prefix=crates/<name> satellite-<name> main`
+   for each satellite that had accepted commits post-split
+5. Restore workspace membership in the root `Cargo.toml` from
+   the pre-split state
+6. `cargo test --workspace` to confirm the restored shape is
+   green
+7. Cut a `v0.0.16` release from the restored workspace
+8. Mark each satellite crate on crates.io as `yanked` at every
+   version >= the rollback point (yank is not deletion; the
+   monorepo re-takes precedence)
+9. Update the parent repo README to note the rollback and cite
+   the failing acceptance criterion
+
+The pre-flight dry-run of this recipe MUST be exercised at least
+once (in a scratch clone against a mock satellite) as part of
+the pilot's pre-work, and the wall-clock time MUST be recorded
+in the ADR update section below.
+
+### Naming reservations
+
+`noyalib-wasm@0.0.0` has been published as a namespace
+reservation (2026-07-01) to close the pre-split race window for
+the only unclaimed name. `noyalib`, `noyalib-mcp`, `noyalib-lsp`,
+and `noya-cli` are already owned by `sebastienrousseau` from the
+v0.0.11 release. Ownership drift is monitored daily via
+[`crates-io-ownership.yml`](../../.github/workflows/crates-io-ownership.yml).
+
+## Consequences
+
+### Positive
+
+- Downstream contributors reach the right repo for the component
+  they care about; issue triage lives at the correct level of
+  granularity.
+- Each satellite carries its own OpenSSF Scorecard score, its own
+  supply-chain gates, its own security policy — a security
+  reviewer auditing `noyalib-mcp` sees only the MCP surface, not
+  the LSP or CLI surface they will never use.
+- Per-satellite release history is separately auditable — a
+  downstream user chasing "when did this LSP behaviour change"
+  reads only the noyalib-lsp git log, not a 10x-noisier
+  monorepo log.
+- The v0.0.11 CI cache-poisoning guard, docs-strict gate, and
+  README-examples gate propagate to all 5 repos via reusable
+  workflows — a security-first invariant enforced by one
+  authority.
+- Each satellite has its own Renovate / Dependabot config,
+  scoped to its own dep tree — downstream security scanners
+  observe a tighter blast radius per component.
+
+### Negative
+
+- Every hardening pass now touches 5 repos: 1 PR in the parent
+  (the shared workflow bump) + 4 Dependabot PRs in satellites.
+  For maintainer time this is roughly break-even with the
+  monorepo shape (single-repo PR touching 5 crates), but the
+  wall-clock latency is higher because each satellite's
+  Dependabot has its own cycle.
+- Every release cuts 5 tags across 5 repos in a coordinated
+  ceremony. A shared release-orchestration workflow makes this
+  one command, but the failure surface is 5x per release: any
+  single satellite failing to publish requires the whole cohort
+  to be re-tagged.
+- Cross-repo issues (an LSP bug caused by a scanner change in
+  noyalib) require cross-linking across repos, which GitHub's
+  issue-linking model does not enforce.
+- Contributors mid-split (e.g. #91 @EdJoPaTo, #117 @canardleteer)
+  need clear guidance on which repo their commits belong in.
+  Migration guides in MIGRATION.md handle this but require
+  active maintainer bandwidth during the split window.
+- Rollback is possible (`≤60min`) but costs credibility if
+  exercised — announcing a rollback for a shipped release is a
+  publicly visible admission of a bad decision. Mitigation is
+  the strict pilot-then-observe cadence with a 14-day soak
+  gate between each split.
+
+### Neutral
+
+- Repo count 1 → 5. Star count / watcher count / community
+  metrics fragment; the sum stays the same but no single number
+  represents the project any more.
+- CODEOWNERS, SECURITY.md, deny.toml, REUSE.toml, osv-scanner.toml
+  duplicate across all 5 repos. This is a shared-workflow
+  problem to solve; documented under #127.
+- Downstream `cargo add noyalib-lsp` behaviour is unchanged: the
+  crate name is stable, the API surface is stable, the
+  `use noyalib::...` paths are unchanged.
+
+## Alternatives considered
+
+### Keep the monorepo
+
+Would have kept the current shape indefinitely. Rejected because:
+
+- Contributor-surface confusion accumulates as the project's
+  audience diversifies (browser, MCP, LSP, CLI) — the monorepo
+  optimises for maintainer clarity at the cost of downstream
+  clarity.
+- Per-satellite Scorecard, security-policy, and issue-triage
+  granularity is a hard requirement for the components that
+  ship to security-conscious downstreams (LSP, MCP).
+- Not splitting means the security-review surface grows without
+  bound as the workspace accepts more satellites.
+
+### Independent SemVer (posture B from #128)
+
+Would have let each satellite version on its own cadence, pinning
+noyalib to a caret range (`noyalib = "^0.0"`). Rejected because:
+
+- Introduces a compatibility matrix — the downstream question
+  "which noyalib × noyalib-lsp combo actually works" becomes a
+  table to consult on every upgrade.
+- Slower security-patch propagation: a CVE in noyalib does not
+  force a coupled satellite re-release, so downstreams pinning
+  `noyalib-lsp = "0.0.9"` might not pick up the noyalib patch
+  until they Dependabot-bump the LSP separately.
+- Contradicts the security-first / audit-clarity posture of the
+  project (documented in the security-first-posture memory).
+
+### Hybrid (posture C from #128)
+
+Would have made noyalib patches transparent to satellites but
+required a coupled satellite patch on every noyalib minor.
+Rejected because:
+
+- Adds a decision-point ("is this noyalib change patch-shaped or
+  minor-shaped?") that requires an active call at every release.
+  Lockstep and independent-semver both remove this
+  decision-point; hybrid re-introduces it.
+- The edge-case surface is real: a noyalib patch that subtly
+  breaks a satellite's assumptions is possible under any
+  posture, but hybrid papers over it by refusing to bump the
+  satellite. Under strict lockstep the same patch forces a
+  satellite re-release that gets soak-tested end-to-end.
+
+### One repo per satellite, but keep noyalib in this repo
+
+Would have moved `noyalib-wasm`, `noyalib-mcp`, `noyalib-lsp`,
+`noya-cli`, and `xtask` to their own repos while leaving the
+core library in `sebastienrousseau/noyalib`. This is the shape
+we ARE adopting; it's noted here only to distinguish it from
+"one repo per crate including a fresh repo for noyalib core"
+which would have added migration cost for downstream users of
+`noyalib` itself without any offsetting benefit.
+
+## References
+
+- Pre-work issues: [#125](https://github.com/sebastienrousseau/noyalib/issues/125),
+  [#126](https://github.com/sebastienrousseau/noyalib/issues/126),
+  [#127](https://github.com/sebastienrousseau/noyalib/issues/127),
+  [#128](https://github.com/sebastienrousseau/noyalib/issues/128)
+- Split issues: [#129](https://github.com/sebastienrousseau/noyalib/issues/129) (v0.0.12 pilot),
+  [#130](https://github.com/sebastienrousseau/noyalib/issues/130) (v0.0.13),
+  [#131](https://github.com/sebastienrousseau/noyalib/issues/131) (v0.0.14),
+  [#132](https://github.com/sebastienrousseau/noyalib/issues/132) (v0.0.15)
+- Post-split cleanup: [#133](https://github.com/sebastienrousseau/noyalib/issues/133) (MIGRATION.md),
+  [#134](https://github.com/sebastienrousseau/noyalib/issues/134) (retire monorepo tooling)
+- Related PR: [#135](https://github.com/sebastienrousseau/noyalib/pull/135) — crates.io
+  ownership-drift regression harness closing #125 AC5
+- `noyalib-wasm@0.0.0` namespace reservation: <https://crates.io/crates/noyalib-wasm>
+- Prior art: [tokio](https://github.com/tokio-rs/tokio) uses
+  a workspace for the reasons this ADR chose to move away from;
+  [serde](https://github.com/serde-rs/serde) uses a workspace
+  but ships `serde_derive` and `serde_json` separately at
+  independent semver, which was the posture we rejected.
+
+## Post-implementation update
+
+The rollback dry-run was performed on: **PENDING** (target: pilot
+pre-work window). Wall-clock time recorded: **PENDING**.
+
+The 14-day soak reviews at each split window will record their
+GO / NO-GO signal here as an inline update rather than moving the
+ADR to `superseded`; this ADR remains the source of truth for
+the whole split project. If the project rolls back mid-flight,
+this ADR moves to `superseded by [next ADR]` and a fresh ADR
+describes the rollback rationale.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -26,6 +26,7 @@ reference back. Nothing is silently rewritten.
 | [0001](./0001-cst-rowan-shape.md) | CST shape: parallel green tree, not unified | accepted |
 | [0002](./0002-yaml-1.2-default.md) | YAML 1.2 strict semantics by default; 1.1 opt-in | accepted |
 | [0003](./0003-zero-unsafe-policy.md) | `#![forbid(unsafe_code)]` workspace-wide | accepted |
+| [0005](./0005-workspace-split.md) | Split the workspace into 4 satellite repos with strict-lockstep versioning | proposed |
 
 ## When to add an ADR
 

--- a/scripts/check-crates-io-ownership.sh
+++ b/scripts/check-crates-io-ownership.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Guard against mid-split namespace squats.
+#
+# For every crate name that the workspace-split project depends on
+# (noyalib, noyalib-wasm, noyalib-mcp, noyalib-lsp, noya-cli), this
+# script asserts that the crates.io owner is still `sebastienrousseau`.
+# If any owner has changed — because the crate was force-transferred,
+# yanked-then-taken-over, or a delisted-and-re-registered exploit —
+# CI fails immediately.
+#
+# Runs as a scheduled workflow (daily at 04:00 UTC) plus on every PR
+# labelled `workspace-split` so the pre-work is validated whenever
+# the split project touches the tree.
+#
+# Exit codes:
+#   0  every satellite name still owned by sebastienrousseau
+#   1  at least one owner drift detected (see stderr for names)
+#   2  crates.io API unreachable / transient network error
+#
+# References:
+#   Issue #125 acceptance criterion #5
+#   ADR-0005 (workspace split, cross-repo dep policy)
+
+set -euo pipefail
+
+EXPECTED_OWNER="sebastienrousseau"
+EXPECTED_OWNER_ID="186843"
+
+CRATES=(
+    noyalib
+    noyalib-wasm
+    noyalib-mcp
+    noyalib-lsp
+    noya-cli
+)
+
+DRIFT=0
+UNREACHABLE=0
+
+for CRATE in "${CRATES[@]}"; do
+    HTTP=$(curl -sfL -o /dev/null -w "%{http_code}" \
+        "https://crates.io/api/v1/crates/${CRATE}/owners" \
+        --max-time 10 \
+        --retry 3 \
+        --retry-delay 2 \
+        || echo "network-error")
+
+    case "${HTTP}" in
+        network-error|000)
+            printf '  [NET ] %s — crates.io unreachable\n' "${CRATE}" >&2
+            UNREACHABLE=$((UNREACHABLE + 1))
+            continue
+            ;;
+        404)
+            printf '  [FAIL] %s — HTTP 404, name is UNCLAIMED (was reserved by us? someone deleted it?)\n' "${CRATE}" >&2
+            DRIFT=$((DRIFT + 1))
+            continue
+            ;;
+        200)
+            ;;
+        *)
+            printf '  [WARN] %s — unexpected HTTP %s\n' "${CRATE}" "${HTTP}" >&2
+            UNREACHABLE=$((UNREACHABLE + 1))
+            continue
+            ;;
+    esac
+
+    OWNER_JSON=$(curl -sfL "https://crates.io/api/v1/crates/${CRATE}/owners" \
+        --max-time 10 --retry 3 --retry-delay 2)
+
+    OWNER_LOGIN=$(printf '%s' "${OWNER_JSON}" | jq -r '.users[0].login // "??"')
+    OWNER_ID=$(printf '%s' "${OWNER_JSON}" | jq -r '.users[0].id // "??"')
+
+    if [[ "${OWNER_LOGIN}" == "${EXPECTED_OWNER}" && "${OWNER_ID}" == "${EXPECTED_OWNER_ID}" ]]; then
+        printf '  [ OK ] %s — owner: %s (id=%s)\n' "${CRATE}" "${OWNER_LOGIN}" "${OWNER_ID}"
+    else
+        printf '  [FAIL] %s — owner DRIFT: got %s (id=%s), expected %s (id=%s)\n' \
+            "${CRATE}" "${OWNER_LOGIN}" "${OWNER_ID}" \
+            "${EXPECTED_OWNER}" "${EXPECTED_OWNER_ID}" >&2
+        DRIFT=$((DRIFT + 1))
+    fi
+done
+
+echo
+if [[ ${DRIFT} -gt 0 ]]; then
+    printf '── FAIL: %d owner drift(s) detected. Investigate before opening the next split PR.\n' "${DRIFT}" >&2
+    exit 1
+fi
+
+if [[ ${UNREACHABLE} -gt 0 ]]; then
+    printf '── WARN: %d crate(s) unreachable due to network; retry when connectivity returns.\n' "${UNREACHABLE}" >&2
+    exit 2
+fi
+
+printf '── OK: all %d satellite names still owned by %s.\n' "${#CRATES[@]}" "${EXPECTED_OWNER}"


### PR DESCRIPTION
Closes **[#125](https://github.com/sebastienrousseau/noyalib/issues/125)** (AC #5 residual — the scheduled regression harness) and **[#126](https://github.com/sebastienrousseau/noyalib/issues/126)** (ADR-0005 workspace-split design + rollback plan).

## What landed before this PR

- All 5 satellite crates.io names owned by \`sebastienrousseau\` (verified in [#125 findings comment](https://github.com/sebastienrousseau/noyalib/issues/125#issuecomment-4855749346))
- **\`noyalib-wasm@0.0.0\`** published to crates.io today as a namespace reservation, closing the pre-split race window
- Versioning-posture decision recorded on [#128](https://github.com/sebastienrousseau/noyalib/issues/128#issuecomment-4857403386): **strict lockstep**

## What this PR adds

### Ownership-drift harness (closes #125)

- \`scripts/check-crates-io-ownership.sh\` — plain \`curl + jq\` script; exit 0 (all owned), 1 (drift, fail CI), 2 (API unreachable, inconclusive)
- \`.github/workflows/crates-io-ownership.yml\` — fires daily at 04:00 UTC + on every PR with \`workspace-split\` label + on-demand \`workflow_dispatch\`

Locally verified against all 5 names:
\`\`\`
[ OK ] noyalib — owner: sebastienrousseau (id=186843)
[ OK ] noyalib-wasm — owner: sebastienrousseau (id=186843)
[ OK ] noyalib-mcp — owner: sebastienrousseau (id=186843)
[ OK ] noyalib-lsp — owner: sebastienrousseau (id=186843)
[ OK ] noya-cli — owner: sebastienrousseau (id=186843)
── OK: all 5 satellite names still owned by sebastienrousseau.
\`\`\`

### ADR-0005 (closes #126)

329-line ADR under \`doc/adr/0005-workspace-split.md\` (status: **proposed** until v0.0.15 ships) covering:

- **Context** — forces pushing toward split, counter-arguments weighed
- **Decision** — 4-satellite split, staged pilot with 14-day soak gates, strict-lockstep versioning, \`= \` exact-match cross-repo deps, no \`path = \` overrides on published branches, shared reusable workflows
- **Rollback recipe** — 9-step ≤60-minute recipe, dry-run required before pilot ships
- **Consequences** — positive, negative, neutral (honest about the 5x release-ceremony surface, cross-repo issue linking)
- **Alternatives** — keep monorepo, independent semver, hybrid, split-with-noyalib-repo-too — each rejected with reasons
- **References** — all 10 workspace-split issues + prior art (tokio, serde)

Registered under [\`doc/adr/README.md\`](doc/adr/README.md) at slot 0005 (slot 0004 reserved for the lossless-u64 ADR in PR #117).

## Test plan

- [x] Ownership script runs clean locally
- [x] YAML syntax valid (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] ADR follows the project's Nygard-format template
- [x] ADR-0005 correctly indexed under \`doc/adr/README.md\`
- [ ] CI: strict rustdoc, cache-poisoning-guarded no_std, README-examples-compile gates all remain green
- [ ] New \`crates.io ownership drift\` workflow appears in the Actions tab after merge
- [ ] Scheduled daily trigger visible under the workflow's "Schedule" section

Post-merge, only [#127](https://github.com/sebastienrousseau/noyalib/issues/127) (shared reusable workflows) remains blocking [#129](https://github.com/sebastienrousseau/noyalib/issues/129) (the v0.0.12 pilot).