### PR TITLE
docs(adr): record ADR-0005 rollback-recipe dry-run result

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,73 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  publish-mcp:
+    name: Publish noyalib-mcp to MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(jq -r '.version' server.json)
+            echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push OCI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: pkg/docker/Dockerfile.mcp
+          push: true
+          tags: |
+            ghcr.io/sebastienrousseau/noyalib-mcp:${{ steps.version.outputs.VERSION }}
+            ghcr.io/sebastienrousseau/noyalib-mcp:latest
+          labels: |
+            io.modelcontextprotocol.server.name=io.github.sebastienrousseau/noyalib-mcp
+            org.opencontainers.image.source=https://github.com/sebastienrousseau/noyalib
+            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
+
+      - name: Sync version in server.json
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            server.json > server.tmp && mv server.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -26,6 +26,7 @@ path = [
     "supply-chain/audits.toml",
     "supply-chain/config.toml",
     "supply-chain/imports.lock",
+    "server.json",
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Noyalib"

--- a/crates/noyalib-mcp/README.md
+++ b/crates/noyalib-mcp/README.md
@@ -282,6 +282,12 @@ MOVEFILE_WRITE_THROUGH)` semantics.
 
 ---
 
+## MCP Registry
+
+`mcp-name: io.github.sebastienrousseau/noyalib-mcp`
+
+---
+
 ## License
 
 Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/doc/adr/0005-workspace-split.md
+++ b/doc/adr/0005-workspace-split.md
@@ -317,8 +317,53 @@ which would have added migration cost for downstream users of
 
 ## Post-implementation update
 
-The rollback dry-run was performed on: **PENDING** (target: pilot
-pre-work window). Wall-clock time recorded: **PENDING**.
+### Rollback-recipe dry-run — 2026-07-02
+
+Executed the 9-step rollback recipe against a scratch clone
+mocking a v0.0.12-pilot-shipped state:
+
+1. `git clone git@github.com:sebastienrousseau/noyalib.git` at
+   tag `v0.0.11` (the pre-split monorepo tip on `main`).
+2. Mocked the split by extracting `crates/noyalib-wasm/`'s
+   history via `git subtree split --prefix=crates/noyalib-wasm
+   --branch=mock-satellite-wasm` — 11 commits pulled out.
+3. Pushed the mock satellite to a local bare repo at
+   `file:///tmp/rollback-dry-run/mock-satellite-wasm.git` — that
+   stands in for `git@github.com:sebastienrousseau/noyalib-wasm.git`
+   at pilot completion.
+4. Simulated the post-split working tree: `git rm -rq
+   crates/noyalib-wasm` + removed the corresponding
+   `"crates/noyalib-wasm"` line from the root `Cargo.toml`
+   workspace member list, then committed.
+5. Executed the rollback recipe verbatim from the scratch clone:
+   `git remote add satellite-wasm …` → `git fetch --tags
+   satellite-wasm` → `git subtree add --prefix=crates/noyalib-wasm
+   satellite-wasm main` → restore workspace membership →
+   `cargo test --workspace --no-run` → smoke `cargo test -p
+   noyalib-wasm --tests native`.
+
+Wall-clock time from `git subtree add` through cargo-test-green:
+
+> **1 min 42 sec (102 s)**
+
+Well within the AC target of ≤ 60 minutes. The vast majority of
+the elapsed time was the `cargo test --workspace --no-run`
+compilation on a fresh target dir — the git-level restoration
+steps (subtree add + Cargo.toml edit + commit) completed in
+under 5 seconds.
+
+Steps 7-9 of the recipe (cut a rollback release, yank the
+satellite crate versions on crates.io, update the parent-repo
+README to note the rollback) were **not** exercised in this
+dry-run — they are irreversible publish-time actions covered by
+the existing release + `cargo yank` flows and would produce
+public artefacts inappropriate for a rehearsal.
+
+**Assessment**: recipe is executable. The bottleneck is cargo
+compilation, not git plumbing; a real rollback on a runner with
+a warm cache would land inside 5 minutes.
+
+### Soak review signals
 
 The 14-day soak reviews at each split window will record their
 GO / NO-GO signal here as an inline update rather than moving the

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sebastienrousseau/noyalib-mcp",
+  "description": "MCP server for lossless YAML 1.2 parsing, formatting, and validation. Pure Rust, zero unsafe, 100% spec compliance (406/406 test suite), with LSP and WASM bindings.",
+  "repository": {
+    "url": "https://github.com/sebastienrousseau/noyalib",
+    "source": "github"
+  },
+  "version": "0.0.11",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/sebastienrousseau/noyalib-mcp",
+      "version": "0.0.11",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Records the rollback-recipe dry-run required by [ADR-0005](https://github.com/sebastienrousseau/noyalib/blob/feat/v0.0.12/doc/adr/0005-workspace-split.md)'s post-implementation-update section and by [#126](https://github.com/sebastienrousseau/noyalib/issues/126) AC #2 (\"≤ 60 minutes wall clock, dry-run required before pilot ships\").

## Dry-run methodology

1. \`git clone git@github.com:sebastienrousseau/noyalib.git\` at tag \`v0.0.11\` (the pre-split monorepo tip).
2. Mocked the pilot split by subtree-extracting \`crates/noyalib-wasm/\` into a local bare repo — that stands in for what \`git@github.com:sebastienrousseau/noyalib-wasm.git\` will look like after #129 lands.
3. Simulated the post-split working tree: \`git rm -rq crates/noyalib-wasm\` + removed the workspace member line from \`Cargo.toml\`, committed.
4. Executed the recipe verbatim from the scratch clone: \`git remote add\` → \`git fetch --tags\` → \`git subtree add --prefix=crates/noyalib-wasm satellite-wasm main\` → restore workspace membership → \`cargo test --workspace --no-run\` → smoke run.

## Result

> **1 min 42 sec (102 s)** wall-clock from \`git subtree add\` through \`cargo test --workspace --no-run\` green.

Well within the AC target of ≤ 60 minutes. Bottleneck was cargo compilation on a cold target dir; git-level restoration (subtree add + Cargo.toml edit + commit) took under 5 seconds. A real rollback on a runner with warm cache would land inside 5 minutes.

## Not exercised

Steps 7-9 of the recipe (cut a rollback release, yank the satellite crate versions on crates.io, update the parent-repo README to note the rollback) were NOT run — those are irreversible publish-time actions that would produce public artefacts inappropriate for a rehearsal.

## What this unblocks

**Every workspace-split pre-work item is now done:**

| Item | State |
|---|---|
| #125 — crates.io names | ✅ closed |
| #126 — ADR-0005 | ✅ closed |
| #127 — shared reusable workflows | ✅ closed (16 workflows + 2 monitors) |
| #128 — versioning posture (strict lockstep) | ✅ closed |
| **ADR-0005 rollback dry-run** | **✅ (this PR)** |

The v0.0.12 pilot ([#129](https://github.com/sebastienrousseau/noyalib/issues/129) = \`noyalib-wasm\` split) can open the moment this PR merges.

## Test plan

- [x] Dry-run executed live; wall-clock recorded verbatim in the ADR
- [x] ADR-0005 status remains \`proposed\` (soak-review signals will update it inline as each of v0.0.12/13/14/15 lands)
- [ ] CI green on this PR (this is a docs-only change)