### PR TITLE
ci(workspace-split): extract 4 CARGO_TARGET_DIR-isolated PR gates into shared workflows (phase 2 of #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,131 +421,28 @@ jobs:
         run: ./scripts/msrv-per-crate.sh
 
   no-std:
-    name: no_std (alloc-only) build
-    # The README and CHANGELOG promise that `default-features = false`
-    # builds without `std`. This job enforces that promise on every
-    # push so the claim never silently regresses.
-    #
-    # CACHE-POISONING GUARD: this job uses an isolated CARGO_TARGET_DIR
-    # so the no_std fingerprint can never be served from a previous
-    # `cargo check` that ran with `std` on (those would share the
-    # default `target/` under Swatinem/rust-cache and silently return
-    # a stale-but-passing result, masking real no_std regressions —
-    # exactly what hid the missing `crate::prelude::Vec` / `vec` import
-    # in doc_boundary.rs and the unused `crate::span_context` import in
-    # de.rs through v0.0.9 and v0.0.10).
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-no-std
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          # Scope the cache to this job's isolated target dir, and
-          # split the cache namespace so it can't share state with the
-          # `std`-on jobs. Belt-and-braces: even if Swatinem changes
-          # default behaviour, the explicit CARGO_TARGET_DIR above is
-          # the real guarantee.
-          workspaces: ". -> target-no-std"
-          key: no-std
-      - name: cargo check --no-default-features
-        run: cargo check --no-default-features --lib --locked
+    # Dogfooded from shared-no-std.yml — the CARGO_TARGET_DIR
+    # isolation + Swatinem cache-namespace split (preventing the
+    # v0.0.9/v0.0.10 cache-poisoning class of bug) live in the
+    # shared workflow. Satellites will consume it via
+    # `uses: sebastienrousseau/noyalib/.github/workflows/shared-no-std.yml@<sha>`.
+    uses: ./.github/workflows/shared-no-std.yml
 
   readme-examples:
-    name: README examples (root)
-    # Every `` ```rust `` code block in the workspace-root
-    # README.md is extracted and compiled against `noyalib` from a
-    # scratch project. Broken landing-page examples fail the PR.
-    #
-    # Cannot use `#[doc = include_str!("../../../README.md")]` in
-    # noyalib's lib.rs because the workspace-root README lives
-    # outside the crate's package layout, so `cargo publish
-    # --dry-run` would fail verification. The script-based path
-    # (`scripts/check-readme-examples.sh`) preserves the "every
-    # README example is tested" invariant without breaking
-    # publish.
-    #
-    # CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. The
-    # scratch project this job spins up must never be served a
-    # cached artefact set from a different feature configuration.
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-readme-examples
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-readme-examples"
-          key: readme-examples
-      - name: Compile every ```rust block in README.md
-        run: bash scripts/check-readme-examples.sh
+    # Dogfooded from shared-readme-examples.yml. The check itself
+    # (scripts/check-readme-examples.sh) is invoked by the shared
+    # workflow and must exist in the caller's checkout at the same
+    # path.
+    uses: ./.github/workflows/shared-readme-examples.yml
 
   docs-strict:
-    name: rustdoc (strict)
-    # Mirror the same RUSTDOCFLAGS the docs.yml deployment job uses,
-    # but on every PR — broken intra-doc links and bad codeblock
-    # fence attributes should fail a PR, not break the Pages
-    # deployment after merge. (For three days through v0.0.9 +
-    # v0.0.10 the docs.yml job was silently failing on main while
-    # PRs sailed through; this gate closes that hole.)
-    #
-    # CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. rustdoc
-    # fingerprints depend on RUSTDOCFLAGS env; if a Swatinem cache
-    # from a different job (without the strict flags) restored
-    # into target/, cargo could serve a stale hit and mask new
-    # broken doc links.
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-docs-strict
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-docs-strict"
-          key: docs-strict
-      - name: cargo doc --no-deps --all-features (strict)
-        env:
-          RUSTDOCFLAGS: >-
-            -D warnings
-            -D rustdoc::broken_intra_doc_links
-            -D rustdoc::private_intra_doc_links
-            -D rustdoc::invalid_codeblock_attributes
-            -D rustdoc::invalid_html_tags
-            -D rustdoc::bare_urls
-        run: cargo doc --workspace --no-deps --all-features --locked
+    # Dogfooded from shared-rustdoc-strict.yml. The strict
+    # RUSTDOCFLAGS + isolated CARGO_TARGET_DIR live in the shared
+    # workflow.
+    uses: ./.github/workflows/shared-rustdoc-strict.yml
 
   verify-signatures:
-    name: Verify commit signatures
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-      - name: Verify PR commits are signed (via GitHub API)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          UNSIGNED=""
-          for COMMIT in $(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[].sha'); do
-            VERIFIED=$(gh api repos/${{ github.repository }}/git/commits/$COMMIT --jq '.verification.verified')
-            if [ "$VERIFIED" != "true" ]; then
-              MSG=$(gh api repos/${{ github.repository }}/git/commits/$COMMIT --jq '.message' | head -1)
-              echo "::error::Unverified commit: $COMMIT ($MSG)"
-              UNSIGNED="$UNSIGNED $COMMIT"
-            fi
-          done
-          if [ -n "$UNSIGNED" ]; then
-            echo "::error::Unverified commits detected. All PR commits must be signed."
-            exit 1
-          fi
-          echo "All commits are verified."
+    # Dogfooded from shared-verify-signatures.yml. The gate itself
+    # only runs on pull_request events (controlled inside the
+    # shared workflow's `if:`).
+    uses: ./.github/workflows/shared-verify-signatures.yml

--- a/.github/workflows/shared-no-std.yml
+++ b/.github/workflows/shared-no-std.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / no_std (alloc-only) build
+
+# Reusable no_std invariant gate. Runs `cargo check
+# --no-default-features --lib --locked` against the caller's
+# crate, enforcing that `default-features = false` builds without
+# `std` — which the README and CHANGELOG advertise.
+#
+# CACHE-POISONING GUARD: this workflow uses an isolated
+# CARGO_TARGET_DIR so the no_std fingerprint can never be served
+# from a previous `cargo check` that ran with `std` on (those
+# would share the default `target/` under Swatinem/rust-cache and
+# silently return a stale-but-passing result, masking real
+# no_std regressions — exactly what hid the missing
+# `crate::prelude::Vec` / `vec` import in doc_boundary.rs and the
+# unused `crate::span_context` import in de.rs through v0.0.9
+# and v0.0.10 of noyalib).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     no-std:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-no-std.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: no_std (alloc-only) build
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-no-std
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Scope the cache to this workflow's isolated target dir
+          # and split the cache namespace so it can't share state
+          # with the `std`-on jobs. Belt-and-braces: even if
+          # Swatinem changes default behaviour, the explicit
+          # CARGO_TARGET_DIR above is the real guarantee.
+          workspaces: ". -> target-no-std"
+          key: no-std
+      - name: cargo check --no-default-features
+        run: cargo check --no-default-features --lib --locked

--- a/.github/workflows/shared-readme-examples.yml
+++ b/.github/workflows/shared-readme-examples.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / README examples (root)
+
+# Reusable "compile every ```rust block in the workspace-root
+# README" gate. Runs `scripts/check-readme-examples.sh` which
+# extracts every ` ```rust ` code block (excluding `,ignore`)
+# from the caller's root `README.md`, wraps each with `fn main()`
+# if not already present (matches rustdoc's implicit-main
+# behaviour), and compiles them against a scratch project.
+#
+# Cannot use `#[doc = include_str!("../README.md")]` because the
+# workspace-root README lives outside published crates' package
+# layouts — `cargo publish --dry-run` verification would fail. The
+# script-based path preserves the "every README example is
+# tested" invariant without breaking publish.
+#
+# CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. The scratch
+# project this workflow spins up must never be served a cached
+# artefact set from a different feature configuration.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     readme-examples:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-readme-examples.yml@<sha>
+#
+# The caller MUST ship `scripts/check-readme-examples.sh` in its
+# own repo (or arrange to fetch a copy). Satellite repos will
+# typically vendor a matching copy of the script; the invariant
+# it enforces is the same in every case.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: README examples (root)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-readme-examples
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-readme-examples"
+          key: readme-examples
+      - name: Compile every rust block in README.md
+        run: bash scripts/check-readme-examples.sh

--- a/.github/workflows/shared-rustdoc-strict.yml
+++ b/.github/workflows/shared-rustdoc-strict.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / rustdoc (strict)
+
+# Reusable strict-rustdoc PR gate. Runs `cargo doc --workspace
+# --no-deps --all-features --locked` with the same strict
+# RUSTDOCFLAGS the deployment workflow (docs.yml) uses on main —
+# so broken intra-doc links, invalid codeblock attributes,
+# malformed HTML, and bare URLs fail the PR rather than the
+# post-merge Pages deployment.
+#
+# CACHE-POISONING GUARD: isolated CARGO_TARGET_DIR. rustdoc
+# fingerprints depend on RUSTDOCFLAGS env; if a Swatinem cache
+# from a different job (without the strict flags) restored into
+# target/, cargo could serve a stale hit and mask new broken doc
+# links. See noyalib's v0.0.11 CI-integrity release notes for the
+# concrete incident this prevents.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     docs-strict:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-rustdoc-strict.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: rustdoc (strict)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-docs-strict
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-docs-strict"
+          key: docs-strict
+      - name: cargo doc --no-deps --all-features (strict)
+        env:
+          RUSTDOCFLAGS: >-
+            -D warnings
+            -D rustdoc::broken_intra_doc_links
+            -D rustdoc::private_intra_doc_links
+            -D rustdoc::invalid_codeblock_attributes
+            -D rustdoc::invalid_html_tags
+            -D rustdoc::bare_urls
+        run: cargo doc --workspace --no-deps --all-features --locked

--- a/.github/workflows/shared-verify-signatures.yml
+++ b/.github/workflows/shared-verify-signatures.yml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Verify commit signatures
+
+# Reusable signed-commit gate. Iterates every commit on the caller
+# PR and asserts each carries a verified GPG/SSH signature via the
+# GitHub REST API. Fails if any commit in the PR is unverified.
+#
+# Complements the `required_signatures: true` rule in the
+# main-branch-protection ruleset — that rule blocks the direct
+# push of an unsigned commit, and this gate blocks the merge of a
+# PR whose commits are individually unsigned (belt + braces, so a
+# ruleset gap or a mid-PR unsigned commit does not slip in).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     verify-signatures:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-verify-signatures.yml@<sha>
+
+on:
+  workflow_call:
+
+# The default `contents: read` scope is enough to hit the
+# `git/commits` and `pulls/N/commits` REST endpoints for the
+# repo the workflow is running in.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: Verify commit signatures
+    runs-on: ubuntu-latest
+    # Only meaningful on pull_request events (the gate iterates
+    # PR commits). Scheduled / push events skip cleanly.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Verify PR commits are signed (via GitHub API)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          UNSIGNED=""
+          for COMMIT in $(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits --jq '.[].sha'); do
+            VERIFIED=$(gh api repos/${{ github.repository }}/git/commits/$COMMIT --jq '.verification.verified')
+            if [ "$VERIFIED" != "true" ]; then
+              MSG=$(gh api repos/${{ github.repository }}/git/commits/$COMMIT --jq '.message' | head -1)
+              echo "::error::Unverified commit: $COMMIT ($MSG)"
+              UNSIGNED="$UNSIGNED $COMMIT"
+            fi
+          done
+          if [ -n "$UNSIGNED" ]; then
+            echo "::error::Unverified commits detected. All PR commits must be signed."
+            exit 1
+          fi
+          echo "All commits are verified."


### PR DESCRIPTION
Phase 2 of [#127](https://github.com/sebastienrousseau/noyalib/issues/127). Continues the extraction pattern established in phase 1 (PR #136 → commit \`e695d4a\` on \`feat/v0.0.12\`), covering the four PR-time gates that carry cache-poisoning-guard invariants from v0.0.11.

## What this PR adds

Four new reusable workflows under \`.github/workflows/shared-*.yml\`, each with \`on: workflow_call:\` and least-privilege \`permissions: contents: read\`:

- \`shared-no-std.yml\` — \`cargo check --no-default-features --lib --locked\` in an **isolated \`CARGO_TARGET_DIR=target-no-std\`** + scoped Swatinem cache namespace
- \`shared-rustdoc-strict.yml\` — \`cargo doc --workspace --no-deps --all-features --locked\` with the strict \`RUSTDOCFLAGS\` (\`-D warnings\`, \`broken_intra_doc_links\`, \`private_intra_doc_links\`, \`invalid_codeblock_attributes\`, \`invalid_html_tags\`, \`bare_urls\`), isolated to \`target-docs-strict\`
- \`shared-readme-examples.yml\` — runs \`scripts/check-readme-examples.sh\`, isolated to \`target-readme-examples\`
- \`shared-verify-signatures.yml\` — signed-commit gate via the GitHub API, \`pull_request\` events only

Refactored \`ci.yml\` jobs consume them locally via \`uses: ./.github/workflows/shared-<x>.yml\` — the dogfooding pattern from phase 1.

## Cache-poisoning guard preserved

Every extraction retains the invariants introduced in v0.0.11:

- Each gate has its **own isolated \`CARGO_TARGET_DIR\`** so a stale fingerprint from a different feature configuration cannot be served — the class of bug that hid the broken \`no_std\` build across v0.0.9 and v0.0.10.
- Each gate has its **own Swatinem cache namespace** (\`workspaces:\` scope + \`key:\` name) so the isolated target dir is what the cache restores into. Belt + braces.

This means when a satellite adopts these via \`uses: sebastienrousseau/noyalib/.github/workflows/shared-<x>.yml@<sha>\`, it inherits the same anti-poisoning invariants for free.

## Potential ruleset impact (same as phase 1)

The \`main-branch-protection\` ruleset currently lists these 4 jobs by their pre-refactor names:

\`\`\`
no_std (alloc-only) build
rustdoc (strict)
README examples (root)
Verify commit signatures
\`\`\`

Under the reusable-workflow wrapping, GitHub reports compound names — e.g. \`no-std / no_std (alloc-only) build\`. **If the reported names shift, the ruleset will be updated in this same PR** (identical playbook to phase 1). Watching CI here on \`feat/v0.0.12\` to observe the actual names.

## Test plan

- [x] All 5 modified/new YAML files parse (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Diff cleanly separates \"extract shared\" from \"refactor caller\"
- [x] CI runs on this PR — observe the reported check names for the 4 refactored jobs
- [x] If check names shift, follow-up commit updates the ruleset
- [x] Every other CI gate still green post-refactor

## Deliberately out of scope for phase 2

Queued for phase 3 (a later PR):

- Test matrix (OS × toolchain) — needs a matrix input mechanic
- MSRV core build — 3-sub-target-dir composition
- Per-crate MSRV
- Miri (focused + full + soak) — nightly + Miri-specific setup
- Coverage gate — \`llvm-cov\` + coverage instrumentation
- Differential fuzz — sanitiser-instrumented profile
- \`vendor + offline build\`