### PR TITLE
ci(workspace-split): CI-duration + propagation-SLA monitors (phase 4 of #127)

### DIFF
--- a/.github/workflows/ci-duration-monitor.yml
+++ b/.github/workflows/ci-duration-monitor.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: CI duration monitor
+
+# AC #5 of issue #127 — wall-clock CI regression monitor.
+#
+# Queries the last 6 successful CI runs on main via the GitHub
+# REST API, computes the rolling 5-run average duration, and
+# fails if the most-recent run exceeds 1.1× that baseline.
+#
+# The idea: a shared-workflow SHA bump that silently doubles CI
+# runtime should surface here rather than propagate to every
+# satellite unchallenged. When this workflow fails, the
+# maintainer investigates the bumps landed since the last green
+# baseline.
+#
+# Runs on:
+#   * every push to main — catches regressions the moment they
+#     merge, so the alert lands within minutes of the offending
+#     commit;
+#   * scheduled daily at 05:00 UTC — belt-and-braces safety net
+#     in case a push-triggered run got cancelled or missed;
+#   * on-demand via workflow_dispatch — for manual re-checks.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ci-duration-monitor
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    name: CI wall-clock regression check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run duration monitor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci-duration-monitor.sh

--- a/.github/workflows/shared-workflow-propagation.yml
+++ b/.github/workflows/shared-workflow-propagation.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+name: Shared-workflow propagation SLA monitor
+
+# AC #6 of issue #127 — cross-repo propagation SLA monitor.
+#
+# Under the strict-lockstep versioning contract from ADR-0005,
+# every satellite must consume noyalib's shared reusable
+# workflows via SHA-pinned `uses:` references. When noyalib bumps
+# a shared workflow (typically a security hardening pass),
+# Dependabot opens a SHA-bump PR in each satellite. If any of
+# those PRs sits open for more than 48 hours the corresponding
+# satellite is running stale CI — defeating the propagation
+# invariant.
+#
+# This workflow calls `scripts/shared-workflow-propagation-monitor.sh`
+# daily to enforce the 48h SLA across every satellite.
+#
+# Pre-split (before v0.0.12 pilot ships), no satellite repos
+# exist yet — the monitor SKIPs cleanly and reports zero
+# violations. After the pilot creates
+# `sebastienrousseau/noyalib-wasm`, the monitor starts checking
+# that repo automatically.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # Daily 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shared-workflow-propagation
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    name: Cross-repo Dependabot SLA check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run propagation monitor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/shared-workflow-propagation-monitor.sh

--- a/scripts/ci-duration-monitor.sh
+++ b/scripts/ci-duration-monitor.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Wall-clock CI regression monitor. Closes #127 AC #5:
+#
+#   "record baseline CI duration; script fails if a new run
+#    exceeds 1.1× rolling 5-run average"
+#
+# Reads the last N + 1 successful CI runs of `.github/workflows/
+# ci.yml` on main via the GitHub REST API, computes the rolling
+# N-run average of runs 2..N+1, and compares the latest run
+# (run 1) against that baseline. Exits non-zero if the latest
+# run exceeds `${THRESHOLD_RATIO}` × baseline.
+#
+# The threshold + window size are inputs (not hardcoded) so the
+# calling workflow can loosen or tighten the gate without editing
+# the script.
+#
+# Runs against $GH_REPO_OWNER/$GH_REPO_NAME (default: derived from
+# git remote); works without any auth for public repos, but
+# GH_TOKEN is preferred to avoid rate-limiting.
+#
+# WHY THIS EXISTS
+#
+# After #127 lands, a supply-chain hardening pass in noyalib
+# propagates to every satellite via Dependabot PRs that bump the
+# `uses: sebastienrousseau/noyalib/.github/workflows/shared-<x>.yml@<sha>`
+# reference. Without a wall-clock signal, a shared-workflow bump
+# could silently double CI runtime across every satellite. This
+# monitor catches that class of regression by ratchet — if the
+# latest CI run is 10 %+ slower than the 5-run baseline, the
+# scheduled workflow that calls this script fails and files an
+# issue.
+#
+# Exit codes:
+#   0  latest run within threshold (or insufficient history yet)
+#   1  latest run exceeds threshold — CI slowdown regression
+#   2  API unreachable / transient error
+
+set -euo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────
+BRANCH="${BRANCH:-main}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-ci.yml}"
+N_BASELINE="${N_BASELINE:-5}"
+THRESHOLD_RATIO="${THRESHOLD_RATIO:-1.1}"
+REPO="${GITHUB_REPOSITORY:-$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
+
+echo "── CI duration monitor ──"
+echo "  repo:        ${REPO}"
+echo "  branch:      ${BRANCH}"
+echo "  workflow:    ${WORKFLOW_FILE}"
+echo "  baseline N:  ${N_BASELINE}"
+echo "  threshold:   ${THRESHOLD_RATIO}×"
+echo
+
+# ── Fetch recent successful CI runs ────────────────────────────────
+NEED=$((N_BASELINE + 1))
+RUNS=$(gh api "/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=${BRANCH}&status=success&per_page=${NEED}" \
+    --paginate=false 2>&1 || echo "__err__")
+
+if [[ "${RUNS}" == "__err__" ]] || ! printf '%s' "${RUNS}" | jq -e '.workflow_runs' > /dev/null 2>&1; then
+    echo "  [NET] failed to fetch runs from GitHub API" >&2
+    exit 2
+fi
+
+RUN_COUNT=$(printf '%s' "${RUNS}" | jq '.workflow_runs | length')
+
+if [[ "${RUN_COUNT}" -lt "${NEED}" ]]; then
+    echo "  [SKIP] only ${RUN_COUNT} successful runs on ${BRANCH} — need ${NEED}. Insufficient history."
+    exit 0
+fi
+
+# ── Compute durations (seconds) ────────────────────────────────────
+# `run_started_at` may be null on very old records; fall back to
+# `created_at`. `updated_at` is when the run reached its terminal
+# state.
+DURATIONS=$(printf '%s' "${RUNS}" | jq -r '.workflow_runs[] |
+    ((.updated_at | fromdateiso8601) - ((.run_started_at // .created_at) | fromdateiso8601))')
+
+LATEST=$(printf '%s' "${DURATIONS}" | head -1)
+BASELINE_LIST=$(printf '%s' "${DURATIONS}" | tail -n +2 | head -"${N_BASELINE}")
+
+# ── Rolling average (integer arithmetic via awk to avoid python) ──
+BASELINE_AVG=$(printf '%s\n' "${BASELINE_LIST}" | awk 'BEGIN {sum=0; n=0} {sum+=$1; n+=1} END {printf "%.1f", sum/n}')
+
+# Threshold in seconds.
+LATEST_INT=${LATEST%.*}
+THRESHOLD_SEC=$(awk -v b="${BASELINE_AVG}" -v t="${THRESHOLD_RATIO}" 'BEGIN {printf "%.1f", b * t}')
+
+RATIO=$(awk -v l="${LATEST_INT}" -v b="${BASELINE_AVG}" 'BEGIN {printf "%.2f", l / b}')
+
+echo "  latest run:  ${LATEST_INT}s"
+echo "  baseline (${N_BASELINE}-run avg): ${BASELINE_AVG}s"
+echo "  threshold:   ${THRESHOLD_SEC}s (${THRESHOLD_RATIO}× baseline)"
+echo "  observed:    ${RATIO}× baseline"
+echo
+
+REGRESSION=$(awk -v l="${LATEST_INT}" -v t="${THRESHOLD_SEC}" 'BEGIN {print (l > t) ? 1 : 0}')
+
+if [[ "${REGRESSION}" == "1" ]]; then
+    cat >&2 <<EOF
+  [FAIL] wall-clock regression: latest run ${LATEST_INT}s > threshold ${THRESHOLD_SEC}s
+         (observed ${RATIO}×; gate is ${THRESHOLD_RATIO}×)
+
+  Investigate the shared-workflow bumps landed since the last
+  green baseline. See #127 AC #5 for the invariant.
+EOF
+    exit 1
+fi
+
+echo "  [ OK ] latest run within threshold."

--- a/scripts/shared-workflow-propagation-monitor.sh
+++ b/scripts/shared-workflow-propagation-monitor.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Cross-repo shared-workflow propagation SLA monitor. Closes
+# #127 AC #6:
+#
+#   "scheduled workflow alerts if a Dependabot PR sits open in
+#    any satellite for more than 48h without merge"
+#
+# For every satellite in ${SATELLITES}, this script:
+#
+#   1. Checks whether the satellite repo has been created yet
+#      (pre-pilot repos will 404 — that is expected and reported
+#      as SKIP, not FAIL).
+#   2. If the repo exists, lists open PRs from `dependabot[bot]`
+#      whose head branch or title matches the shared-workflow
+#      pattern (`shared-*.yml` or `.github/workflows/shared-*.yml`).
+#   3. For each matching PR, computes age in hours.
+#   4. Fails if any PR exceeds ${SLA_HOURS}.
+#
+# WHY THIS EXISTS
+#
+# Under the strict-lockstep versioning contract from ADR-0005,
+# every satellite must consume noyalib's shared reusable workflows
+# via SHA-pinned `uses:` references. When noyalib bumps a shared
+# workflow (typically a security hardening pass), Dependabot opens
+# a SHA-bump PR in each satellite. If any of those PRs sits open
+# too long, the corresponding satellite is running stale CI —
+# defeating the propagation invariant.
+#
+# The scheduled workflow calling this script (48h SLA by default)
+# fails loudly and files an issue in the offending satellite.
+#
+# Exit codes:
+#   0  every satellite is either not-yet-created OR has no stale
+#      shared-workflow Dependabot PRs
+#   1  at least one satellite has an SLA breach — investigate
+#   2  API unreachable / transient error
+
+set -euo pipefail
+
+# ── Config ─────────────────────────────────────────────────────────
+OWNER="${OWNER:-sebastienrousseau}"
+SATELLITES="${SATELLITES:-noyalib-wasm noyalib-mcp noyalib-lsp noya-cli}"
+SLA_HOURS="${SLA_HOURS:-48}"
+
+# Match `.github/workflows/shared-*.yml` references. The head
+# branch Dependabot creates for a Github Actions bump looks like
+# `dependabot/github_actions/.../shared-...` — matching on both
+# title and head branch keeps false-negatives away.
+SHARED_WF_PATTERN="shared-.*\\.yml"
+
+echo "── Shared-workflow propagation SLA monitor ──"
+echo "  owner:        ${OWNER}"
+echo "  satellites:   ${SATELLITES}"
+echo "  SLA:          ${SLA_HOURS}h"
+echo
+
+STALE_COUNT=0
+CHECKED=0
+SKIPPED=0
+
+for SAT in ${SATELLITES}; do
+    # Does the satellite repo exist yet?
+    if ! gh api "/repos/${OWNER}/${SAT}" > /dev/null 2>&1; then
+        printf '  [SKIP] %s/%s — repo does not yet exist (pre-pilot)\n' "${OWNER}" "${SAT}"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    CHECKED=$((CHECKED + 1))
+
+    # Open PRs authored by dependabot[bot].
+    PRS_JSON=$(gh api "/repos/${OWNER}/${SAT}/pulls?state=open&per_page=100" 2>&1 || echo "__err__")
+    if [[ "${PRS_JSON}" == "__err__" ]] || ! printf '%s' "${PRS_JSON}" | jq -e '.' > /dev/null 2>&1; then
+        printf '  [NET ] %s/%s — API unreachable\n' "${OWNER}" "${SAT}" >&2
+        continue
+    fi
+
+    STALE_PRS=$(printf '%s' "${PRS_JSON}" | jq --arg sla "${SLA_HOURS}" --arg pat "${SHARED_WF_PATTERN}" '
+        [.[] |
+         select(.user.login == "dependabot[bot]") |
+         select((.title | test($pat)) or (.head.ref | test($pat))) |
+         select(((now - (.created_at | fromdateiso8601)) / 3600) > ($sla | tonumber))
+        ]')
+
+    STALE_LEN=$(printf '%s' "${STALE_PRS}" | jq 'length')
+
+    if [[ "${STALE_LEN}" -gt 0 ]]; then
+        printf '  [FAIL] %s/%s — %d stale shared-workflow Dependabot PR(s):\n' "${OWNER}" "${SAT}" "${STALE_LEN}" >&2
+        printf '%s' "${STALE_PRS}" | jq -r '.[] |
+            "         #\(.number): \(.title) (age: \((now - (.created_at | fromdateiso8601)) / 3600 | floor)h) — \(.html_url)"' >&2
+        STALE_COUNT=$((STALE_COUNT + STALE_LEN))
+    else
+        printf '  [ OK ] %s/%s — no stale shared-workflow Dependabot PRs\n' "${OWNER}" "${SAT}"
+    fi
+done
+
+echo
+if [[ "${CHECKED}" -eq 0 ]]; then
+    echo "── SKIP: no satellite repos exist yet (pre-pilot). Monitor stays in place for post-pilot activation. ──"
+    exit 0
+fi
+
+if [[ "${STALE_COUNT}" -gt 0 ]]; then
+    printf '── FAIL: %d stale shared-workflow Dependabot PR(s) across %d satellite(s) exceed the %dh SLA ──\n' \
+        "${STALE_COUNT}" "${CHECKED}" "${SLA_HOURS}" >&2
+    exit 1
+fi
+
+printf '── OK: %d satellite(s) checked, %d not-yet-created, zero stale PRs ──\n' "${CHECKED}" "${SKIPPED}"


### PR DESCRIPTION
Phase 4 of [#127](https://github.com/sebastienrousseau/noyalib/issues/127). Adds the two meta-CI monitors declared as [#127](https://github.com/sebastienrousseau/noyalib/issues/127)'s AC #5 and AC #6, and **closes the whole issue** — the workspace-split pre-work track is complete.

## AC #5 — wall-clock CI regression monitor

\`scripts/ci-duration-monitor.sh\` — plain \`gh api\` + \`jq\` + \`awk\` script. Queries the last 6 successful \`.github/workflows/ci.yml\` runs on \`main\`, computes the rolling 5-run baseline duration, fails if the most-recent run > 1.1× baseline. Exit 0 = within threshold or insufficient history; 1 = regression; 2 = API unreachable.

Wired via \`.github/workflows/ci-duration-monitor.yml\`:
- **on every push to main** — catches the regression the instant it lands
- **daily 05:00 UTC** — belt-and-braces
- **workflow_dispatch** — manual re-check

**Live-tested against noyalib's own history**:
\`\`\`
── CI duration monitor ──
  repo:        sebastienrousseau/noyalib
  branch:      main
  workflow:    ci.yml
  baseline N:  5
  threshold:   1.1×

  latest run:  439s
  baseline (5-run avg): 464.0s
  threshold:   510.4s (1.1× baseline)
  observed:    0.95× baseline

  [ OK ] latest run within threshold.
\`\`\`

Threshold + window are env-var inputs so a future PR can tighten the gate as the baseline improves.

## AC #6 — cross-repo propagation SLA monitor

\`scripts/shared-workflow-propagation-monitor.sh\` — iterates every satellite (\`noyalib-wasm\`, \`noyalib-mcp\`, \`noyalib-lsp\`, \`noya-cli\`), lists open Dependabot PRs matching \`shared-*\.yml\`, fails if any exceeds a 48h SLA. Pre-split (satellite repo not created yet), SKIPs cleanly.

Wired via \`.github/workflows/shared-workflow-propagation.yml\`:
- **daily 06:00 UTC**
- **workflow_dispatch**

**Live-tested**:
\`\`\`
── Shared-workflow propagation SLA monitor ──
  owner:        sebastienrousseau
  satellites:   noyalib-wasm noyalib-mcp noyalib-lsp noya-cli
  SLA:          48h

  [SKIP] sebastienrousseau/noyalib-wasm — repo does not yet exist (pre-pilot)
  [SKIP] sebastienrousseau/noyalib-mcp — repo does not yet exist (pre-pilot)
  [SKIP] sebastienrousseau/noyalib-lsp — repo does not yet exist (pre-pilot)
  [SKIP] sebastienrousseau/noya-cli — repo does not yet exist (pre-pilot)

── SKIP: no satellite repos exist yet (pre-pilot). Monitor stays in place for post-pilot activation. ──
\`\`\`

After #129 creates \`sebastienrousseau/noyalib-wasm\`, the monitor starts checking that repo automatically without any script edit.

The SLA hours + satellite list are env-var inputs.

## What #127 delivers overall

| Phase | Merged | Content |
|---|---|---|
| 1 | \`e695d4a\` | 4 supply-chain shared workflows |
| 2 | \`f984e3b\` | 4 CARGO_TARGET_DIR-isolated shared workflows |
| 3 | \`69e3bf3\` | 8 matrix/toolchain shared workflows |
| **4 (this PR)** | pending | 2 meta-CI monitors — closes #127 |

**Total: 16 shared reusable workflows + 2 meta-CI monitors.** \`ci.yml\` is now 200 lines (down from 445 pre-refactor). Every satellite in the v0.0.12+ split window can consume all 16 workflows by SHA on day 1, and the 48h propagation SLA enforces that hardening passes reach every satellite within 2 days.

## Test plan

- [x] Both YAML workflow files parse
- [x] Both bash scripts pass \`bash -n\` (syntax check)
- [x] \`ci-duration-monitor.sh\` live-tested against noyalib main (returns 0.95× baseline — well within 1.1× gate)
- [x] \`shared-workflow-propagation-monitor.sh\` live-tested (4 SKIPs, exit 0 — expected pre-pilot behaviour)
- [ ] CI runs on this PR — every gate still green post-refactor

## After this PR merges

The v0.0.12 pilot (#129 = \`noyalib-wasm\` split) is unblocked from a workflow-infrastructure standpoint. Only the rollback dry-run (declared in ADR-0005) remains before the pilot PR opens.

Closes [#127](https://github.com/sebastienrousseau/noyalib/issues/127).