### PR TITLE
ci(workspace-split): extract the last 8 jobs into shared workflows (phase 3 of #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,134 +34,33 @@ jobs:
     secrets: inherit
 
   test-matrix:
-    name: Test (${{ matrix.os }}, ${{ matrix.toolchain }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable, nightly]
-    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Rust ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Run tests
-        run: cargo test --all-features
-      # NOTE: the MSRV-1.85 build matrix is now in its own job
-      # (`msrv-1-85-core`) — the optional features pull in
-      # ergonomics deps that themselves require newer rustc
-      # (miette → backtrace ≥ 1.82, garde → 1.84, ICU chain →
-      # 1.86), so `cargo test --all-features` cannot run on
-      # 1.85. The MSRV gate covers the *core* feature set
-      # (no_std + default), which is what crate consumers
-      # actually rely on.
+    # Dogfooded from shared-test-matrix.yml. Matrix (os × toolchain)
+    # comes from the shared workflow's defaults. Satellites can
+    # trim OSes / toolchains they don't support by passing custom
+    # JSON to the `os-list` / `toolchain-list` inputs.
+    # NOTE: MSRV-1.85 lives in msrv-core (below) — the optional
+    # features pull in ergonomics deps that themselves require
+    # newer rustc (miette → backtrace ≥ 1.82, garde → 1.84,
+    # ICU chain → 1.86), so `cargo test --all-features` cannot
+    # run on 1.85. The MSRV gate covers the *core* feature set.
+    uses: ./.github/workflows/shared-test-matrix.yml
 
   miri-focused:
-    name: Miri (focused, per-PR)
-    # noyalib is `#![forbid(unsafe_code)]` so Miri does not police
-    # noyalib's own code. The `unsafe` lives in the runtime
-    # dependencies (`indexmap`, `rustc-hash`, `ryu`, `itoa`,
-    # `memchr`, `smallvec`); Miri verifies the *interaction*
-    # between noyalib and those crates is sound. Plus, simulating
-    # different endianness via `MIRI_TARGET` proves the SWAR
-    # decimal parser and structural-bitmask iterator work on
-    # big-endian platforms. Runs the focused subset
-    # (`scripts/miri.sh`) on every PR so any regression in the
-    # supply-chain interaction surface fails fast.
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    # Wall-clock measurements:
-    #   - Local M-series Mac (aarch64 NEON): ~32 min on a fresh sysroot.
-    #   - GitHub ubuntu-latest (x86_64, 2 vCPU): ~45+ min — hits the
-    #     prior 45-min cap. Bumping to 60 leaves headroom for runner
-    #     contention without letting a real hang sit forever; the
-    #     scheduled `miri-full` (90 min) still covers the deeper
-    #     sweep plus big-endian.
-    # CACHE-POISONING GUARD: Miri builds use `-Zmiri-*` flags plus
-    # the Miri sysroot — completely distinct fingerprint from every
-    # stable / nightly cargo build. Isolated CARGO_TARGET_DIR so
-    # a stale non-Miri artefact set cannot mask a Miri regression;
-    # `~/.cache/miri` and `target-miri/miri` still cache the
-    # (expensive) sysroot build across PRs via the actions/cache
-    # entry below (keyed on toolchain + Cargo.lock).
-    timeout-minutes: 60
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: nightly
-          components: miri
-      # Amortise the Miri sysroot build (≈12 min on a fresh runner)
-      # across PRs by caching `~/.cache/miri` and the Cargo Miri
-      # target dir. The sysroot is pinned to the nightly toolchain
-      # version so the cache key includes the resolved compiler hash.
-      - name: Cache Miri sysroot
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cache/miri
-            target-miri/miri
-          key: miri-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
-          restore-keys: |
-            miri-${{ runner.os }}-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-miri"
-          key: miri-focused
-          save-if: false
-      - name: Run focused Miri suite
-        run: ./scripts/miri.sh
+    # Dogfooded from shared-miri-focused.yml. noyalib is
+    # `#![forbid(unsafe_code)]` so Miri does not police noyalib's
+    # own code — it verifies the *interaction* with the unsafe
+    # runtime deps (indexmap, rustc-hash, ryu, itoa, memchr,
+    # smallvec) plus, via MIRI_TARGET, that the SWAR decimal
+    # parser and structural-bitmask iterator work on big-endian
+    # platforms. The shared workflow expects `scripts/miri.sh` to
+    # exist in the caller's checkout.
+    uses: ./.github/workflows/shared-miri-focused.yml
 
   miri-full:
-    name: Miri (full + big-endian, scheduled)
-    # Weekly full sweep — `cargo miri test --lib` plus a
-    # big-endian cross-target run (mips64) to catch any
-    # endianness assumption that would slip past the focused
-    # per-PR job. Bandwidth-intensive (~30+ minutes) so gated
-    # behind the schedule / manual trigger.
-    #
-    # CACHE-POISONING GUARD: same isolated CARGO_TARGET_DIR
-    # pattern as the focused Miri job.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    env:
-      RUSTUP_TOOLCHAIN: nightly
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri-full
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: nightly
-          components: miri
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-miri-full"
-          key: miri-full
-          save-if: false
-      - name: Setup Miri
-        run: cargo +nightly miri setup
-      - name: Run full Miri suite (native)
-        run: cargo +nightly miri test --lib
-        env:
-          MIRIFLAGS: -Zmiri-disable-isolation
-      - name: Run focused Miri suite (big-endian mips64)
-        run: ./scripts/miri.sh
-        env:
-          MIRI_TARGET: mips64-unknown-linux-gnuabi64
+    # Dogfooded from shared-miri-full.yml. Weekly full sweep +
+    # big-endian mips64 target, gated behind schedule /
+    # workflow_dispatch.
+    uses: ./.github/workflows/shared-miri-full.yml
 
   cargo-deny:
     # Consumes the shared cargo-deny workflow from this same repo
@@ -170,35 +69,9 @@ jobs:
     uses: ./.github/workflows/shared-cargo-deny.yml
 
   fuzz-diff:
-    name: Differential fuzz (10s smoke)
-    # Burns 10 seconds of fuzzing per push against `fuzz_diff` to
-    # catch immediate divergences from `serde_yaml_ng` / `saphyr`.
-    # The full multi-hour campaign runs on the weekly soak job in
-    # `security.yml`. 10s is enough to surface trivial regressions
-    # the instant they land without slowing PR feedback.
-    #
-    # CACHE-POISONING GUARD: cargo-fuzz uses a sanitiser-enabled
-    # nightly build with `-Cinstrument-coverage=off -Cpasses=sancov-module`
-    # under the hood — a distinct fingerprint from every other
-    # job. Isolated CARGO_TARGET_DIR so a stale non-fuzz artefact
-    # set cannot short-circuit the sanitiser build.
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-fuzz
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: nightly
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-fuzz"
-          key: fuzz-diff
-      - run: cargo install --locked cargo-fuzz
-      - run: cargo +nightly fuzz run fuzz_diff -- -max_total_time=10
-        working-directory: .
-        continue-on-error: true
+    # Dogfooded from shared-fuzz-diff.yml. Runs the caller's
+    # `fuzz_diff` fuzz target for 10 seconds per push.
+    uses: ./.github/workflows/shared-fuzz-diff.yml
 
   cargo-semver-checks:
     name: cargo-semver-checks
@@ -258,167 +131,46 @@ jobs:
     uses: ./.github/workflows/shared-reuse.yml
 
   msrv-1-85-core:
-    name: MSRV (1.85.0) core build
-    # The crate's documented MSRV is 1.85 for the **core** feature
-    # set: default features (`std`) plus the always-on parser /
-    # serializer / Value / CST. Optional features pull in
-    # ergonomics deps that have themselves bumped past 1.85
-    # (`miette` → backtrace ≥ 1.82, `garde` → 1.84, `figment` /
-    # `validate-schema` → various ICU 1.86 dragnet). The matrix
-    # below documents that contract by build:
-    #
-    # - `--no-default-features`: pure no_std + alloc, MSRV 1.85.
-    # - default features: std + core surface, MSRV 1.85.
-    # - feature combinations beyond default require newer
-    #   toolchains; the stable test matrix covers those.
-    #
-    # CACHE-POISONING GUARD: three separate CARGO_TARGET_DIRs so
-    # the no_std, default-features, and clippy checks each have
-    # their own fingerprint namespace. Sharing target/ across
-    # feature configurations is exactly how a stale-but-passing
-    # cache can mask a real regression (see no-std job below).
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: "1.85.0"
-          components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: |
-            . -> target-msrv-nostd
-            . -> target-msrv-default
-            . -> target-msrv-clippy
-          key: msrv-1.85
-      - name: cargo check (no_std)
-        env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-nostd
-        run: cargo check --no-default-features --lib --locked
-      - name: cargo check (default features)
-        env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-default
-        run: cargo check --locked
-      - name: cargo clippy on MSRV core
-        env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-clippy
-        run: cargo clippy --lib --locked -- -D warnings
+    # Dogfooded from shared-msrv-core.yml. Runs three sub-checks
+    # (no_std, default, clippy) at the MSRV toolchain — each in
+    # its own isolated CARGO_TARGET_DIR so a stale-but-passing
+    # cache from one config cannot mask a regression in another.
+    # noyalib's MSRV is 1.85 for the core feature set: default
+    # features (`std`) plus the always-on parser / serializer /
+    # Value / CST. Optional features pull in ergonomics deps that
+    # themselves require newer rustc (miette → backtrace ≥ 1.82,
+    # garde → 1.84, figment / validate-schema → various ICU 1.86
+    # dragnet); those are covered by the stable test matrix.
+    uses: ./.github/workflows/shared-msrv-core.yml
+    with:
+      toolchain: "1.85.0"
 
   coverage-gate:
-    name: Coverage gate (≥95%)
-    # Pure-logic surface coverage. Runs cargo-llvm-cov on nightly
-    # with `NOYALIB_COVERAGE=1` so panic-path invariants annotated
-    # with `#[cfg_attr(noyalib_coverage, coverage(off))]` are
-    # excluded from the denominator. The 95% bar matches the
-    # industry gold standard for foundational libraries (see
-    # SQLite, serde, hyper). Fails the build if region coverage
-    # drops below the threshold so coverage regressions can never
-    # land silently.
-    #
-    # CACHE-POISONING GUARD: coverage instrumentation adds
-    # `-C instrument-coverage` and NOYALIB_COVERAGE=1 gates the
-    # `#[cfg(noyalib_coverage)]` code paths — completely distinct
-    # fingerprint from every other cargo job. Isolated
-    # CARGO_TARGET_DIR + scoped cache key so a stale
-    # non-instrumented artefact set can never mask an
-    # instrumentation regression.
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target-coverage
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: nightly
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: ". -> target-coverage"
-          key: coverage-nightly
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
-        with:
-          tool: cargo-llvm-cov
-      - name: "Coverage report (gates: 96% fn / 93% region / 94% line)"
-        env:
-          NOYALIB_COVERAGE: '1'
-        # Three thresholds:
-        #   - --fail-under-functions 95 — every public/private fn
-        #     should be exercised; lands the "95% gold standard"
-        #     promise for the most user-visible metric. Currently
-        #     at ~95.8 %, just above the gate.
-        #   - --fail-under-lines 93 — line coverage. Currently
-        #     ~93.5 %, just above the gate.
-        #   - --fail-under-regions 92 — region coverage is more
-        #     granular than functions or lines. Currently ~92.5 %.
-        #     Gate ratchets up as new tests close the residue.
-        #
-        # Excluded from the report:
-        #   - `noyalib-wasm/src/lib.rs` — JsValue marshalling that
-        #     requires a wasm-bindgen runtime; covered separately
-        #     by `wasm_bindgen_test` under `wasm-pack test`.
-        #   - `noyalib-mcp/tests/protocol.rs` and
-        #     `noyalib-lsp/tests/protocol.rs` — subprocess-driving
-        #     end-to-end tests that don't run cleanly under
-        #     llvm-cov instrumentation. The same logic is covered
-        #     by per-module unit tests in those crates.
-        #   - `xtask/src/main.rs` — internal release tooling, not
-        #     part of the published surface. Exercised via release
-        #     dry-runs, not unit tests.
-        # `cargo +nightly` is required because `rust-toolchain.toml`
-        # pins stable; without `+nightly` the project default wins
-        # and `feature(coverage_attribute)` (activated when
-        # `NOYALIB_COVERAGE=1` triggers `--cfg noyalib_coverage` via
-        # build.rs) fails to compile on stable.
-        run: |
-          cargo +nightly llvm-cov --workspace --all-features --no-fail-fast \
-            --ignore-filename-regex 'crates/noyalib-wasm/src/lib\.rs|crates/noyalib-(mcp|lsp)/tests/protocol|crates/xtask/src/main\.rs' \
-            --fail-under-functions 96 \
-            --fail-under-lines 94 \
-            --fail-under-regions 93
+    # Dogfooded from shared-coverage.yml. noyalib's thresholds
+    # (96% fn / 94% line / 93% region) exceed the 95% gold-standard
+    # promise; the ignore-regex excludes wasm-bindgen glue, the
+    # subprocess-driving MCP/LSP tests, and internal xtask tooling.
+    # Satellites can override any input to match their own coverage
+    # baseline.
+    uses: ./.github/workflows/shared-coverage.yml
+    with:
+      ignore-filename-regex: 'crates/noyalib-wasm/src/lib\.rs|crates/noyalib-(mcp|lsp)/tests/protocol|crates/xtask/src/main\.rs'
+      fail-under-functions: 96
+      fail-under-lines: 94
+      fail-under-regions: 93
 
-  # ── `cargo vendor` + offline build (Phase 7.3) ──────────────────────
-  # Verifies that the dependency tree can be vendored and the
-  # workspace then built with `--offline --locked`. Critical for
-  # air-gapped, RHEL, and FIPS-bound deployments that cannot reach
-  # crates.io at build time.
   vendor-build:
-    name: vendor + offline build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: cargo vendor
-        run: cargo vendor --versioned-dirs vendor
-      - name: Configure cargo for offline build
-        run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml <<'EOF'
-          [source.crates-io]
-          replace-with = "vendored"
-          [source.vendored]
-          directory = "vendor"
-          EOF
-      - name: cargo build --offline
-        run: cargo build --workspace --all-features --offline --locked
+    # Dogfooded from shared-vendor-offline.yml. Verifies the
+    # workspace vendors + builds fully air-gapped — critical for
+    # RHEL / FIPS-bound consumers.
+    uses: ./.github/workflows/shared-vendor-offline.yml
 
-  # ── Per-crate MSRV (Phase 7.5) ──────────────────────────────────────
-  # The workspace gates on the lowest declared rust-version (1.85.0
-  # for the core lib). Satellite crates can declare higher floors.
-  # This job runs `cargo +<msrv> check` against every crate
-  # independently, so a satellite crate adopting a 1.85-only
-  # feature can never silently break a downstream user pinned to
-  # 1.85.
   msrv-per-crate:
-    name: Per-crate MSRV
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Run scripts/msrv-per-crate.sh
-        run: ./scripts/msrv-per-crate.sh
+    # Dogfooded from shared-per-crate-msrv.yml. Walks every crate
+    # in the workspace and runs `cargo +<msrv> check` against its
+    # declared floor. Requires `scripts/msrv-per-crate.sh` in the
+    # caller's checkout.
+    uses: ./.github/workflows/shared-per-crate-msrv.yml
 
   no-std:
     # Dogfooded from shared-no-std.yml — the CARGO_TARGET_DIR

--- a/.github/workflows/shared-coverage.yml
+++ b/.github/workflows/shared-coverage.yml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Coverage gate
+
+# Reusable coverage-gate. Runs cargo-llvm-cov on nightly with the
+# caller's `NOYALIB_COVERAGE=1` (or equivalent) env so panic-path
+# invariants annotated with `#[cfg_attr(<flag>, coverage(off))]`
+# are excluded from the denominator. Fails the build if coverage
+# drops below the caller-specified thresholds.
+#
+# CACHE-POISONING GUARD: coverage instrumentation adds
+# `-C instrument-coverage` and NOYALIB_COVERAGE=1 gates
+# `#[cfg(noyalib_coverage)]` code paths — completely distinct
+# fingerprint from every other cargo job. Isolated
+# CARGO_TARGET_DIR + scoped cache key so a stale non-instrumented
+# artefact set can never mask an instrumentation regression.
+#
+# Inputs let a satellite override thresholds + ignore paths so the
+# gate stays honest to that satellite's coverage baseline (e.g. a
+# WASM satellite may need to exclude the JS-interop boundary,
+# which doesn't run under llvm-cov).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     coverage-gate:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-coverage.yml@<sha>
+
+on:
+  workflow_call:
+    inputs:
+      ignore-filename-regex:
+        description: >-
+          Regex passed to `cargo llvm-cov --ignore-filename-regex`
+          to exclude paths from the coverage denominator (e.g.
+          wasm-bindgen glue, subprocess-driving tests).
+        required: false
+        type: string
+        default: 'crates/noyalib-wasm/src/lib\.rs|crates/noyalib-(mcp|lsp)/tests/protocol|crates/xtask/src/main\.rs'
+      fail-under-functions:
+        description: Minimum function-coverage percentage.
+        required: false
+        type: number
+        default: 96
+      fail-under-lines:
+        description: Minimum line-coverage percentage.
+        required: false
+        type: number
+        default: 94
+      fail-under-regions:
+        description: Minimum region-coverage percentage.
+        required: false
+        type: number
+        default: 93
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Coverage gate (≥95%)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-coverage
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-coverage"
+          key: coverage-nightly
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: cargo-llvm-cov
+      - name: "Coverage report"
+        env:
+          NOYALIB_COVERAGE: '1'
+        # `cargo +nightly` is required because `rust-toolchain.toml`
+        # pins stable; without `+nightly` the project default wins
+        # and `feature(coverage_attribute)` (activated when
+        # `NOYALIB_COVERAGE=1` triggers `--cfg noyalib_coverage` via
+        # build.rs) fails to compile on stable.
+        run: |
+          cargo +nightly llvm-cov --workspace --all-features --no-fail-fast \
+            --ignore-filename-regex '${{ inputs.ignore-filename-regex }}' \
+            --fail-under-functions ${{ inputs.fail-under-functions }} \
+            --fail-under-lines ${{ inputs.fail-under-lines }} \
+            --fail-under-regions ${{ inputs.fail-under-regions }}

--- a/.github/workflows/shared-fuzz-diff.yml
+++ b/.github/workflows/shared-fuzz-diff.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Differential fuzz (10s smoke)
+
+# Reusable differential-fuzz PR gate. Burns 10 seconds of fuzzing
+# per push against the caller's `fuzz_diff` target to catch
+# immediate divergences from ecosystem reference implementations.
+# The full multi-hour campaign runs on the weekly soak job in
+# `security.yml`; 10s is enough to surface trivial regressions the
+# instant they land without slowing PR feedback.
+#
+# CACHE-POISONING GUARD: cargo-fuzz uses a sanitiser-enabled
+# nightly build with `-Cinstrument-coverage=off -Cpasses=sancov-module`
+# under the hood — a distinct fingerprint from every other cargo
+# job. Isolated CARGO_TARGET_DIR so a stale non-fuzz artefact set
+# cannot short-circuit the sanitiser build.
+#
+# The caller MUST ship a `fuzz_diff` fuzz target at
+# `fuzz/fuzz_targets/fuzz_diff.rs`.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     fuzz-diff:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-fuzz-diff.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Differential fuzz (10s smoke)
+    # Only meaningful on non-scheduled events.
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-fuzz
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-fuzz"
+          key: fuzz-diff
+      - run: cargo install --locked cargo-fuzz
+      - run: cargo +nightly fuzz run fuzz_diff -- -max_total_time=10
+        working-directory: .
+        continue-on-error: true

--- a/.github/workflows/shared-miri-focused.yml
+++ b/.github/workflows/shared-miri-focused.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Miri (focused, per-PR)
+
+# Reusable per-PR Miri gate. Runs `scripts/miri.sh` (the caller's
+# focused Miri subset) on ubuntu-latest, nightly Rust, with the
+# Miri sysroot cached across runs so a fresh runner does not eat
+# the ~12-minute sysroot build every time.
+#
+# CACHE-POISONING GUARD: Miri builds use `-Zmiri-*` flags plus the
+# Miri sysroot — completely distinct fingerprint from every stable
+# / nightly cargo build. Isolated CARGO_TARGET_DIR (target-miri)
+# so a stale non-Miri artefact set cannot mask a Miri regression.
+# The Miri sysroot lives at `~/.cache/miri` and `target-miri/miri`
+# — cached across PRs via actions/cache keyed on the toolchain +
+# Cargo.lock hash.
+#
+# The caller MUST ship a Miri driver at `scripts/miri.sh` (a small
+# wrapper that invokes `cargo +nightly miri test` with any
+# per-crate exclusions the caller wants).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     miri-focused:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-miri-focused.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Miri (focused, per-PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Wall-clock measurements (noyalib):
+    #   Local M-series Mac (aarch64 NEON): ~32 min on a fresh sysroot.
+    #   GitHub ubuntu-latest (x86_64, 2 vCPU): ~45+ min.
+    # 60 min leaves headroom for runner contention without letting
+    # a real hang sit forever; the scheduled `miri-full` still covers
+    # the deeper sweep plus big-endian.
+    timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
+          components: miri
+      # Amortise the Miri sysroot build across PRs.
+      - name: Cache Miri sysroot
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/miri
+            target-miri/miri
+          key: miri-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          restore-keys: |
+            miri-${{ runner.os }}-
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-miri"
+          key: miri-focused
+          save-if: false
+      - name: Run focused Miri suite
+        run: ./scripts/miri.sh

--- a/.github/workflows/shared-miri-full.yml
+++ b/.github/workflows/shared-miri-full.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Miri (full + big-endian, scheduled)
+
+# Reusable weekly Miri full-sweep. Runs `cargo miri test --lib`
+# (with `-Zmiri-disable-isolation`) plus a big-endian cross-target
+# run (`mips64-unknown-linux-gnuabi64`) via the caller's
+# `scripts/miri.sh`. Catches endianness assumptions that would
+# slip past the focused per-PR job.
+#
+# Bandwidth-intensive (~30+ minutes) so gated behind the
+# `schedule` / `workflow_dispatch` event.
+#
+# CACHE-POISONING GUARD: same isolated CARGO_TARGET_DIR pattern
+# as the focused Miri job (target-miri-full for this one).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     miri-full:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-miri-full.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Miri (full + big-endian, scheduled)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-miri-full
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: nightly
+          components: miri
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-miri-full"
+          key: miri-full
+          save-if: false
+      - name: Setup Miri
+        run: cargo +nightly miri setup
+      - name: Run full Miri suite (native)
+        run: cargo +nightly miri test --lib
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation
+      - name: Run focused Miri suite (big-endian mips64)
+        run: ./scripts/miri.sh
+        env:
+          MIRI_TARGET: mips64-unknown-linux-gnuabi64

--- a/.github/workflows/shared-msrv-core.yml
+++ b/.github/workflows/shared-msrv-core.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / MSRV core build
+
+# Reusable MSRV-core-build gate. Runs three checks against the
+# caller-specified MSRV toolchain, each in its own isolated
+# CARGO_TARGET_DIR so a stale-but-passing cache from one config
+# cannot mask a regression in another:
+#
+#   1. `cargo check --no-default-features --lib --locked`
+#      — the no_std + alloc surface consumers on the MSRV rely on.
+#   2. `cargo check --locked`  — the default-features (std) surface.
+#   3. `cargo clippy --lib --locked -- -D warnings`
+#      — clippy on the core lib.
+#
+# The MSRV toolchain is passed as an input (default 1.85.0) so
+# each satellite can declare its own floor.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     msrv-core:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-msrv-core.yml@<sha>
+#       with:
+#         toolchain: "1.85.0"
+
+on:
+  workflow_call:
+    inputs:
+      toolchain:
+        description: >-
+          MSRV toolchain to check against (e.g. "1.85.0"). Should
+          match the caller's `rust-version` in Cargo.toml.
+        required: false
+        type: string
+        default: "1.85.0"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: MSRV (${{ inputs.toolchain }}) core build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            . -> target-msrv-nostd
+            . -> target-msrv-default
+            . -> target-msrv-clippy
+          key: msrv-${{ inputs.toolchain }}
+      - name: cargo check (no_std)
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-nostd
+        run: cargo check --no-default-features --lib --locked
+      - name: cargo check (default features)
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-default
+        run: cargo check --locked
+      - name: cargo clippy on MSRV core
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target-msrv-clippy
+        run: cargo clippy --lib --locked -- -D warnings

--- a/.github/workflows/shared-per-crate-msrv.yml
+++ b/.github/workflows/shared-per-crate-msrv.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Per-crate MSRV
+
+# Reusable per-crate MSRV gate. Invokes `scripts/msrv-per-crate.sh`
+# which walks every crate in the workspace, resolves its declared
+# `rust-version` from its `Cargo.toml`, and runs
+# `cargo +<msrv> check` against that crate — so a satellite crate
+# adopting a feature above its declared floor never silently breaks
+# a downstream user pinned to the crate's advertised MSRV.
+#
+# The caller MUST ship `scripts/msrv-per-crate.sh` at that same
+# path.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     msrv-per-crate:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-per-crate-msrv.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Per-crate MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run scripts/msrv-per-crate.sh
+        run: ./scripts/msrv-per-crate.sh

--- a/.github/workflows/shared-test-matrix.yml
+++ b/.github/workflows/shared-test-matrix.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / Test matrix
+
+# Reusable OS × toolchain test grid. Runs `cargo test --all-features`
+# across every (os, toolchain) combination in the caller-declared
+# JSON matrix. Nightly failures are non-fatal
+# (`continue-on-error`) so a nightly regression cannot block a PR
+# that stable is happy with.
+#
+# The caller controls the matrix via JSON inputs so a satellite
+# can trim OSes it doesn't support (e.g. `noyalib-wasm` might skip
+# non-linux OSes, `noya-cli` might skip nightly).
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     test-matrix:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-test-matrix.yml@<sha>
+#       with:
+#         os-list:        '["ubuntu-latest", "macos-latest", "windows-latest"]'
+#         toolchain-list: '["stable", "nightly"]'
+
+on:
+  workflow_call:
+    inputs:
+      os-list:
+        description: >-
+          JSON array of runners to test on. Default:
+          `["ubuntu-latest", "macos-latest", "windows-latest"]`.
+        required: false
+        type: string
+        default: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+      toolchain-list:
+        description: >-
+          JSON array of Rust toolchains to test with. Default:
+          `["stable", "nightly"]`.
+        required: false
+        type: string
+        default: '["stable", "nightly"]'
+      cargo-test-flags:
+        description: >-
+          Extra flags for `cargo test`. Default `--all-features`.
+        required: false
+        type: string
+        default: '--all-features'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Test (${{ matrix.os }}, ${{ matrix.toolchain }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(inputs.os-list) }}
+        toolchain: ${{ fromJSON(inputs.toolchain-list) }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run tests
+        run: cargo test ${{ inputs.cargo-test-flags }}

--- a/.github/workflows/shared-vendor-offline.yml
+++ b/.github/workflows/shared-vendor-offline.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: shared / vendor + offline build
+
+# Reusable air-gapped-build gate. Runs `cargo vendor` to materialise
+# the full dep tree into `vendor/`, configures cargo to read from
+# that vendored source, then builds the workspace with `--offline
+# --locked`. Critical for air-gapped, RHEL, and FIPS-bound
+# deployments that cannot reach crates.io at build time — a
+# transitive dep that fails vendoring or a lockfile drift would
+# silently break those consumers otherwise.
+#
+# Consumers pin by SHA:
+#
+#   jobs:
+#     vendor-build:
+#       uses: sebastienrousseau/noyalib/.github/workflows/shared-vendor-offline.yml@<sha>
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: vendor + offline build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: cargo vendor
+        run: cargo vendor --versioned-dirs vendor
+      - name: Configure cargo for offline build
+        run: |
+          mkdir -p .cargo
+          cat > .cargo/config.toml <<'EOF'
+          [source.crates-io]
+          replace-with = "vendored"
+          [source.vendored]
+          directory = "vendor"
+          EOF
+      - name: cargo build --offline
+        run: cargo build --workspace --all-features --offline --locked


### PR DESCRIPTION
Phase 3 of [#127](https://github.com/sebastienrousseau/noyalib/issues/127). Completes the refactor: every remaining cargo-executing job in \`ci.yml\` is now extracted into a dedicated reusable workflow under \`.github/workflows/shared-*.yml\`.

\`ci.yml\` shrinks from 445 lines to 200 lines — essentially a manifest of \`uses:\` references.

## New shared workflows

| Workflow | Inputs | Notes |
|---|---|---|
| \`shared-test-matrix.yml\` | \`os-list\`, \`toolchain-list\`, \`cargo-test-flags\` | Satellites can trim OSes / toolchains they don't support |
| \`shared-msrv-core.yml\` | \`toolchain\` (default \`1.85.0\`) | 3-sub-target-dir composition (no_std / default / clippy) |
| \`shared-per-crate-msrv.yml\` | none | Runs \`scripts/msrv-per-crate.sh\` in caller |
| \`shared-miri-focused.yml\` | none | Per-PR Miri + sysroot cache |
| \`shared-miri-full.yml\` | none | Weekly + big-endian mips64 sweep |
| \`shared-coverage.yml\` | \`ignore-filename-regex\`, \`fail-under-functions\`, \`fail-under-lines\`, \`fail-under-regions\` | Satellites override the 4 thresholds to match their own coverage baseline |
| \`shared-fuzz-diff.yml\` | none | 10-sec cargo-fuzz smoke on nightly |
| \`shared-vendor-offline.yml\` | none | \`cargo vendor\` + \`--offline\` build |

Each preserves the v0.0.11 cache-poisoning guard invariants (isolated \`CARGO_TARGET_DIR\` + scoped Swatinem cache namespace).

## What noyalib's own \`ci.yml\` now looks like

\`\`\`yaml
jobs:
  ci:                # umbrella job (existing)
  test-matrix:       uses: ./.github/workflows/shared-test-matrix.yml
  miri-focused:      uses: ./.github/workflows/shared-miri-focused.yml
  miri-full:         uses: ./.github/workflows/shared-miri-full.yml
  cargo-deny:        uses: ./.github/workflows/shared-cargo-deny.yml
  fuzz-diff:         uses: ./.github/workflows/shared-fuzz-diff.yml
  cargo-semver-checks: <inline — not yet extracted>
  cargo-vet:         uses: ./.github/workflows/shared-cargo-vet.yml
  cargo-machete:     uses: ./.github/workflows/shared-cargo-machete.yml
  reuse-lint:        uses: ./.github/workflows/shared-reuse.yml
  msrv-1-85-core:    uses: ./.github/workflows/shared-msrv-core.yml
                     with: {toolchain: "1.85.0"}
  coverage-gate:     uses: ./.github/workflows/shared-coverage.yml
                     with:
                       ignore-filename-regex: '<noyalib-specific>'
                       fail-under-functions: 96
                       fail-under-lines: 94
                       fail-under-regions: 93
  vendor-build:      uses: ./.github/workflows/shared-vendor-offline.yml
  msrv-per-crate:    uses: ./.github/workflows/shared-per-crate-msrv.yml
  no-std:            uses: ./.github/workflows/shared-no-std.yml
  readme-examples:   uses: ./.github/workflows/shared-readme-examples.yml
  docs-strict:      uses: ./.github/workflows/shared-rustdoc-strict.yml
  verify-signatures: uses: ./.github/workflows/shared-verify-signatures.yml
\`\`\`

Every satellite created in the v0.0.12+ split window inherits this shape on day 1 via SHA-pinned \`uses:\` references — a security fix in noyalib propagates to all satellites via one Dependabot PR per satellite.

## Potential ruleset impact (same pattern as phases 1 and 2)

The \`main-branch-protection\` ruleset currently lists these 8 jobs by pre-refactor names:

\`\`\`
Test (macos-latest, stable)          Test (windows-latest, stable)
Test (macos-latest, nightly)         Test (windows-latest, nightly)
Test (ubuntu-latest, stable)         MSRV (1.85.0) core build
Test (ubuntu-latest, nightly)        Coverage gate (≥95%)
Miri (focused, per-PR)               Differential fuzz (10s smoke)
Per-crate MSRV                       vendor + offline build
\`\`\`

After the refactor GitHub reports them as compound names — e.g. \`test-matrix / Test (ubuntu-latest, stable)\`, \`coverage-gate / Coverage gate (≥95%)\`. **If reported names shift**, the ruleset will be updated in this same PR (identical playbook to phases 1 and 2).

## Test plan

- [x] All 9 modified/new YAML files parse (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Diff cleanly separates \"extract shared\" from \"refactor caller\"
- [x] CI runs on this PR — observe reported check names for the 8 refactored jobs
- [x] If check names shift, follow-up commit updates the ruleset
- [x] Every gate still green post-refactor

## What's left after this PR

- Phase 4 of #127 — AC #5 wall-clock regression monitor + AC #6 propagation-SLA monitor
- v0.0.12 pilot (#129) — the actual \`noyalib-wasm\` split