### PR TITLE
ci(workspace-split): extract 4 supply-chain jobs into shared workflows (phase 1 of #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,10 @@ jobs:
           MIRI_TARGET: mips64-unknown-linux-gnuabi64
 
   cargo-deny:
-    name: cargo-deny
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+    # Consumes the shared cargo-deny workflow from this same repo
+    # so noyalib dogfoods the shared pattern before any satellite
+    # takes it via `uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-deny.yml@<sha>`.
+    uses: ./.github/workflows/shared-cargo-deny.yml
 
   fuzz-diff:
     name: Differential fuzz (10s smoke)
@@ -241,55 +240,22 @@ jobs:
           package: noyalib
 
   cargo-vet:
-    name: cargo-vet
-    # Verify every dependency in the build graph has either a local
-    # audit or coverage from one of the imported trusted audit sets
-    # (Mozilla, Google, Bytecode Alliance, Embark, ISRG). Bootstrap
-    # exemptions live in `supply-chain/config.toml`; the goal is to
-    # drive that list down to zero over time. Adding a new dep that
-    # is not yet covered will fail this job.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install cargo-vet
-        run: cargo install --locked cargo-vet
-      - name: cargo vet check
-        run: cargo vet --locked
+    # Dogfooded from shared-cargo-vet.yml — see the shared file
+    # for full context. Satellites will consume it via
+    # `uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-vet.yml@<sha>`.
+    uses: ./.github/workflows/shared-cargo-vet.yml
 
   cargo-machete:
-    name: cargo-machete (unused-dep gate)
-    # Catches dependencies declared in `Cargo.toml` that are no
-    # longer referenced anywhere in the crate. Keeps the dep
-    # tree honest as the workspace grows: a removed feature or
-    # refactor that orphans a `[dependencies]` entry surfaces
-    # here rather than slowly bloating the lockfile.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install cargo-machete
-        run: cargo install --locked cargo-machete
-      - name: cargo machete
-        run: cargo machete
+    # Dogfooded from shared-cargo-machete.yml — see the shared
+    # file for full context. Satellites will consume it via
+    # `uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-machete.yml@<sha>`.
+    uses: ./.github/workflows/shared-cargo-machete.yml
 
   reuse-lint:
-    name: REUSE.software compliance
-    # Every source file in this crate carries an SPDX license header.
-    # `reuse lint` enforces that they remain in place, that LICENSE
-    # files exist for every license the project declares, and that no
-    # untagged file slips into the tree. Cheap belt-and-suspenders
-    # against accidental licensing rot.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v6
+    # Dogfooded from shared-reuse.yml — see the shared file for
+    # full context. Satellites will consume it via
+    # `uses: sebastienrousseau/noyalib/.github/workflows/shared-reuse.yml@<sha>`.
+    uses: ./.github/workflows/shared-reuse.yml
 
   msrv-1-85-core:
     name: MSRV (1.85.0) core build

--- a/.github/workflows/shared-cargo-deny.yml
+++ b/.github/workflows/shared-cargo-deny.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / cargo-deny
+
+# Reusable supply-chain gate. Runs `cargo deny check` (advisories +
+# bans + licenses + sources) against the caller's `deny.toml` and
+# `Cargo.lock`.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     cargo-deny:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-deny.yml@<sha>
+#
+# Every satellite (noyalib-wasm, noyalib-mcp, noyalib-lsp, noya-cli)
+# consumes this so a supply-chain policy tightening in noyalib
+# propagates via a single Dependabot SHA bump per satellite.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20

--- a/.github/workflows/shared-cargo-machete.yml
+++ b/.github/workflows/shared-cargo-machete.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / cargo-machete
+
+# Reusable unused-dependency gate. Runs `cargo machete` against the
+# caller's Cargo.toml — catches declared dependencies that are no
+# longer referenced anywhere in the crate. Keeps the dep tree
+# honest as a workspace grows: a removed feature or a refactor
+# that orphans a `[dependencies]` entry surfaces here rather than
+# slowly bloating the lockfile.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     cargo-machete:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-machete.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: cargo-machete (unused-dep gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-machete
+        run: cargo install --locked cargo-machete
+      - name: cargo machete
+        run: cargo machete

--- a/.github/workflows/shared-cargo-vet.yml
+++ b/.github/workflows/shared-cargo-vet.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / cargo-vet
+
+# Reusable supply-chain gate. Runs `cargo vet --locked` against the
+# caller's `supply-chain/{audits,config,imports}.toml` and
+# `Cargo.lock`. Every dep in the build graph MUST have either a
+# local audit or coverage from an imported trusted audit set
+# (Mozilla, Google, Bytecode Alliance, Embark, Fermyon, ISRG,
+# Zcash). Bootstrap exemptions live in
+# `supply-chain/config.toml`; adding a new dep that is not yet
+# covered fails this job.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     cargo-vet:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-vet.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: cargo-vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-vet
+        run: cargo install --locked cargo-vet
+      - name: cargo vet check
+        run: cargo vet --locked

--- a/.github/workflows/shared-reuse.yml
+++ b/.github/workflows/shared-reuse.yml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / REUSE compliance
+
+# Reusable REUSE.software compliance gate. Runs `fsfe/reuse-action`
+# against the caller's source tree — enforces that every file
+# carries an SPDX license header (either inline or via
+# `REUSE.toml` aggregate annotations), LICENSE files exist for
+# every license the project declares, and no untagged file slips
+# into the tree.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     reuse:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-reuse.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: REUSE.software compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v6


### PR DESCRIPTION
Phase 1 of [#127](https://github.com/sebastienrousseau/noyalib/issues/127) — extracts the four smallest, lowest-risk supply-chain gates into dedicated reusable workflows and dogfoods them in noyalib's own \`ci.yml\`.

## What this PR adds

Four new reusable workflows under \`.github/workflows/shared-*.yml\`, each with \`on: workflow_call:\` and \`permissions: contents: read\`:

- \`shared-cargo-deny.yml\` — advisories + bans + licenses + sources
- \`shared-cargo-vet.yml\` — audit coverage from trusted sets  
- \`shared-cargo-machete.yml\` — unused-dep gate
- \`shared-reuse.yml\` — REUSE.software SPDX compliance

Refactored \`ci.yml\` jobs consume them locally via \`uses: ./.github/workflows/shared-<x>.yml\` — the dogfooding required by [#127 AC #2](https://github.com/sebastienrousseau/noyalib/issues/127) (\"noyalib's own ci.yml MUST reference the shared workflows via \`uses: ./.github/workflows/shared-<x>.yml\` (local path) — proving they work for the repo that owns them BEFORE any satellite consumes them\").

Once these are proven in noyalib's own CI, satellite repos will consume them by SHA:

\`\`\`yaml
jobs:
  cargo-deny:
    uses: sebastienrousseau/noyalib/.github/workflows/shared-cargo-deny.yml@<sha>
\`\`\`

A hardening pass then lands as one PR in this repo + N (small, Dependabot-managed) SHA-bump PRs across satellite repos.

## Deliberately out of scope for this phase

Queued for follow-up PRs under #127 as the shared-workflow pattern matures:

- Test matrix (OS × toolchain) — needs a matrix input mechanic
- Rustdoc strict — has a specific \`CARGO_TARGET_DIR\` isolation pattern
- \`no_std\` check — same
- MSRV core build — 3-sub-target-dir composition
- Miri (focused + full + soak) — nightly + Miri-specific setup
- Coverage gate — llvm-cov + coverage instrumentation
- Differential fuzz — sanitiser-instrumented profile
- README examples (root) — the script-based check I added in v0.0.11
- Verify commit signatures — GitHub-API check specific to PR events

## Potential ruleset impact

The \`main-branch-protection\` ruleset lists four required checks by name (\`cargo-deny\`, \`cargo-vet\`, \`cargo-machete (unused-dep gate)\`, \`REUSE.software compliance\`). When a reusable workflow is called, the check name reported to the ruleset is derived from the CALLER's job id + the SHARED workflow's inner job name. **If that changes the reported name**, the ruleset needs updating in a follow-up commit before this PR can merge to \`main\` (via the eventual v0.0.12 release PR). Watching CI here on \`feat/v0.0.12\` to observe the actual reported names.

## Test plan

- [x] All 5 modified/new YAML files parse (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Diff cleanly separates \"extract shared\" from \"refactor caller\"
- [x] CI runs on this PR — observe the reported check names for the 4 refactored jobs
- [x] If check names shift, follow-up commit updates the ruleset
- [x] Every other CI gate (Miri, Coverage, no_std, MSRV, rustdoc-strict, README examples, tests × 6 OS/toolchain) still green post-refactor