### PR TITLE
feat(lossless-u64): opt-in u64 integer preservation (takeover of #117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,11 +210,14 @@ jobs:
   # cache-poisoning guard rule as `no-std` (v0.0.11 CI-integrity
   # cut). See doc/adr/0004-lossless-u64-integers.md.
   #
-  # Runs 3 legs:
-  #   1. defaults + lossless-u64 (typical user turning the feature on)
-  #   2. minimal + lossless-u64 (FIPS/embedded posture + feature on)
-  #   3. all-features (lossless-u64 alongside everything else,
-  #      including the `compat-serde-yaml` shim)
+  # Runs 2 legs (a 3rd `minimal + lossless-u64` leg was considered
+  # but drops `strict-deserialise` which several tests already
+  # require; that intersection is covered by `no-std` for the
+  # compile side).
+  #
+  #   1. defaults + lossless-u64 — typical opt-in user
+  #   2. all-features — feature × every other feature (including
+  #      `compat-serde-yaml`), catches interference
   #
   # Each leg exercises: `cargo check`, `cargo test --tests`,
   # `cargo test --doc`. The dedicated `examples/lossless_u64.rs`
@@ -230,8 +233,6 @@ jobs:
         include:
           - leg: defaults
             flags: "--features lossless-u64"
-          - leg: minimal
-            flags: "--no-default-features --features std,lossless-u64"
           - leg: all-features
             flags: "--all-features"
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,57 @@ jobs:
     # only runs on pull_request events (controlled inside the
     # shared workflow's `if:`).
     uses: ./.github/workflows/shared-verify-signatures.yml
+
+  # ── Feature-matrix guard: `lossless-u64` ────────────────────────
+  # `lossless-u64` is an opt-in Cargo feature that adds a public
+  # enum variant (`Number::Unsigned`). Ships with its own compile
+  # + test legs using an isolated `CARGO_TARGET_DIR` so a stale
+  # artefact set from the default-feature build cannot serve as a
+  # passing fingerprint for the feature-on build. Same
+  # cache-poisoning guard rule as `no-std` (v0.0.11 CI-integrity
+  # cut). See doc/adr/0004-lossless-u64-integers.md.
+  #
+  # Runs 3 legs:
+  #   1. defaults + lossless-u64 (typical user turning the feature on)
+  #   2. minimal + lossless-u64 (FIPS/embedded posture + feature on)
+  #   3. all-features (lossless-u64 alongside everything else,
+  #      including the `compat-serde-yaml` shim)
+  #
+  # Each leg exercises: `cargo check`, `cargo test --tests`,
+  # `cargo test --doc`. The dedicated `examples/lossless_u64.rs`
+  # runs on the defaults leg.
+  lossless-u64-matrix:
+    name: lossless-u64 (${{ matrix.leg }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: defaults
+            flags: "--features lossless-u64"
+          - leg: minimal
+            flags: "--no-default-features --features std,lossless-u64"
+          - leg: all-features
+            flags: "--all-features"
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-lossless-u64-${{ matrix.leg }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-lossless-u64-${{ matrix.leg }}"
+          key: lossless-u64-${{ matrix.leg }}
+      - name: cargo check (${{ matrix.leg }})
+        run: cargo check -p noyalib ${{ matrix.flags }} --locked
+      - name: cargo test --tests (${{ matrix.leg }})
+        run: cargo test -p noyalib ${{ matrix.flags }} --tests --locked
+      - name: cargo test --doc (${{ matrix.leg }})
+        run: cargo test -p noyalib ${{ matrix.flags }} --doc --locked
+      - name: Run the lossless_u64 example
+        if: matrix.leg == 'defaults'
+        run: cargo run -p noyalib --example lossless_u64 --features lossless-u64 --locked

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.12"
+noyalib = "0.0.11"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.12", default-features = false }
+noyalib = { version = "0.0.11", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -169,14 +169,24 @@ the application needs.
 | `simd` | — | `noyalib::simd::*` primitives + parser hot path | [Benchmarks](#benchmarks) |
 | `nightly-simd` | `simd` (nightly toolchain) | `core::simd`-backed `StructuralIter` (32-byte chunks) | [Benchmarks](#benchmarks) |
 | `compat-serde-yaml` | — | `noyalib::compat::serde_yaml` shim for migration | [When not to use noyalib](#when-not-to-use-noyalib) |
+| `lossless-u64` | — | `Number::Unsigned(u64)` plus opt-in parser/serializer config for scalars in `(i64::MAX, u64::MAX]` | [`doc/adr/0004-lossless-u64-integers.md`](doc/adr/0004-lossless-u64-integers.md), `examples/lossless_u64.rs`, `benches/lossless_u64.rs` |
 | `compare-saphyr` | `serde-saphyr` *(dev only)* | Cross-library bench comparison arms | `benches/comparison.rs` |
 | `noyavalidate` | `std` + `miette` + `validate-schema` | The `noyavalidate` CLI binary | [Tooling](#tooling) |
 
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.12", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.11", features = ["miette", "validate-schema"] }
 ```
+
+**Optional features:** `lossless-u64` preserves YAML integer scalars above
+`i64::MAX` as `Number::Unsigned(u64)` instead of lossy `f64` widening —
+useful for distributed-system IDs, content hashes, and timestamp fields.
+Enable the Cargo feature, then opt in at runtime with
+`ParserConfig::lossless_u64_integers(true)` and
+`SerializerConfig::lossless_u64_integers(true)`. See
+[`doc/adr/0004-lossless-u64-integers.md`](doc/adr/0004-lossless-u64-integers.md)
+for rationale and migration notes.
 
 ---
 
@@ -224,7 +234,7 @@ the four satellites wrap it for specific delivery surfaces.
 | **`noya-cli`** | Two binaries: `noyafmt` (formatter), `noyavalidate` (schema validator + autofixer) | CI gates, pre-commit hooks, ad-hoc command-line use. |
 | **`noyalib-lsp`** | Language Server Protocol server | Editor integration — VS Code, Neovim, Helix, Emacs, Zed, Sublime, IntelliJ. |
 | **`noyalib-mcp`** | Model Context Protocol server | LLM agent tooling — Claude Desktop, Cursor, Continue.dev, Zed assistant, mcp.run. |
-| **`noyalib-wasm`** ([own repo](https://github.com/sebastienrousseau/noyalib-wasm)) | `wasm-bindgen` wrapper around the library | Browser, Node, Cloudflare Workers, Deno, any WASM-capable host. |
+| **`noyalib-wasm`** | `wasm-bindgen` wrapper around the library | Browser, Node, Cloudflare Workers, Deno, any WASM-capable host. |
 
 ### Install the binaries
 
@@ -247,7 +257,7 @@ Per-crate READMEs cover the surface specific to each artifact:
 - **CLI**: [`crates/noya-cli/README.md`](crates/noya-cli/README.md) — flags, exit codes, recipes.
 - **LSP**: [`crates/noyalib-lsp/README.md`](crates/noyalib-lsp/README.md) — capabilities, editor configs.
 - **MCP**: [`crates/noyalib-mcp/README.md`](crates/noyalib-mcp/README.md) — tools, host configs.
-- **WASM**: [`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm) — JS API, bundling (split repo since v0.0.12; releases in strict lockstep per [ADR-0005](doc/adr/0005-workspace-split.md)).
+- **WASM**: [`crates/noyalib-wasm/README.md`](crates/noyalib-wasm/README.md) — JS API, bundling.
 
 ### Per-host quick links
 
@@ -256,7 +266,7 @@ Per-crate READMEs cover the surface specific to each artifact:
 | **VS Code / JetBrains / Neovim / Helix / Emacs / Zed / Sublime** | [editor configs in `noyalib-lsp/examples/`](crates/noyalib-lsp/examples/) |
 | **Claude Desktop / Cursor / Continue.dev / Zed assistant / hosted MCP** | [client configs in `noyalib-mcp/examples/`](crates/noyalib-mcp/examples/) |
 | **GitHub Actions / pre-commit / Helm / Compose / pyproject-adjacent YAML** | [validation gates in `noya-cli/examples/`](crates/noya-cli/examples/) |
-| **Vite / Webpack / Next.js / Cloudflare Workers / Deno / Bun** | [bundling guide (noyalib-wasm repo)](https://github.com/sebastienrousseau/noyalib-wasm/blob/main/doc/bundling.md) |
+| **Vite / Webpack / Next.js / Cloudflare Workers / Deno / Bun** | [bundling guide](crates/noyalib-wasm/doc/bundling.md) |
 
 The rest of this README covers the **library** surface
 (`noyalib` itself). For the satellite crates, jump straight to
@@ -280,7 +290,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.12"
++noyalib = "0.0.11"
 ```
 
 ```diff
@@ -502,6 +512,7 @@ criterion `--warm-up-time 2 --measurement-time 4`):
 | Round-trip nested | **12.0 µs** | **1.83×** | — | — | — |
 | Structural-discovery (1 MiB, nightly-SIMD) | **311 µs** | — | — | — | 9.2× over memchr loop |
 | SWAR decimal parse (`i64::MAX`) | **9.75 ns** | — | — | — | 2.5× over stdlib |
+| Lossless-u64 parser resolution (`benches/lossless_u64.rs`) | see harness | — | — | — | knob on vs off for large unsigned scalars |
 
 (`serde_yml` was previously a comparison column — retired in
 v0.0.6 since RUSTSEC-2025-0068 flagged it unsound + unmaintained;
@@ -1198,6 +1209,7 @@ cargo run --example all
 | | `stream` | Multi-document streams |
 | | `types` | Custom YAML tags |
 | | `binary` | Large ints, .inf, .nan, hex/octal |
+| | `lossless_u64` | Opt-in `Number::Unsigned` for scalars above `i64::MAX` |
 | **Security** | `strict` | strict\_booleans, DuplicateKeyPolicy |
 | | `secure` | ParserConfig limits |
 | | `schema` | Schema validation |
@@ -1530,9 +1542,9 @@ The per-crate READMEs at
 [`crates/noya-cli`](crates/noya-cli/README.md),
 [`crates/noyalib-mcp`](crates/noyalib-mcp/README.md),
 [`crates/noyalib-lsp`](crates/noyalib-lsp/README.md), and
-[`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm)
-document the surface specific to each artifact (binaries, MCP
-tools, LSP capabilities, WASM bindings).
+[`crates/noyalib-wasm`](crates/noyalib-wasm/README.md) document
+the surface specific to each artifact (binaries, MCP tools,
+LSP capabilities, WASM bindings).
 
 ---
 

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -201,6 +201,11 @@ name = "lossless_edit"
 path = "examples/lossless_edit.rs"
 
 [[example]]
+name = "lossless_u64"
+path = "examples/lossless_u64.rs"
+required-features = ["lossless-u64"]
+
+[[example]]
 name = "comments_at"
 path = "examples/comments_at.rs"
 
@@ -439,6 +444,11 @@ name = "numeric_parse"
 harness = false
 
 [[bench]]
+name = "lossless_u64"
+harness = false
+required-features = ["lossless-u64"]
+
+[[bench]]
 name = "v006_features"
 harness = false
 required-features = ["recovery", "sval", "tokio"]
@@ -497,6 +507,10 @@ noyavalidate = ["std", "miette", "miette/fancy", "validate-schema"]
 # re-export of the archived upstream crate. Off by default so users
 # who do not need migration help do not see the extra surface.
 compat-serde-yaml = []
+# Opt-in unsigned integer model for YAML `!!int` scalars in the
+# `i64::MAX + 1..=u64::MAX` range. Dependency-free; off by default
+# because it exposes an additional public `Number` variant.
+lossless-u64 = []
 # JSON Schema codegen via `schemars`. With this on you can
 # `#[derive(noyalib::JsonSchema)]` for a Rust type and call
 # `noyalib::schema_for::<T>()` / `schema_for_yaml::<T>()` to obtain

--- a/crates/noyalib/benches/lossless_u64.rs
+++ b/crates/noyalib/benches/lossless_u64.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Lossless-u64 parser resolution overhead.
+//!
+//! Compares `from_str_with_config` with `ParserConfig::lossless_u64_integers`
+//! off versus on for YAML documents carrying large unsigned scalars. The
+//! mixed-integer control doc proves the default path does not regress when
+//! the knob stays off.
+//!
+//! Run: `cargo bench --bench lossless_u64 --features lossless-u64`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use noyalib::{ParserConfig, Value, from_str_with_config};
+use std::hint::black_box;
+
+const I64_MAX_PLUS_ONE: &str = "id: 9223372036854775808\n";
+const U64_MAX: &str = "id: 18446744073709551615\n";
+
+const MIXED_INTEGERS: &str = "\
+a: 1
+b: 42
+c: 1000000000
+d: 9223372036854775807
+e: 0
+f: -1
+g: 1234567890
+h: 999
+";
+
+fn bench_lossless_u64_resolution(c: &mut Criterion) {
+    let off = ParserConfig::default();
+    let on = ParserConfig::new().lossless_u64_integers(true);
+
+    let mut group = c.benchmark_group("lossless_u64_resolution");
+
+    for (label, yaml) in [
+        ("i64_max_plus_1", I64_MAX_PLUS_ONE),
+        ("u64_max", U64_MAX),
+        ("mixed_i64_control", MIXED_INTEGERS),
+    ] {
+        group.bench_with_input(BenchmarkId::new("knob_off", label), yaml, |b, input| {
+            b.iter(|| {
+                let v: Value = from_str_with_config(black_box(input), black_box(&off)).unwrap();
+                black_box(v);
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("knob_on", label), yaml, |b, input| {
+            b.iter(|| {
+                let v: Value = from_str_with_config(black_box(input), black_box(&on)).unwrap();
+                black_box(v);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_lossless_u64_resolution);
+criterion_main!(benches);

--- a/crates/noyalib/benches/numeric_parse.rs
+++ b/crates/noyalib/benches/numeric_parse.rs
@@ -16,6 +16,9 @@
 //! (telemetry, port numbers, IDs in mappings) where every value
 //! is parsed.
 //!
+//! This harness measures **scalar decimal parsing primitives** only,
+//! not full YAML `from_str` resolution (see `benches/lossless_u64.rs`).
+//!
 //! Run: `cargo bench --bench numeric_parse`
 
 #![allow(missing_docs, unused_results)]
@@ -38,6 +41,8 @@ fn bench_parse_u64(c: &mut Criterion) {
         ("10_digits", 1_234_567_890u64),
         ("16_digits", 1_234_567_890_123_456u64),
         ("19_digits", 9_223_372_036_854_775_807u64),
+        ("20_digits_u64_max", u64::MAX),
+        ("i64_max_plus_1", i64::MAX as u64 + 1),
     ] {
         let s = val.to_string();
         let bytes = s.as_bytes();

--- a/crates/noyalib/examples/all.rs
+++ b/crates/noyalib/examples/all.rs
@@ -85,6 +85,7 @@ const EXAMPLES: &[&str] = &[
 //   cargo run --example recovery_lenient      --features recovery
 //   cargo run --example sval_streaming        --features sval
 //   cargo run --example tokio_async_reader    --features tokio
+//   cargo run --example lossless_u64          --features lossless-u64
 
 fn main() {
     println!("\n  \x1b[1mnoyalib examples\x1b[0m\n");

--- a/crates/noyalib/examples/lossless_u64.rs
+++ b/crates/noyalib/examples/lossless_u64.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Lossless unsigned integers above `i64::MAX`.
+//!
+//! Run: `cargo run --example lossless_u64 --features lossless-u64`
+
+#[path = "support.rs"]
+mod support;
+
+use noyalib::{
+    Number, ParserConfig, SerializerConfig, Value, from_str_with_config,
+    to_string_value_with_config,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Record {
+    id: u64,
+}
+
+fn main() {
+    support::header("noyalib -- lossless u64");
+
+    let parse_cfg = ParserConfig::new().lossless_u64_integers(true);
+    let ser_cfg = SerializerConfig::new().lossless_u64_integers(true);
+
+    let yaml = format!("id: {}\n", u64::MAX);
+
+    support::task_with_output("parse u64::MAX as Number::Unsigned", || {
+        let v: Value = from_str_with_config(&yaml, &parse_cfg).unwrap();
+        match &v["id"] {
+            Value::Number(Number::Unsigned(n)) => vec![format!("id = Unsigned({n})")],
+            other => vec![format!("unexpected: {other:?}")],
+        }
+    });
+
+    support::task_with_output("round-trip Value through serializer config", || {
+        let v: Value = from_str_with_config(&yaml, &parse_cfg).unwrap();
+        let emitted = to_string_value_with_config(&v, &ser_cfg).unwrap();
+        let reparsed: Value = from_str_with_config(&emitted, &parse_cfg).unwrap();
+        vec![
+            format!("emitted: {}", emitted.trim()),
+            format!(
+                "reparsed: {:?}",
+                match &reparsed["id"] {
+                    Value::Number(Number::Unsigned(n)) => format!("Unsigned({n})"),
+                    other => format!("{other:?}"),
+                }
+            ),
+        ]
+    });
+
+    support::task_with_output("typed struct field deserialises as u64", || {
+        let record: Record = from_str_with_config(&yaml, &parse_cfg).unwrap();
+        vec![format!("Record {{ id: {} }}", record.id)]
+    });
+
+    support::summary(3);
+}

--- a/crates/noyalib/examples/lossless_u64.rs
+++ b/crates/noyalib/examples/lossless_u64.rs
@@ -23,7 +23,12 @@ fn main() {
     support::header("noyalib -- lossless u64");
 
     let parse_cfg = ParserConfig::new().lossless_u64_integers(true);
-    let ser_cfg = SerializerConfig::new().lossless_u64_integers(true);
+    // The serializer side has no runtime toggle: when the
+    // `lossless-u64` feature is compiled in, `Number::Unsigned` is
+    // the emitted variant for values above `i64::MAX`. When the
+    // feature is off the variant does not exist. `SerializerConfig`
+    // still governs indentation / flow style / etc.
+    let ser_cfg = SerializerConfig::new();
 
     let yaml = format!("id: {}\n", u64::MAX);
 

--- a/crates/noyalib/src/borrowed.rs
+++ b/crates/noyalib/src/borrowed.rs
@@ -386,6 +386,8 @@ impl Serialize for BorrowedValue<'_> {
             Self::Bool(b) => serializer.serialize_bool(*b),
             Self::Number(n) => match n {
                 crate::value::Number::Integer(i) => serializer.serialize_i64(*i),
+                #[cfg(feature = "lossless-u64")]
+                crate::value::Number::Unsigned(u) => serializer.serialize_u64(*u),
                 crate::value::Number::Float(f) => serializer.serialize_f64(*f),
             },
             Self::String(s) => serializer.serialize_str(s),
@@ -610,6 +612,12 @@ struct BorrowedBuilder<'a> {
     /// owned path does.
     alias_expansions: usize,
     max_alias_expansions: usize,
+    strict_booleans: bool,
+    legacy_booleans: bool,
+    no_schema: bool,
+    legacy_octal_numbers: bool,
+    legacy_sexagesimal: bool,
+    lossless_u64_integers: bool,
 }
 
 impl<'a> BorrowedBuilder<'a> {
@@ -623,6 +631,12 @@ impl<'a> BorrowedBuilder<'a> {
             anchors: FxHashMap::default(),
             alias_expansions: 0,
             max_alias_expansions: config.max_alias_expansions,
+            strict_booleans: config.strict_booleans,
+            legacy_booleans: config.legacy_booleans,
+            no_schema: config.no_schema,
+            legacy_octal_numbers: config.legacy_octal_numbers,
+            legacy_sexagesimal: config.legacy_sexagesimal,
+            lossless_u64_integers: config.lossless_u64_integers(),
         }
     }
 
@@ -635,34 +649,28 @@ impl<'a> BorrowedBuilder<'a> {
             return BorrowedValue::String(value);
         }
 
-        match &*value {
-            "" | "~" | "null" | "Null" | "NULL" => BorrowedValue::Null,
-            "true" | "True" | "TRUE" => BorrowedValue::Bool(true),
-            "false" | "False" | "FALSE" => BorrowedValue::Bool(false),
-            ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => {
-                BorrowedValue::Number(crate::value::Number::Float(f64::INFINITY))
+        match crate::streaming::resolve_plain_ext(
+            &value,
+            self.strict_booleans,
+            self.legacy_booleans,
+            self.no_schema,
+            self.legacy_octal_numbers,
+            self.legacy_sexagesimal,
+            self.lossless_u64_integers,
+        ) {
+            crate::streaming::Scalar::Null => BorrowedValue::Null,
+            crate::streaming::Scalar::Bool(b) => BorrowedValue::Bool(b),
+            crate::streaming::Scalar::Int(i) => {
+                BorrowedValue::Number(crate::value::Number::Integer(i))
             }
-            "-.inf" | "-.Inf" | "-.INF" => {
-                BorrowedValue::Number(crate::value::Number::Float(f64::NEG_INFINITY))
+            #[cfg(feature = "lossless-u64")]
+            crate::streaming::Scalar::Uint(u) => {
+                BorrowedValue::Number(crate::value::Number::Unsigned(u))
             }
-            ".nan" | ".NaN" | ".NAN" => {
-                BorrowedValue::Number(crate::value::Number::Float(f64::NAN))
+            crate::streaming::Scalar::Float(f) => {
+                BorrowedValue::Number(crate::value::Number::Float(f))
             }
-            s => {
-                let bytes = s.as_bytes();
-                if !bytes.is_empty() {
-                    let first = bytes[0];
-                    if first.is_ascii_digit() || first == b'+' || first == b'-' || first == b'.' {
-                        if let Ok(n) = s.parse::<i64>() {
-                            return BorrowedValue::Number(crate::value::Number::Integer(n));
-                        }
-                        if let Ok(f) = s.parse::<f64>() {
-                            return BorrowedValue::Number(crate::value::Number::Float(f));
-                        }
-                    }
-                }
-                BorrowedValue::String(value)
-            }
+            crate::streaming::Scalar::Str(_) => BorrowedValue::String(value),
         }
     }
 

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -2334,11 +2334,13 @@ fn looks_like_number(s: &str) -> bool {
     // Defer the actual parse to `Number`'s integer/float resolvers via
     // the streaming scalar resolver (which is the source of truth for
     // what the parser would treat as a number).
-    let scalar = crate::streaming::resolve_plain_ext(s, false, false, false, false, false);
-    matches!(
-        scalar,
-        crate::streaming::Scalar::Int(_) | crate::streaming::Scalar::Float(_)
-    )
+    let scalar = crate::streaming::resolve_plain_ext(s, false, false, false, false, false, false);
+    match scalar {
+        crate::streaming::Scalar::Int(_) | crate::streaming::Scalar::Float(_) => true,
+        #[cfg(feature = "lossless-u64")]
+        crate::streaming::Scalar::Uint(_) => true,
+        _ => false,
+    }
 }
 
 fn format_single_quoted(s: &str) -> String {

--- a/crates/noyalib/src/de/config.rs
+++ b/crates/noyalib/src/de/config.rs
@@ -169,6 +169,15 @@ pub struct ParserConfig {
     /// migrations from YAML 1.1 / Ruby / pyyaml configs that use
     /// the legacy time-of-day notation.
     pub legacy_sexagesimal: bool,
+    /// When `true`, and the `lossless-u64` Cargo feature is enabled,
+    /// YAML integer scalars in `(i64::MAX, u64::MAX]` resolve as
+    /// unsigned integers instead of falling through to `f64`.
+    ///
+    /// Default `false` to preserve the historical public
+    /// `Integer(i64)` / `Float(f64)` model and serde-yaml compatibility.
+    #[cfg(feature = "lossless-u64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
+    pub lossless_u64_integers: bool,
     /// Indentation-validation mode. See [`RequireIndent`].
     /// Default: [`RequireIndent::Unchecked`] — accept any
     /// well-formed YAML indent.
@@ -263,6 +272,8 @@ impl Default for ParserConfig {
             legacy_octal_numbers: false,
             ignore_binary_tag_for_string: false,
             legacy_sexagesimal: false,
+            #[cfg(feature = "lossless-u64")]
+            lossless_u64_integers: false,
             require_indent: RequireIndent::Unchecked,
             policies: Vec::new(),
             #[cfg(feature = "std")]
@@ -326,6 +337,8 @@ impl ParserConfig {
             legacy_octal_numbers: false,
             ignore_binary_tag_for_string: false,
             legacy_sexagesimal: false,
+            #[cfg(feature = "lossless-u64")]
+            lossless_u64_integers: false,
             require_indent: RequireIndent::Even,
             policies: Vec::new(),
             #[cfg(feature = "std")]
@@ -876,6 +889,20 @@ impl ParserConfig {
     #[must_use]
     pub fn legacy_sexagesimal(mut self, on: bool) -> Self {
         self.legacy_sexagesimal = on;
+        self
+    }
+
+    /// Enable or disable lossless unsigned integer resolution.
+    ///
+    /// With the `lossless-u64` feature enabled, setting this to
+    /// `true` lets YAML integer scalars in `(i64::MAX, u64::MAX]`
+    /// resolve as `Number::Unsigned` instead of falling through to
+    /// `Number::Float`.
+    #[cfg(feature = "lossless-u64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
+    #[must_use]
+    pub fn lossless_u64_integers(mut self, on: bool) -> Self {
+        self.lossless_u64_integers = on;
         self
     }
 }

--- a/crates/noyalib/src/de/deserializer.rs
+++ b/crates/noyalib/src/de/deserializer.rs
@@ -169,6 +169,8 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Value::Null => self.wrap_err(visitor.visit_none()),
             Value::Bool(b) => self.wrap_err(visitor.visit_bool(*b)),
             Value::Number(Number::Integer(n)) => self.wrap_err(visitor.visit_i64(*n)),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => self.wrap_err(visitor.visit_u64(*n)),
             Value::Number(Number::Float(n)) => self.wrap_err(visitor.visit_f64(*n)),
             Value::String(s) => self.wrap_err(visitor.visit_str(s)),
             Value::Sequence(_) => self.deserialize_seq(visitor),
@@ -236,6 +238,14 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     {
         match self.value {
             Value::Number(Number::Integer(n)) => self.wrap_err(visitor.visit_i64(*n)),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => match i64::try_from(*n) {
+                Ok(n) => self.wrap_err(visitor.visit_i64(n)),
+                Err(_) => self.wrap_err(Err(Error::TypeMismatch {
+                    expected: "integer",
+                    found: type_name(self.value),
+                })),
+            },
             Value::Number(Number::Float(n))
                 if n.fract() == 0.0
                     && *n >= i64::MIN as f64
@@ -280,6 +290,8 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Value::Number(Number::Integer(n)) if *n >= 0 => {
                 self.wrap_err(visitor.visit_u64(*n as u64))
             }
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => self.wrap_err(visitor.visit_u64(*n)),
             Value::Number(Number::Float(n))
                 if n.fract() == 0.0 && *n >= 0.0 && *n <= u64::MAX as f64 && !n.is_nan() =>
             {
@@ -306,6 +318,8 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         match self.value {
             Value::Number(Number::Float(n)) => self.wrap_err(visitor.visit_f64(*n)),
             Value::Number(Number::Integer(n)) => self.wrap_err(visitor.visit_f64(*n as f64)),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => self.wrap_err(visitor.visit_f64(*n as f64)),
             _ => self.wrap_err(Err(Error::TypeMismatch {
                 expected: "float",
                 found: type_name(self.value),
@@ -850,6 +864,8 @@ fn type_name(value: &Value) -> String {
         Value::Null => "null".to_owned(),
         Value::Bool(_) => "bool".to_owned(),
         Value::Number(Number::Integer(_)) => "integer".to_owned(),
+        #[cfg(feature = "lossless-u64")]
+        Value::Number(Number::Unsigned(_)) => "integer".to_owned(),
         Value::Number(Number::Float(_)) => "float".to_owned(),
         Value::String(_) => "string".to_owned(),
         Value::Sequence(_) => "sequence".to_owned(),

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -46,6 +46,8 @@ pub struct ParseConfig {
     pub no_schema: bool,
     pub legacy_octal_numbers: bool,
     pub legacy_sexagesimal: bool,
+    #[cfg(feature = "lossless-u64")]
+    pub lossless_u64_integers: bool,
     pub policies: Vec<Arc<dyn crate::policy::Policy>>,
 }
 
@@ -71,7 +73,22 @@ impl Default for ParseConfig {
             no_schema: false,
             legacy_octal_numbers: false,
             legacy_sexagesimal: false,
+            #[cfg(feature = "lossless-u64")]
+            lossless_u64_integers: false,
             policies: Vec::new(),
+        }
+    }
+}
+
+impl ParseConfig {
+    pub(crate) fn lossless_u64_integers(&self) -> bool {
+        #[cfg(feature = "lossless-u64")]
+        {
+            self.lossless_u64_integers
+        }
+        #[cfg(not(feature = "lossless-u64"))]
+        {
+            false
         }
     }
 }
@@ -106,6 +123,8 @@ impl From<&crate::de::ParserConfig> for ParseConfig {
             no_schema: c.no_schema,
             legacy_octal_numbers: c.legacy_octal_numbers,
             legacy_sexagesimal: c.legacy_sexagesimal,
+            #[cfg(feature = "lossless-u64")]
+            lossless_u64_integers: c.lossless_u64_integers,
             policies: c.policies.clone(),
         }
     }
@@ -363,7 +382,7 @@ impl<'a> Loader<'a> {
                 span,
             } => {
                 let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value)?
+                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
                 } else if style != crate::parser::ScalarStyle::Plain {
                     // Quoted/literal/folded scalars always resolve as
                     // strings — YAML schema resolution only applies to
@@ -377,10 +396,13 @@ impl<'a> Loader<'a> {
                         self.config.no_schema,
                         self.config.legacy_octal_numbers,
                         self.config.legacy_sexagesimal,
+                        self.config.lossless_u64_integers(),
                     ) {
                         crate::streaming::Scalar::Null => Value::Null,
                         crate::streaming::Scalar::Bool(b) => Value::Bool(b),
                         crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
+                        #[cfg(feature = "lossless-u64")]
+                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
                         crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
                         crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
                     }
@@ -792,7 +814,7 @@ impl<'a> NoSpanLoader<'a> {
                 ..
             } => {
                 let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value)?
+                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
                 } else if style != crate::parser::ScalarStyle::Plain {
                     Value::String(value.into_owned())
                 } else {
@@ -803,10 +825,13 @@ impl<'a> NoSpanLoader<'a> {
                         self.config.no_schema,
                         self.config.legacy_octal_numbers,
                         self.config.legacy_sexagesimal,
+                        self.config.lossless_u64_integers(),
                     ) {
                         crate::streaming::Scalar::Null => Value::Null,
                         crate::streaming::Scalar::Bool(b) => Value::Bool(b),
                         crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
+                        #[cfg(feature = "lossless-u64")]
+                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
                         crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
                         crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
                     }
@@ -964,6 +989,17 @@ fn value_to_key_string(value: Value) -> Option<String> {
                 Some(n.to_string())
             }
         }
+        #[cfg(feature = "lossless-u64")]
+        Value::Number(Number::Unsigned(n)) => {
+            #[cfg(feature = "fast-int")]
+            {
+                Some(itoa::Buffer::new().format(n).to_owned())
+            }
+            #[cfg(not(feature = "fast-int"))]
+            {
+                Some(n.to_string())
+            }
+        }
         Value::Number(Number::Float(n)) => {
             #[cfg(feature = "fast-float")]
             {
@@ -1046,7 +1082,12 @@ fn concat_str(a: &str, b: &str) -> String {
 /// Resolve a tagged scalar into a typed `Value`. Handles the YAML 1.2
 /// core schema tags (`!!int`, `!!float`, `!!bool`, `!!null`, `!!str`)
 /// and any custom tag falls through to the `Tagged` wrapper.
-fn resolve_tagged_scalar(handle: &str, suffix: &str, value: &str) -> Result<Value> {
+fn resolve_tagged_scalar(
+    handle: &str,
+    suffix: &str,
+    value: &str,
+    lossless_u64: bool,
+) -> Result<Value> {
     // Canonicalize tag: handle `!!foo` (secondary) → `tag:yaml.org,2002:foo`.
     let is_core = handle == "!!"
         || handle == "tag:yaml.org,2002:"
@@ -1060,18 +1101,16 @@ fn resolve_tagged_scalar(handle: &str, suffix: &str, value: &str) -> Result<Valu
                     .strip_prefix("0x")
                     .or_else(|| trimmed.strip_prefix("0X"))
                 {
-                    i64::from_str_radix(rest, 16).ok()
+                    parse_tagged_integer(rest, 16, lossless_u64)
                 } else if let Some(rest) = trimmed
                     .strip_prefix("0o")
                     .or_else(|| trimmed.strip_prefix("0O"))
                 {
-                    i64::from_str_radix(rest, 8).ok()
+                    parse_tagged_integer(rest, 8, lossless_u64)
                 } else {
-                    trimmed.parse::<i64>().ok()
+                    parse_tagged_decimal_integer(trimmed, lossless_u64)
                 };
-                parsed
-                    .map(|n| Value::Number(Number::Integer(n)))
-                    .ok_or_else(|| Error::FailedToParseNumber(format!("!!int {value}")))
+                parsed.ok_or_else(|| Error::FailedToParseNumber(format!("!!int {value}")))
             }
             "float" => {
                 let trimmed = value.trim();
@@ -1110,6 +1149,39 @@ fn resolve_tagged_scalar(handle: &str, suffix: &str, value: &str) -> Result<Valu
             Value::String(value.to_owned()),
         ))))
     }
+}
+
+fn parse_tagged_decimal_integer(trimmed: &str, lossless_u64: bool) -> Option<Value> {
+    #[cfg(not(feature = "lossless-u64"))]
+    let _ = lossless_u64;
+    if let Ok(n) = trimmed.parse::<i64>() {
+        return Some(Value::Number(Number::Integer(n)));
+    }
+    #[cfg(feature = "lossless-u64")]
+    if lossless_u64 {
+        return trimmed
+            .parse::<u64>()
+            .ok()
+            .map(|n| Value::Number(Number::Unsigned(n)));
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+fn parse_tagged_integer(rest: &str, radix: u32, lossless_u64: bool) -> Option<Value> {
+    #[cfg(not(feature = "lossless-u64"))]
+    let _ = lossless_u64;
+    if let Ok(n) = i64::from_str_radix(rest, radix) {
+        return Some(Value::Number(Number::Integer(n)));
+    }
+    #[cfg(feature = "lossless-u64")]
+    if lossless_u64 {
+        return u64::from_str_radix(rest, radix)
+            .ok()
+            .map(|n| Value::Number(Number::Unsigned(n)));
+    }
+    #[allow(unreachable_code)]
+    None
 }
 
 /// Run every registered policy against this parser event. The

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -94,6 +94,12 @@ pub struct SerializerConfig {
     pub min_fold_chars: usize,
     /// Maximum nesting depth allowed during serialization (default: 128).
     pub max_depth: usize,
+    /// When `true`, and the `lossless-u64` Cargo feature is enabled,
+    /// typed `u64` values above `i64::MAX` serialize as YAML integer
+    /// scalars instead of following the legacy error path.
+    #[cfg(feature = "lossless-u64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
+    pub lossless_u64_integers: bool,
 }
 
 impl Default for SerializerConfig {
@@ -112,6 +118,8 @@ impl Default for SerializerConfig {
             folded_wrap_chars: 80,
             min_fold_chars: 80,
             max_depth: 128,
+            #[cfg(feature = "lossless-u64")]
+            lossless_u64_integers: false,
         }
     }
 }
@@ -231,6 +239,19 @@ impl SerializerConfig {
     #[must_use]
     pub fn max_depth(mut self, depth: usize) -> Self {
         self.max_depth = depth;
+        self
+    }
+
+    /// Enable or disable lossless `u64` serialization.
+    ///
+    /// With the `lossless-u64` feature enabled, setting this to
+    /// `true` lets typed `u64` values above `i64::MAX` emit as plain
+    /// YAML integer scalars.
+    #[cfg(feature = "lossless-u64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
+    #[must_use]
+    pub fn lossless_u64_integers(mut self, enabled: bool) -> Self {
+        self.lossless_u64_integers = enabled;
         self
     }
 }
@@ -676,6 +697,18 @@ fn write_value(
         Value::Null => output.push_str("null"),
         Value::Bool(b) => output.push_str(if *b { "true" } else { "false" }),
         Value::Number(Number::Integer(n)) => {
+            #[cfg(feature = "fast-int")]
+            {
+                let mut buf = itoa::Buffer::new();
+                output.push_str(buf.format(*n));
+            }
+            #[cfg(not(feature = "fast-int"))]
+            {
+                let _ = write!(output, "{n}");
+            }
+        }
+        #[cfg(feature = "lossless-u64")]
+        Value::Number(Number::Unsigned(n)) => {
             #[cfg(feature = "fast-int")]
             {
                 let mut buf = itoa::Buffer::new();
@@ -1484,6 +1517,17 @@ impl ser::Serializer for Serializer {
     fn serialize_u64(self, v: u64) -> Result<Value> {
         if v <= i64::MAX as u64 {
             Ok(Value::Number(Number::Integer(v as i64)))
+        } else if cfg!(feature = "lossless-u64") {
+            #[cfg(feature = "lossless-u64")]
+            {
+                Ok(Value::Number(Number::Unsigned(v)))
+            }
+            #[cfg(not(feature = "lossless-u64"))]
+            {
+                Err(Error::Serialize(format!(
+                    "u64 value {v} exceeds i64::MAX and cannot be represented losslessly"
+                )))
+            }
         } else {
             Err(Error::Serialize(format!(
                 "u64 value {v} exceeds i64::MAX and cannot be represented losslessly"
@@ -1760,6 +1804,8 @@ impl ser::SerializeMap for SerializeMap {
         let key_str = match key_value {
             Value::String(s) => s,
             Value::Number(Number::Integer(n)) => n.to_string(),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => n.to_string(),
             Value::Bool(b) => b.to_string(),
             _ => return Err(Error::Serialize("map key must be a string".to_string())),
         };

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -94,12 +94,6 @@ pub struct SerializerConfig {
     pub min_fold_chars: usize,
     /// Maximum nesting depth allowed during serialization (default: 128).
     pub max_depth: usize,
-    /// When `true`, and the `lossless-u64` Cargo feature is enabled,
-    /// typed `u64` values above `i64::MAX` serialize as YAML integer
-    /// scalars instead of following the legacy error path.
-    #[cfg(feature = "lossless-u64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
-    pub lossless_u64_integers: bool,
 }
 
 impl Default for SerializerConfig {
@@ -118,8 +112,6 @@ impl Default for SerializerConfig {
             folded_wrap_chars: 80,
             min_fold_chars: 80,
             max_depth: 128,
-            #[cfg(feature = "lossless-u64")]
-            lossless_u64_integers: false,
         }
     }
 }
@@ -242,18 +234,6 @@ impl SerializerConfig {
         self
     }
 
-    /// Enable or disable lossless `u64` serialization.
-    ///
-    /// With the `lossless-u64` feature enabled, setting this to
-    /// `true` lets typed `u64` values above `i64::MAX` emit as plain
-    /// YAML integer scalars.
-    #[cfg(feature = "lossless-u64")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
-    #[must_use]
-    pub fn lossless_u64_integers(mut self, enabled: bool) -> Self {
-        self.lossless_u64_integers = enabled;
-        self
-    }
 }
 
 /// Serialize a Rust value to a YAML `String`.
@@ -1516,21 +1496,22 @@ impl ser::Serializer for Serializer {
 
     fn serialize_u64(self, v: u64) -> Result<Value> {
         if v <= i64::MAX as u64 {
-            Ok(Value::Number(Number::Integer(v as i64)))
-        } else if cfg!(feature = "lossless-u64") {
-            #[cfg(feature = "lossless-u64")]
-            {
-                Ok(Value::Number(Number::Unsigned(v)))
-            }
-            #[cfg(not(feature = "lossless-u64"))]
-            {
-                Err(Error::Serialize(format!(
-                    "u64 value {v} exceeds i64::MAX and cannot be represented losslessly"
-                )))
-            }
-        } else {
+            return Ok(Value::Number(Number::Integer(v as i64)));
+        }
+        // Values above `i64::MAX` require the `lossless-u64` feature.
+        // Without it the `Number::Unsigned` variant does not exist and
+        // there is no lossless representation to fall back to — return
+        // an explicit serialise-time error so callers can surface the
+        // limit to their users.
+        #[cfg(feature = "lossless-u64")]
+        {
+            Ok(Value::Number(Number::Unsigned(v)))
+        }
+        #[cfg(not(feature = "lossless-u64"))]
+        {
             Err(Error::Serialize(format!(
-                "u64 value {v} exceeds i64::MAX and cannot be represented losslessly"
+                "u64 value {v} exceeds i64::MAX and cannot be represented losslessly; \
+                 enable the `lossless-u64` Cargo feature to opt in to unsigned integer support"
             )))
         }
     }

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -233,7 +233,6 @@ impl SerializerConfig {
         self.max_depth = depth;
         self
     }
-
 }
 
 /// Serialize a Rust value to a YAML `String`.

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -43,6 +43,8 @@ pub(crate) enum Scalar<'a> {
     Null,
     Bool(bool),
     Int(i64),
+    #[cfg(feature = "lossless-u64")]
+    Uint(u64),
     Float(f64),
     Str(Cow<'a, str>),
 }
@@ -596,6 +598,7 @@ impl<'a> StreamingDeserializer<'a> {
                 self.config.no_schema,
                 self.config.legacy_octal_numbers,
                 self.config.legacy_sexagesimal,
+                self.config.lossless_u64_integers(),
             )
         } else {
             Scalar::Str(Cow::Borrowed(value))
@@ -630,6 +633,8 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     Scalar::Null => visitor.visit_none(),
                     Scalar::Bool(b) => visitor.visit_bool(b),
                     Scalar::Int(n) => visitor.visit_i64(n),
+                    #[cfg(feature = "lossless-u64")]
+                    Scalar::Uint(n) => visitor.visit_u64(n),
                     Scalar::Float(f) => visitor.visit_f64(f),
                     Scalar::Str(Cow::Borrowed(b)) => visitor.visit_borrowed_str(b),
                     Scalar::Str(Cow::Owned(o)) => visitor.visit_string(o),
@@ -638,6 +643,8 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     Scalar::Null => visitor.visit_none(),
                     Scalar::Bool(b) => visitor.visit_bool(b),
                     Scalar::Int(n) => visitor.visit_i64(n),
+                    #[cfg(feature = "lossless-u64")]
+                    Scalar::Uint(n) => visitor.visit_u64(n),
                     Scalar::Float(f) => visitor.visit_f64(f),
                     Scalar::Str(_) => visitor.visit_string(s),
                 },
@@ -730,6 +737,8 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
         if let Event::Scalar { value, style, .. } = self.next_event()? {
             match self.resolve_scalar(&value, style) {
                 Scalar::Int(n) if n >= 0 => return visitor.visit_u64(n as u64),
+                #[cfg(feature = "lossless-u64")]
+                Scalar::Uint(n) => return visitor.visit_u64(n),
                 Scalar::Float(f)
                     if f.is_finite() && f.fract() == 0.0 && f >= 0.0 && f <= u64::MAX as f64 =>
                 {
@@ -753,6 +762,8 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
             match self.resolve_scalar(&value, style) {
                 Scalar::Float(f) => return visitor.visit_f64(f),
                 Scalar::Int(n) => return visitor.visit_f64(n as f64),
+                #[cfg(feature = "lossless-u64")]
+                Scalar::Uint(n) => return visitor.visit_f64(n as f64),
                 _ => {}
             }
         }
@@ -1121,6 +1132,11 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     found: "bool".into(),
                 }),
                 Scalar::Int(_) => Err(Error::TypeMismatch {
+                    expected: "bytes",
+                    found: "integer".into(),
+                }),
+                #[cfg(feature = "lossless-u64")]
+                Scalar::Uint(_) => Err(Error::TypeMismatch {
                     expected: "bytes",
                     found: "integer".into(),
                 }),
@@ -1598,6 +1614,9 @@ fn is_fallback_error(e: &Error) -> bool {
 ///   colon-separated base-60 numbers (`60:00` → 3 600,
 ///   `1:30:00` → 5 400). Off by default; YAML 1.2 dropped the
 ///   sexagesimal schema.
+/// - `lossless_u64` — when `true` and the `lossless-u64` feature is
+///   enabled, resolve unsigned integer scalars up to `u64::MAX`
+///   before considering a float fallback.
 pub(crate) fn resolve_plain_ext(
     s: &str,
     strict: bool,
@@ -1605,6 +1624,7 @@ pub(crate) fn resolve_plain_ext(
     no_schema: bool,
     legacy_octal: bool,
     legacy_sexagesimal: bool,
+    lossless_u64: bool,
 ) -> Scalar<'_> {
     if no_schema {
         // Schema-strict mode: every plain scalar surfaces as a
@@ -1625,8 +1645,14 @@ pub(crate) fn resolve_plain_ext(
         "on" | "On" | "ON" if !strict && legacy => Scalar::Bool(true),
         "off" | "Off" | "OFF" if !strict && legacy => Scalar::Bool(false),
         _ => {
-            if let Some(n) = parse_integer(s, legacy_octal) {
-                Scalar::Int(n)
+            if let Some(n) = parse_integer(s, legacy_octal, lossless_u64) {
+                match n {
+                    ParsedInteger::Signed(n) => Scalar::Int(n),
+                    #[cfg(feature = "lossless-u64")]
+                    ParsedInteger::Unsigned(n) => Scalar::Uint(n),
+                }
+            } else if lossless_u64 && looks_like_integer_literal(s, legacy_octal) {
+                Scalar::Str(Cow::Borrowed(s))
             } else if legacy_sexagesimal {
                 if let Some(n) = parse_sexagesimal_int(s) {
                     Scalar::Int(n)
@@ -1644,6 +1670,30 @@ pub(crate) fn resolve_plain_ext(
             }
         }
     }
+}
+
+fn looks_like_integer_literal(s: &str, legacy_octal: bool) -> bool {
+    let b = s.as_bytes();
+    if b.is_empty() {
+        return false;
+    }
+    if b.len() > 2 && b[0] == b'0' && (bytes_to_char(b[1]) == 'x' || bytes_to_char(b[1]) == 'X') {
+        return b[2..].iter().all(|c| c.is_ascii_hexdigit());
+    }
+    if b.len() > 2 && b[0] == b'0' && (bytes_to_char(b[1]) == 'o' || bytes_to_char(b[1]) == 'O') {
+        return b[2..].iter().all(|c| (b'0'..=b'7').contains(c));
+    }
+    if legacy_octal && b.len() >= 2 && b[0] == b'0' {
+        return b[1..].iter().all(|c| (b'0'..=b'7').contains(c));
+    }
+    let start = if b[0] == b'+' || b[0] == b'-' { 1 } else { 0 };
+    start < b.len() && b[start..].iter().all(u8::is_ascii_digit)
+}
+
+enum ParsedInteger {
+    Signed(i64),
+    #[cfg(feature = "lossless-u64")]
+    Unsigned(u64),
 }
 
 /// Parse a YAML 1.1 sexagesimal integer like `60:00` or
@@ -1718,16 +1768,16 @@ fn parse_sexagesimal_float(s: &str) -> Option<f64> {
     Some(sign * total)
 }
 
-fn parse_integer(s: &str, legacy_octal: bool) -> Option<i64> {
+fn parse_integer(s: &str, legacy_octal: bool, lossless_u64: bool) -> Option<ParsedInteger> {
     let b = s.as_bytes();
     if b.is_empty() {
         return None;
     }
     if b.len() > 2 && b[0] == b'0' && (bytes_to_char(b[1]) == 'x' || bytes_to_char(b[1]) == 'X') {
-        return i64::from_str_radix(&s[2..], 16).ok();
+        return parse_radix_integer(&s[2..], 16, lossless_u64);
     }
     if b.len() > 2 && b[0] == b'0' && (bytes_to_char(b[1]) == 'o' || bytes_to_char(b[1]) == 'O') {
-        return i64::from_str_radix(&s[2..], 8).ok();
+        return parse_radix_integer(&s[2..], 8, lossless_u64);
     }
     // YAML 1.1-style bare `0`-prefix octal — only when explicitly
     // opted in. The leading `0` must be followed by an octal digit
@@ -1738,7 +1788,7 @@ fn parse_integer(s: &str, legacy_octal: bool) -> Option<i64> {
         && b[0] == b'0'
         && b[1..].iter().all(|&c| c.is_ascii_digit() && c <= b'7')
     {
-        return i64::from_str_radix(&s[1..], 8).ok();
+        return parse_radix_integer(&s[1..], 8, lossless_u64);
     }
     let start = if b[0] == b'+' || b[0] == b'-' { 1 } else { 0 };
     if start >= b.len() {
@@ -1749,10 +1799,34 @@ fn parse_integer(s: &str, legacy_octal: bool) -> Option<i64> {
         // to `s.parse::<i64>()` but processes 8 digits per cycle on
         // the inner pipeline, beating the stdlib byte-by-byte loop
         // on data-heavy workloads (telemetry, IDs, port numbers).
-        crate::simd::parse_decimal_i64(b)
+        if let Some(n) = crate::simd::parse_decimal_i64(b) {
+            return Some(ParsedInteger::Signed(n));
+        }
+        #[cfg(feature = "lossless-u64")]
+        if lossless_u64 && b[0] != b'-' {
+            let digits = if b[0] == b'+' { &b[1..] } else { b };
+            return crate::simd::parse_decimal_u64(digits).map(ParsedInteger::Unsigned);
+        }
+        None
     } else {
         None
     }
+}
+
+fn parse_radix_integer(s: &str, radix: u32, lossless_u64: bool) -> Option<ParsedInteger> {
+    #[cfg(not(feature = "lossless-u64"))]
+    let _ = lossless_u64;
+    if let Ok(n) = i64::from_str_radix(s, radix) {
+        return Some(ParsedInteger::Signed(n));
+    }
+    #[cfg(feature = "lossless-u64")]
+    if lossless_u64 {
+        return u64::from_str_radix(s, radix)
+            .ok()
+            .map(ParsedInteger::Unsigned);
+    }
+    #[allow(unreachable_code)]
+    None
 }
 
 fn bytes_to_char(b: u8) -> char {

--- a/crates/noyalib/src/sval_adapter.rs
+++ b/crates/noyalib/src/sval_adapter.rs
@@ -84,6 +84,8 @@ impl sval::Value for Number {
     fn stream<'sval, S: sval::Stream<'sval> + ?Sized>(&'sval self, stream: &mut S) -> sval::Result {
         match self {
             Number::Integer(i) => stream.i64(*i),
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(u) => stream.u64(*u),
             Number::Float(f) => stream.f64(*f),
         }
     }

--- a/crates/noyalib/src/value/number.rs
+++ b/crates/noyalib/src/value/number.rs
@@ -13,6 +13,10 @@ use core::str::FromStr;
 pub enum Number {
     /// A signed integer.
     Integer(i64),
+    /// An unsigned integer that cannot be represented by `i64`.
+    #[cfg(feature = "lossless-u64")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lossless-u64")))]
+    Unsigned(u64),
     /// A floating-point number.
     Float(f64),
 }
@@ -34,6 +38,8 @@ impl Number {
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Number::Integer(n) => Some(*n),
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => i64::try_from(*n).ok(),
             Number::Float(_) => None,
         }
     }
@@ -54,6 +60,8 @@ impl Number {
     pub fn as_u64(&self) -> Option<u64> {
         match self {
             Number::Integer(n) if *n >= 0 => Some(*n as u64),
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => Some(*n),
             _ => None,
         }
     }
@@ -75,6 +83,8 @@ impl Number {
     pub fn as_f64(&self) -> f64 {
         match self {
             Number::Integer(n) => *n as f64,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => *n as f64,
             Number::Float(n) => *n,
         }
     }
@@ -90,7 +100,12 @@ impl Number {
     /// ```
     #[must_use]
     pub fn is_integer(&self) -> bool {
-        matches!(self, Number::Integer(_))
+        match self {
+            Number::Integer(_) => true,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(_) => true,
+            Number::Float(_) => false,
+        }
     }
 
     /// Returns `true` if the number is a float.
@@ -120,7 +135,12 @@ impl Number {
     /// ```
     #[must_use]
     pub fn is_i64(&self) -> bool {
-        matches!(self, Number::Integer(_))
+        match self {
+            Number::Integer(_) => true,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => i64::try_from(*n).is_ok(),
+            Number::Float(_) => false,
+        }
     }
 
     /// Returns `true` if the number can be represented as a `u64`.
@@ -137,7 +157,12 @@ impl Number {
     /// ```
     #[must_use]
     pub fn is_u64(&self) -> bool {
-        matches!(self, Number::Integer(n) if *n >= 0)
+        match self {
+            Number::Integer(n) => *n >= 0,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(_) => true,
+            Number::Float(_) => false,
+        }
     }
 
     /// Returns `true` if the number can be represented as an `f64`.
@@ -176,6 +201,8 @@ impl Number {
         match self {
             Number::Float(n) => n.is_nan(),
             Number::Integer(_) => false,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(_) => false,
         }
     }
 
@@ -197,6 +224,8 @@ impl Number {
         match self {
             Number::Float(n) => n.is_infinite(),
             Number::Integer(_) => false,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(_) => false,
         }
     }
 
@@ -219,6 +248,8 @@ impl Number {
         match self {
             Number::Float(n) => n.is_finite(),
             Number::Integer(_) => true,
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(_) => true,
         }
     }
 }
@@ -227,6 +258,8 @@ impl fmt::Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Number::Integer(n) => write!(f, "{n}"),
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => write!(f, "{n}"),
             Number::Float(n) => write!(f, "{n}"),
         }
     }
@@ -266,6 +299,10 @@ impl FromStr for Number {
         if let Ok(n) = s.parse::<i64>() {
             return Ok(Number::Integer(n));
         }
+        #[cfg(feature = "lossless-u64")]
+        if let Ok(n) = s.parse::<u64>() {
+            return Ok(Number::Unsigned(n));
+        }
 
         // Handle hex (0x), octal (0o), and binary (0b) integers
         if s.len() > 2 {
@@ -275,15 +312,27 @@ impl FromStr for Number {
                     if let Ok(n) = i64::from_str_radix(rest, 16) {
                         return Ok(Number::Integer(n));
                     }
+                    #[cfg(feature = "lossless-u64")]
+                    if let Ok(n) = u64::from_str_radix(rest, 16) {
+                        return Ok(Number::Unsigned(n));
+                    }
                 }
                 "0o" | "0O" => {
                     if let Ok(n) = i64::from_str_radix(rest, 8) {
                         return Ok(Number::Integer(n));
                     }
+                    #[cfg(feature = "lossless-u64")]
+                    if let Ok(n) = u64::from_str_radix(rest, 8) {
+                        return Ok(Number::Unsigned(n));
+                    }
                 }
                 "0b" | "0B" => {
                     if let Ok(n) = i64::from_str_radix(rest, 2) {
                         return Ok(Number::Integer(n));
+                    }
+                    #[cfg(feature = "lossless-u64")]
+                    if let Ok(n) = u64::from_str_radix(rest, 2) {
+                        return Ok(Number::Unsigned(n));
                     }
                 }
                 _ => {}
@@ -303,6 +352,8 @@ impl PartialEq for Number {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Number::Integer(a), Number::Integer(b)) => a == b,
+            #[cfg(feature = "lossless-u64")]
+            (Number::Unsigned(a), Number::Unsigned(b)) => a == b,
             (Number::Float(a), Number::Float(b)) => {
                 // Treat NaN == NaN to satisfy the Eq contract (reflexivity)
                 (a.is_nan() && b.is_nan()) || a == b
@@ -319,6 +370,11 @@ impl Hash for Number {
         match self {
             Number::Integer(n) => {
                 0u8.hash(state);
+                n.hash(state);
+            }
+            #[cfg(feature = "lossless-u64")]
+            Number::Unsigned(n) => {
+                2u8.hash(state);
                 n.hash(state);
             }
             Number::Float(n) => {
@@ -350,10 +406,36 @@ impl PartialOrd for Number {
     }
 }
 
+/// Total ordering for [`Number`].
+///
+/// Same-kind comparisons (`Integer` vs `Integer`, `Unsigned` vs `Unsigned`,
+/// `Float` vs `Float`) use exact arithmetic. Cross-kind comparisons between
+/// integers and floats widen the integer side to [`f64`], matching the
+/// existing `Integer` ↔ `Float` arms. Values with magnitude above 2^53 may
+/// compare [`Ordering::Equal`] to nearby floats because of IEEE rounding; for
+/// exact ordering, compare within the same kind.
 impl Ord for Number {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
             (Number::Integer(a), Number::Integer(b)) => a.cmp(b),
+            #[cfg(feature = "lossless-u64")]
+            (Number::Unsigned(a), Number::Unsigned(b)) => a.cmp(b),
+            #[cfg(feature = "lossless-u64")]
+            (Number::Integer(a), Number::Unsigned(b)) => {
+                if *a < 0 {
+                    Ordering::Less
+                } else {
+                    (*a as u64).cmp(b)
+                }
+            }
+            #[cfg(feature = "lossless-u64")]
+            (Number::Unsigned(a), Number::Integer(b)) => {
+                if *b < 0 {
+                    Ordering::Greater
+                } else {
+                    a.cmp(&(*b as u64))
+                }
+            }
             (Number::Float(a), Number::Float(b)) => {
                 // Handle NaN: treat all NaN as equal and greater than any non-NaN
                 match (a.is_nan(), b.is_nan()) {
@@ -393,6 +475,22 @@ impl Ord for Number {
             (Number::Float(a), Number::Integer(b)) => {
                 // Delegate to the Integer-Float case and invert.
                 match Number::Integer(*b).cmp(&Number::Float(*a)) {
+                    Ordering::Less => Ordering::Greater,
+                    Ordering::Greater => Ordering::Less,
+                    Ordering::Equal => Ordering::Equal,
+                }
+            }
+            #[cfg(feature = "lossless-u64")]
+            (Number::Unsigned(a), Number::Float(b)) => {
+                if b.is_nan() {
+                    Ordering::Less
+                } else {
+                    (*a as f64).partial_cmp(b).unwrap_or(Ordering::Equal)
+                }
+            }
+            #[cfg(feature = "lossless-u64")]
+            (Number::Float(a), Number::Unsigned(b)) => {
+                match Number::Unsigned(*b).cmp(&Number::Float(*a)) {
                     Ordering::Less => Ordering::Greater,
                     Ordering::Greater => Ordering::Less,
                     Ordering::Equal => Ordering::Equal,
@@ -458,6 +556,15 @@ impl From<u64> for Number {
     fn from(v: u64) -> Self {
         if v <= i64::MAX as u64 {
             Number::Integer(v as i64)
+        } else if cfg!(feature = "lossless-u64") {
+            #[cfg(feature = "lossless-u64")]
+            {
+                Number::Unsigned(v)
+            }
+            #[cfg(not(feature = "lossless-u64"))]
+            {
+                Number::Float(v as f64)
+            }
         } else {
             Number::Float(v as f64)
         }

--- a/crates/noyalib/src/value/number.rs
+++ b/crates/noyalib/src/value/number.rs
@@ -9,7 +9,15 @@ use core::hash::{Hash, Hasher};
 use core::str::FromStr;
 
 /// Represents a YAML number.
+///
+/// Marked `#[non_exhaustive]` so future numeric variants can be
+/// added without breaking downstream `match` arms. Callers must
+/// include a `_ => { … }` wildcard when pattern-matching. Adding
+/// `Unsigned(u64)` behind `feature = "lossless-u64"` is the first
+/// use of this contract; see
+/// [ADR-0004](https://github.com/sebastienrousseau/noyalib/blob/main/doc/adr/0004-lossless-u64-integers.md).
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum Number {
     /// A signed integer.
     Integer(i64),

--- a/crates/noyalib/src/value/serde_impl.rs
+++ b/crates/noyalib/src/value/serde_impl.rs
@@ -35,7 +35,7 @@ impl<'de> Deserialize<'de> for Value {
             }
 
             fn visit_u64<E>(self, v: u64) -> Result<Value, E> {
-                Ok(Value::Number(Number::Integer(v as i64)))
+                Ok(Value::Number(Number::from(v)))
             }
 
             fn visit_f64<E>(self, v: f64) -> Result<Value, E> {
@@ -151,6 +151,8 @@ impl Serialize for Value {
             Value::Null => serializer.serialize_none(),
             Value::Bool(b) => serializer.serialize_bool(*b),
             Value::Number(Number::Integer(n)) => serializer.serialize_i64(*n),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => serializer.serialize_u64(*n),
             Value::Number(Number::Float(n)) => serializer.serialize_f64(*n),
             Value::String(s) => serializer.serialize_str(s),
             Value::Sequence(s) => s.serialize(serializer),
@@ -247,6 +249,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
             Value::Null => visitor.visit_unit(),
             Value::Bool(b) => visitor.visit_bool(*b),
             Value::Number(Number::Integer(n)) => visitor.visit_i64(*n),
+            #[cfg(feature = "lossless-u64")]
+            Value::Number(Number::Unsigned(n)) => visitor.visit_u64(*n),
             Value::Number(Number::Float(n)) => visitor.visit_f64(*n),
             Value::String(s) => visitor.visit_borrowed_str(s),
             Value::Sequence(seq) => visitor.visit_seq(ValueSeqAccess { iter: seq.iter() }),

--- a/crates/noyalib/tests/coverage_boost.rs
+++ b/crates/noyalib/tests/coverage_boost.rs
@@ -1521,9 +1521,11 @@ fn loader_mapping_key_limit() {
 
 #[test]
 fn number_from_u64_overflow() {
-    // u64::MAX overflows i64, stored as Float
     let n = Number::from(u64::MAX);
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(n.is_float());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(n.as_u64(), Some(u64::MAX));
 }
 
 #[test]

--- a/crates/noyalib/tests/coverage_borrowed.rs
+++ b/crates/noyalib/tests/coverage_borrowed.rs
@@ -9,7 +9,12 @@
 //! path queries (`get_path`, `query`), and conversion to owned `Value`
 //! via `into_owned`.
 
+use noyalib::Value;
+#[cfg(feature = "lossless-u64")]
+use noyalib::borrowed::from_str_borrowed_with_config;
 use noyalib::borrowed::{BorrowedValue, from_str_borrowed};
+#[cfg(feature = "lossless-u64")]
+use noyalib::{Number, ParserConfig};
 
 // ── Construction & accessors ────────────────────────────────────────────
 
@@ -35,6 +40,16 @@ fn string_scalar() {
 fn integer_scalar() {
     let v: BorrowedValue<'_> = from_str_borrowed("42").unwrap();
     assert_eq!(v.as_i64(), Some(42));
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn lossless_u64_integer_scalar() {
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    let v = from_str_borrowed_with_config("18446744073709551615\n", &cfg).unwrap();
+    let owned = v.into_owned();
+    assert_eq!(owned.as_u64(), Some(u64::MAX));
+    assert!(!matches!(owned, Value::Number(Number::Float(_))));
 }
 
 #[test]
@@ -150,7 +165,7 @@ fn into_owned_preserves_structure() {
     let owned = v.into_owned();
     // Owned Value should roundtrip via to_string / from_str.
     let yaml_out = noyalib::to_string(&owned).unwrap();
-    let reparsed: noyalib::Value = noyalib::from_str(&yaml_out).unwrap();
+    let reparsed: Value = noyalib::from_str(&yaml_out).unwrap();
     assert_eq!(owned, reparsed);
 }
 

--- a/crates/noyalib/tests/coverage_gaps.rs
+++ b/crates/noyalib/tests/coverage_gaps.rs
@@ -1195,7 +1195,10 @@ fn number_i64_max() {
 #[test]
 fn number_u64_max_errors() {
     let result = to_value(&u64::MAX);
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(result.is_err());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(result.unwrap().as_u64(), Some(u64::MAX));
 }
 
 #[test]

--- a/crates/noyalib/tests/coverage_ser.rs
+++ b/crates/noyalib/tests/coverage_ser.rs
@@ -158,9 +158,16 @@ fn document_end_marker() {
 
 #[test]
 fn serialize_u64_max() {
-    // u64::MAX exceeds i64::MAX — should error
     let result = to_value(&u64::MAX);
-    assert!(result.is_err());
+    #[cfg(not(feature = "lossless-u64"))]
+    {
+        // Legacy model cannot represent u64::MAX losslessly.
+        assert!(result.is_err());
+    }
+    #[cfg(feature = "lossless-u64")]
+    {
+        assert_eq!(result.unwrap().as_u64(), Some(u64::MAX));
+    }
 }
 
 #[test]

--- a/crates/noyalib/tests/coverage_value.rs
+++ b/crates/noyalib/tests/coverage_value.rs
@@ -9,6 +9,8 @@ use std::str::FromStr;
 use noyalib::{
     Mapping, MappingAny, MaybeTag, Number, Tag, TaggedValue, Value, check_for_tag, from_str, nobang,
 };
+#[cfg(feature = "lossless-u64")]
+use serde::Deserialize;
 
 // ============================================================================
 // Mapping — capacity, reserve, shrink
@@ -21,6 +23,15 @@ fn mapping_with_capacity_and_reserve() {
     m.reserve(20);
     assert!(m.capacity() >= 20);
     m.shrink_to_fit();
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn value_deserialize_visit_u64_preserves_unsigned() {
+    let producer = serde_json::Value::from(u64::MAX);
+    let value = Value::deserialize(producer).unwrap();
+    assert_eq!(value.as_u64(), Some(u64::MAX));
+    assert!(matches!(value, Value::Number(Number::Unsigned(n)) if n == u64::MAX));
 }
 
 #[test]
@@ -875,7 +886,10 @@ fn number_from_types() {
 #[test]
 fn number_u64_max_becomes_float() {
     let n = Number::from(u64::MAX);
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(n.is_float());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(n.as_u64(), Some(u64::MAX));
 }
 
 // ============================================================================

--- a/crates/noyalib/tests/de.rs
+++ b/crates/noyalib/tests/de.rs
@@ -8,6 +8,8 @@
 use std::collections::BTreeMap;
 
 use noyalib::{Number, Value, from_str, from_value};
+#[cfg(feature = "lossless-u64")]
+use noyalib::{ParserConfig, from_str_with_config};
 use serde::Deserialize;
 
 /// Helper function to test deserialization
@@ -64,6 +66,33 @@ fn test_integers() {
     let yaml = "9223372036854775807\n";
     let value: i64 = from_str(yaml).unwrap();
     assert_eq!(value, i64::MAX);
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_lossless_u64_boundaries_with_config() {
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    for value in [i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+        let yaml = format!("{value}\n");
+        let parsed: u64 = from_str_with_config(&yaml, &cfg).unwrap();
+        assert_eq!(parsed, value);
+    }
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_lossless_u64_rejects_overflow_with_config() {
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    let err = from_str_with_config::<u64>("18446744073709551616\n", &cfg).unwrap_err();
+    assert!(err.to_string().contains("unsigned integer") || err.to_string().contains("u64"));
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_from_value_unsigned_to_u64() {
+    let value = Value::Number(Number::Unsigned(u64::MAX));
+    let parsed: u64 = from_value(&value).unwrap();
+    assert_eq!(parsed, u64::MAX);
 }
 
 #[test]

--- a/crates/noyalib/tests/official_suite.rs
+++ b/crates/noyalib/tests/official_suite.rs
@@ -91,6 +91,8 @@ fn yaml_value_to_json(v: &Value) -> serde_json::Value {
         Value::Null => serde_json::Value::Null,
         Value::Bool(b) => serde_json::Value::Bool(*b),
         Value::Number(Number::Integer(n)) => serde_json::json!(*n),
+        #[cfg(feature = "lossless-u64")]
+        Value::Number(Number::Unsigned(n)) => serde_json::json!(*n),
         Value::Number(Number::Float(f)) => {
             if f.is_finite() && f.fract() == 0.0 && f.abs() < (i64::MAX as f64) {
                 serde_json::json!(*f as i64)

--- a/crates/noyalib/tests/official_suite.rs
+++ b/crates/noyalib/tests/official_suite.rs
@@ -100,6 +100,8 @@ fn yaml_value_to_json(v: &Value) -> serde_json::Value {
                 serde_json::json!(*f)
             }
         }
+        // `Number` is `#[non_exhaustive]`; future variants land here.
+        Value::Number(_) => serde_json::Value::Null,
         Value::String(s) => serde_json::Value::String(s.clone()),
         Value::Sequence(seq) => {
             serde_json::Value::Array(seq.iter().map(yaml_value_to_json).collect())

--- a/crates/noyalib/tests/proptest.rs
+++ b/crates/noyalib/tests/proptest.rs
@@ -7,6 +7,8 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{Mapping, Number, Value, from_str, from_value, to_string, to_value};
+#[cfg(feature = "lossless-u64")]
+use noyalib::{ParserConfig, from_str_with_config};
 use proptest::prelude::*;
 
 // ============================================================================
@@ -14,9 +16,23 @@ use proptest::prelude::*;
 // ============================================================================
 
 /// Generate arbitrary Number values
+#[cfg(not(feature = "lossless-u64"))]
 fn arb_number() -> impl Strategy<Value = Number> {
     prop_oneof![
         any::<i64>().prop_map(Number::Integer),
+        // Use finite floats to avoid NaN comparison issues
+        any::<f64>()
+            .prop_filter("finite floats only", |f| f.is_finite())
+            .prop_map(Number::Float),
+    ]
+}
+
+/// Generate arbitrary Number values, including canonical unsigned values.
+#[cfg(feature = "lossless-u64")]
+fn arb_number() -> impl Strategy<Value = Number> {
+    prop_oneof![
+        any::<i64>().prop_map(Number::Integer),
+        ((i64::MAX as u64 + 1)..=u64::MAX).prop_map(Number::Unsigned),
         // Use finite floats to avoid NaN comparison issues
         any::<f64>()
             .prop_filter("finite floats only", |f| f.is_finite())
@@ -98,6 +114,18 @@ proptest! {
         let parsed: Value = from_str(&yaml).expect("deserialization should succeed");
 
         prop_assert_eq!(parsed.as_i64(), Some(n));
+    }
+
+    /// Unsigned integers should roundtrip exactly when the opt-in is active.
+    #[cfg(feature = "lossless-u64")]
+    #[test]
+    fn roundtrip_unsigned_integer(n in any::<u64>()) {
+        let value = Value::Number(Number::from(n));
+        let yaml = to_string(&value).expect("serialization should succeed");
+        let cfg = ParserConfig::new().lossless_u64_integers(true);
+        let parsed: Value = from_str_with_config(&yaml, &cfg).expect("deserialization should succeed");
+
+        prop_assert_eq!(parsed.as_u64(), Some(n));
     }
 
     /// Booleans should roundtrip exactly
@@ -419,6 +447,8 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         (Value::Null, Value::Null) => true,
         (Value::Bool(a), Value::Bool(b)) => a == b,
         (Value::Number(Number::Integer(a)), Value::Number(Number::Integer(b))) => a == b,
+        #[cfg(feature = "lossless-u64")]
+        (Value::Number(Number::Unsigned(a)), Value::Number(Number::Unsigned(b))) => a == b,
         (Value::Number(Number::Float(a)), Value::Number(Number::Float(b))) => {
             (a - b).abs() < 1e-10 || (a.is_nan() && b.is_nan())
         }
@@ -426,6 +456,14 @@ fn values_equal(a: &Value, b: &Value) -> bool {
             (*a as f64 - b).abs() < 1e-10
         }
         (Value::Number(Number::Float(a)), Value::Number(Number::Integer(b))) => {
+            (a - *b as f64).abs() < 1e-10
+        }
+        #[cfg(feature = "lossless-u64")]
+        (Value::Number(Number::Unsigned(a)), Value::Number(Number::Float(b))) => {
+            (*a as f64 - b).abs() < 1e-10
+        }
+        #[cfg(feature = "lossless-u64")]
+        (Value::Number(Number::Float(a)), Value::Number(Number::Unsigned(b))) => {
             (a - *b as f64).abs() < 1e-10
         }
         (Value::String(a), Value::String(b)) => a == b,

--- a/crates/noyalib/tests/proptest.rs
+++ b/crates/noyalib/tests/proptest.rs
@@ -481,3 +481,172 @@ fn values_equal(a: &Value, b: &Value) -> bool {
         _ => false,
     }
 }
+
+// ============================================================================
+// DoS-limit × lossless-u64 interaction
+// ============================================================================
+
+/// The `lossless-u64` opt-in must not weaken any of the parser's
+/// hardening budgets (`max_depth`, `max_document_length`,
+/// `max_alias_expansions`, `max_mapping_keys`,
+/// `max_sequence_length`). Every scalar-resolution path — including
+/// the new `Number::Unsigned` route — sits inside the loader loop
+/// that increments those counters, so the budget check MUST fire
+/// before the scalar resolver runs.
+///
+/// The tests below feed adversarial documents that pair a
+/// budget-triggering shape with a `u64::MAX` (or MAX-adjacent)
+/// value. The library MUST return a `LimitExceeded` (or moral
+/// equivalent) `Error` — never `Ok`, never a panic. The variant
+/// matters less than the mechanical fact that the limit fires.
+#[cfg(feature = "lossless-u64")]
+mod dos_limits_lossless_u64 {
+    use super::*;
+
+    proptest! {
+        /// A deeply-nested document ending in a `u64` scalar must
+        /// error on the depth limit — never succeed, never panic.
+        #[test]
+        fn depth_limit_fires_before_u64_scalar(
+            depth in 200usize..1_000,
+            n in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            // Build "[ [ [ ... [ N ] ... ] ] ]" nested `depth` levels.
+            let mut yaml = String::with_capacity(depth * 2 + 32);
+            for _ in 0..depth {
+                yaml.push('[');
+            }
+            yaml.push_str(&n.to_string());
+            for _ in 0..depth {
+                yaml.push(']');
+            }
+            yaml.push('\n');
+
+            let cfg = ParserConfig::new()
+                .max_depth(128)
+                .lossless_u64_integers(true);
+            let res: Result<Value, _> = from_str_with_config(&yaml, &cfg);
+            prop_assert!(res.is_err(),
+                "depth {} vs max_depth 128 should fail, got Ok({:?})",
+                depth,
+                res.ok());
+        }
+
+        /// A document *at* the depth limit ending in a `u64::MAX`
+        /// scalar must round-trip cleanly (the budget check should
+        /// not fire before a legal document finishes).
+        #[test]
+        fn depth_limit_permits_legal_u64_scalar(
+            n in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            let depth = 32; // well within default max_depth 128
+            let mut yaml = String::with_capacity(depth * 2 + 32);
+            for _ in 0..depth { yaml.push('['); }
+            yaml.push_str(&n.to_string());
+            for _ in 0..depth { yaml.push(']'); }
+            yaml.push('\n');
+
+            let cfg = ParserConfig::new()
+                .max_depth(128)
+                .lossless_u64_integers(true);
+            let v: Value = from_str_with_config(&yaml, &cfg)
+                .expect("legal-depth u64 doc should parse");
+            // Walk down to the scalar and confirm it kept its value.
+            let mut cursor = &v;
+            for _ in 0..depth {
+                match cursor {
+                    Value::Sequence(s) => cursor = &s[0],
+                    other => panic!("expected sequence, got {other:?}"),
+                }
+            }
+            match cursor {
+                Value::Number(Number::Unsigned(m)) => prop_assert_eq!(*m, n),
+                other => panic!("expected Unsigned({n}), got {other:?}"),
+            }
+        }
+
+        /// A document larger than `max_document_length` must error
+        /// even when its payload is a plain `u64` scalar.
+        #[test]
+        fn document_length_limit_fires_before_u64_scalar(
+            padding in 2_000usize..8_000,
+            n in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            // "# " + N spaces + "id: <n>\n" — padding drives past
+            // `max_document_length = 1024`.
+            let mut yaml = String::from("# ");
+            yaml.extend(core::iter::repeat_n(' ', padding));
+            yaml.push_str(&format!("\nid: {n}\n"));
+
+            let cfg = ParserConfig::new()
+                .max_document_length(1024)
+                .lossless_u64_integers(true);
+            let res: Result<Value, _> = from_str_with_config(&yaml, &cfg);
+            prop_assert!(res.is_err(),
+                "doc-length {} vs max 1024 should fail, got Ok",
+                yaml.len());
+        }
+
+        /// A mapping with more keys than `max_mapping_keys` must
+        /// error — the u64 value in each entry must NOT provide a
+        /// bypass.
+        #[test]
+        fn mapping_keys_limit_fires_before_u64_scalar(
+            keys in 65usize..256,
+            n in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            let mut yaml = String::new();
+            for i in 0..keys {
+                yaml.push_str(&format!("k{i}: {n}\n"));
+            }
+
+            let cfg = ParserConfig::new()
+                .max_mapping_keys(64)
+                .lossless_u64_integers(true);
+            let res: Result<Value, _> = from_str_with_config(&yaml, &cfg);
+            prop_assert!(res.is_err(),
+                "keys {} vs max_mapping_keys 64 should fail, got Ok",
+                keys);
+        }
+
+        /// A sequence longer than `max_sequence_length` must error
+        /// even when every element is a lossless `u64`.
+        #[test]
+        fn sequence_length_limit_fires_before_u64_scalar(
+            elems in 65usize..256,
+            n in (i64::MAX as u64 + 1)..=u64::MAX,
+        ) {
+            let mut yaml = String::from("[");
+            for i in 0..elems {
+                if i > 0 { yaml.push_str(", "); }
+                yaml.push_str(&n.to_string());
+            }
+            yaml.push_str("]\n");
+
+            let cfg = ParserConfig::new()
+                .max_sequence_length(64)
+                .lossless_u64_integers(true);
+            let res: Result<Value, _> = from_str_with_config(&yaml, &cfg);
+            prop_assert!(res.is_err(),
+                "elems {} vs max_sequence_length 64 should fail, got Ok",
+                elems);
+        }
+
+        /// No `u64::MAX` scalar can be silently interpreted as an
+        /// `i64` (wrap-to-negative). Under the opt-in it MUST come
+        /// back as `Number::Unsigned` (or fail cleanly); the
+        /// `as_i64()` accessor MUST NOT return `Some(-1)`.
+        #[test]
+        fn no_signed_wrap_at_u64_max(n in (i64::MAX as u64 + 1)..=u64::MAX) {
+            let yaml = format!("id: {n}\n");
+            let cfg = ParserConfig::new().lossless_u64_integers(true);
+            let v: Value = from_str_with_config(&yaml, &cfg)
+                .expect("legal-shape u64 doc should parse");
+            let scalar = &v["id"];
+            prop_assert!(
+                !matches!(scalar, Value::Number(Number::Integer(_))),
+                "u64::MAX-adjacent scalar {n} incorrectly parsed as Integer: {scalar:?}"
+            );
+        }
+    }
+}

--- a/crates/noyalib/tests/ser.rs
+++ b/crates/noyalib/tests/ser.rs
@@ -27,6 +27,18 @@ fn test_serialize_integers() {
     assert!(to_string(&0i32).unwrap().contains("0"));
 }
 
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_serialize_lossless_u64_plain_scalars() {
+    for value in [i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+        let yaml = to_string(&value).unwrap();
+        assert_eq!(yaml.trim(), value.to_string());
+        assert!(!yaml.contains('"'));
+        assert!(!yaml.contains('\''));
+        assert!(!yaml.contains('.'));
+    }
+}
+
 #[test]
 fn test_serialize_floats() {
     let yaml = to_string(&3.125f64).unwrap();
@@ -77,6 +89,16 @@ fn test_serialize_map() {
     let yaml = to_string(&map).unwrap();
     assert!(yaml.contains("a: 1") || yaml.contains("a:"));
     assert!(yaml.contains("b: 2") || yaml.contains("b:"));
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_serialize_lossless_u64_map_key() {
+    let mut map = BTreeMap::new();
+    let _ = map.insert(u64::MAX, "max");
+    let yaml = to_string(&map).unwrap();
+    assert!(yaml.contains("18446744073709551615"));
+    assert!(yaml.contains("max"));
 }
 
 #[test]
@@ -555,9 +577,11 @@ fn test_serialize_integers_unsigned() {
     let yaml = to_string(&u32_val).unwrap();
     assert!(yaml.contains("4294967295"));
 
-    // u64 max value exceeds i64::MAX and should return an error
     let u64_val: u64 = u64::MAX;
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(to_string(&u64_val).is_err());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(to_string(&u64_val).unwrap().trim(), u64::MAX.to_string());
 
     // u64 values that fit in i64 should serialize fine
     let u64_val: u64 = i64::MAX as u64;

--- a/crates/noyalib/tests/ser_cst_coverage_extra.rs
+++ b/crates/noyalib/tests/ser_cst_coverage_extra.rs
@@ -619,7 +619,10 @@ fn ser_ser_empty_string_double_quoted() {
 fn ser_ser_u64_overflow_returns_error() {
     let big: u64 = u64::MAX;
     let res = to_string(&big);
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(res.is_err());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(res.unwrap().trim(), u64::MAX.to_string());
 }
 
 #[test]

--- a/crates/noyalib/tests/serde.rs
+++ b/crates/noyalib/tests/serde.rs
@@ -7,6 +7,8 @@
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "lossless-u64")]
+use noyalib::{ParserConfig, from_str_with_config};
 use noyalib::{from_str, to_string};
 use serde::{Deserialize, Serialize};
 
@@ -53,6 +55,24 @@ fn test_serde_unsigned() {
     test_serde(&42u16, &["42"]);
     test_serde(&42u32, &["42"]);
     test_serde(&42u64, &["42"]);
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_serde_lossless_u64_struct_field() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Record {
+        id: u64,
+    }
+
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    for id in [i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+        let value = Record { id };
+        let yaml = to_string(&value).unwrap();
+        assert!(yaml.contains(&format!("id: {id}")));
+        let parsed: Record = from_str_with_config(&yaml, &cfg).unwrap();
+        assert_eq!(parsed, value);
+    }
 }
 
 #[test]

--- a/crates/noyalib/tests/spec/numbers.rs
+++ b/crates/noyalib/tests/spec/numbers.rs
@@ -3,6 +3,8 @@
 
 // YAML spec: Number representations
 
+#[cfg(feature = "lossless-u64")]
+use noyalib::{ParserConfig, from_str_with_config, to_string_value};
 use noyalib::{Value, from_str};
 
 // --- Integers ---
@@ -47,6 +49,39 @@ fn integer_octal() {
 fn integer_large() {
     let v: i64 = from_str("1000000000").unwrap();
     assert_eq!(v, 1_000_000_000);
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn integer_lossless_u64_plain_scalars() {
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    for value in [i64::MAX as u64, i64::MAX as u64 + 1, u64::MAX] {
+        let yaml = format!("{value}\n");
+        let v: Value = from_str_with_config(&yaml, &cfg).unwrap();
+        assert_eq!(v.as_u64(), Some(value));
+        assert!(v.is_u64());
+        assert!(!matches!(v, Value::Number(n) if n.is_float()));
+
+        let emitted = to_string_value(&v).unwrap();
+        assert_eq!(emitted.trim(), value.to_string());
+        let reparsed: Value = from_str_with_config(&emitted, &cfg).unwrap();
+        assert_eq!(reparsed.as_u64(), Some(value));
+    }
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn integer_lossless_u64_tagged_and_radix_scalars() {
+    let cfg = ParserConfig::new().lossless_u64_integers(true);
+    for (yaml, expected) in [
+        ("!!int 18446744073709551615\n", u64::MAX),
+        ("0x8000000000000000\n", i64::MAX as u64 + 1),
+        ("0xffffffffffffffff\n", u64::MAX),
+        ("!!int 0xffffffffffffffff\n", u64::MAX),
+    ] {
+        let v: Value = from_str_with_config(yaml, &cfg).unwrap();
+        assert_eq!(v.as_u64(), Some(expected), "{yaml}");
+    }
 }
 
 // --- Floats ---

--- a/crates/noyalib/tests/value.rs
+++ b/crates/noyalib/tests/value.rs
@@ -141,6 +141,22 @@ fn test_number_integer() {
     assert!((num.as_f64() - 42.0).abs() < 0.001);
 }
 
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_number_unsigned() {
+    let num = Number::Unsigned(u64::MAX);
+    assert!(num.is_integer());
+    assert!(!num.is_float());
+    assert_eq!(num.as_i64(), None);
+    assert_eq!(num.as_u64(), Some(u64::MAX));
+    assert_eq!(num.to_string(), "18446744073709551615");
+
+    let value = Value::from(u64::MAX);
+    assert_eq!(value.as_u64(), Some(u64::MAX));
+    assert!(value.as_i64().is_none());
+    assert!(!matches!(value, Value::Number(Number::Float(_))));
+}
+
 #[test]
 fn test_number_float() {
     let num = Number::Float(3.125);
@@ -155,6 +171,19 @@ fn test_number_display() {
     assert_eq!(Number::Integer(42).to_string(), "42");
     assert_eq!(Number::Integer(-42).to_string(), "-42");
     assert!(Number::Float(3.125).to_string().contains("3.125"));
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_number_from_str_unsigned_radix() {
+    assert_eq!(
+        "18446744073709551615".parse::<Number>().unwrap().as_u64(),
+        Some(u64::MAX)
+    );
+    assert_eq!(
+        "0xffffffffffffffff".parse::<Number>().unwrap().as_u64(),
+        Some(u64::MAX)
+    );
 }
 
 // ============================================================================
@@ -606,6 +635,19 @@ fn test_number_hash() {
     let nan1 = Number::Float(f64::NAN);
     let nan2 = Number::Float(f64::NAN);
     assert_eq!(hash_value(&nan1), hash_value(&nan2));
+}
+
+#[cfg(feature = "lossless-u64")]
+#[test]
+fn test_number_hash_lossless_u64_tags() {
+    // Float must keep discriminant 1 when lossless-u64 is enabled.
+    let f1 = Number::Float(3.125);
+    let f2 = Number::Float(3.125);
+    assert_eq!(hash_value(&f1), hash_value(&f2));
+
+    let unsigned = Number::Unsigned(u64::MAX);
+    assert_eq!(hash_value(&unsigned), hash_value(&unsigned));
+    assert_ne!(hash_value(&f1), hash_value(&unsigned));
 }
 
 #[test]
@@ -2485,9 +2527,11 @@ fn test_number_from_impls() {
     assert_eq!(Number::from(100_u64), Number::Integer(100));
     assert_eq!(Number::from(42_usize), Number::Integer(42));
 
-    // u64 > i64::MAX should become Float
     let big = u64::MAX;
+    #[cfg(not(feature = "lossless-u64"))]
     assert_eq!(Number::from(big), Number::Float(big as f64));
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(Number::from(big), Number::Unsigned(big));
 
     assert_eq!(Number::from(1.5_f32), Number::Float(1.5));
     assert_eq!(Number::from(2.5_f64), Number::Float(2.5));
@@ -2499,7 +2543,10 @@ fn test_value_from_u64() {
     assert_eq!(v.as_i64(), Some(42));
 
     let v = Value::from(u64::MAX);
+    #[cfg(not(feature = "lossless-u64"))]
     assert!(v.as_f64().is_some());
+    #[cfg(feature = "lossless-u64")]
+    assert_eq!(v.as_u64(), Some(u64::MAX));
 }
 
 #[test]

--- a/doc/MIGRATION-FROM-SERDE-YAML-BW.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML-BW.md
@@ -69,7 +69,7 @@ enum shape (8 variants vs 7).
 | `serde_yaml_bw::Value` (8 variants) | `noyalib::Value` (7 variants — see below) |
 | `serde_yaml_bw::Value::Alias(name)` | resolved at parse time; no longer a separate variant |
 | `serde_yaml_bw::Mapping` | `noyalib::Mapping` |
-| `serde_yaml_bw::Number` | `noyalib::Number` |
+| `serde_yaml_bw::Number` | `noyalib::Number` (default `Integer` / `Float`; opt-in `Unsigned(u64)` behind `lossless-u64`) |
 | `serde_yaml_bw::Error` | `noyalib::Error` |
 | `serde_yaml_bw::SerializerBuilder` | `noyalib::SerializerConfig` + `to_writer_with_config` |
 | `serde_yaml_bw::SerializerOptions` | `noyalib::SerializerConfig` |

--- a/doc/MIGRATION-FROM-SERDE-YAML-NG.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML-NG.md
@@ -50,7 +50,7 @@ dependency.
 | `serde_yaml_ng::to_value` | `noyalib::to_value` |
 | `serde_yaml_ng::Value` | `noyalib::Value` (same 7 variants) |
 | `serde_yaml_ng::Mapping` | `noyalib::Mapping` |
-| `serde_yaml_ng::Number` | `noyalib::Number` |
+| `serde_yaml_ng::Number` | `noyalib::Number` (default `Integer` / `Float`; opt-in `Unsigned(u64)` behind `lossless-u64`) |
 | `serde_yaml_ng::Error` | `noyalib::Error` |
 | `serde_yaml_ng::Deserializer` | `noyalib::Deserializer` |
 | `serde_yaml_ng::Serializer` | `noyalib::Serializer` |

--- a/doc/MIGRATION-FROM-SERDE-YAML.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML.md
@@ -69,7 +69,7 @@ type — there's no transitive dependency on the archived
 | `serde_yaml::to_value(&v)` | `noyalib::to_value(&v)` | Identical. |
 | `serde_yaml::Value` | `noyalib::Value` | Identical 7-variant enum (`Null`, `Bool`, `Number`, `String`, `Sequence`, `Mapping`, `Tagged`). |
 | `serde_yaml::Mapping` | `noyalib::Mapping` | Wraps `IndexMap<String, Value>`; iteration order preserved. |
-| `serde_yaml::Number` | `noyalib::Number` | Same `Integer` / `Float` split. |
+| `serde_yaml::Number` | `noyalib::Number` | Default mode keeps the same `Integer` / `Float` split. Enabling `lossless-u64` adds an opt-in `Unsigned(u64)` variant; see [ADR 0004](./adr/0004-lossless-u64-integers.md). |
 | `serde_yaml::Error` | `noyalib::Error` | Different variant set, same `Display` shape. See "Error handling" below. |
 | `serde_yaml::with::singleton_map` | `noyalib::with::singleton_map` | Identical. |
 | `serde_yaml::with::singleton_map_optional` | `noyalib::with::singleton_map_optional` | Identical. |

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -377,6 +377,10 @@ This contract holds for all three tag-bearing shapes:
 | `!!str 42` | `Value::String("42")` *(core tag — resolves)* |
 | `!!int 42` | `Value::Number(Integer(42))` *(core tag — resolves)* |
 
+With the `lossless-u64` feature enabled and
+`ParserConfig::lossless_u64_integers(true)`, `!!int` scalars in
+`(i64::MAX, u64::MAX]` resolve as `Value::Number(Unsigned(_))`.
+
 **Reading through the wrapper.** Two helpers on `Value` step
 through the tag for transparent reads:
 
@@ -483,7 +487,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.12", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -506,7 +510,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.12", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -530,7 +534,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.12", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.11", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```
@@ -564,7 +568,8 @@ other channels in [`pkg/PUBLISH.md`](../pkg/PUBLISH.md).
 
 ## 12. WASM, MCP, and LSP
 
-Three satellite crates target specific deployment shapes:
+Three satellite crates in the workspace target specific
+deployment shapes:
 
 - **`noyalib-wasm`** ([`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm)).
   `wasm-pack` output published to npm as

--- a/doc/adr/0004-lossless-u64-integers.md
+++ b/doc/adr/0004-lossless-u64-integers.md
@@ -1,0 +1,128 @@
+# 0004. Opt in to lossless `u64` integers
+
+- **Status:** proposed
+- **Date:** 2026-06-22
+- **Authors:** Noyalib contributors
+
+## Context
+
+YAML 1.2 integer scalars are not limited to Rust's `i64` range.
+noyalib's public `Number` model is currently:
+
+```rust
+pub enum Number {
+    Integer(i64),
+    Float(f64),
+}
+```
+
+That shape leaves no lossless representation for unsigned integer
+scalars in `(i64::MAX, u64::MAX]`. The gap appears in several
+paths:
+
+- `Serializer::serialize_u64` rejects `u64` values above
+  `i64::MAX`.
+- `Number::from(u64)` stores large values as `Float(v as f64)`,
+  losing precision above `2^53`.
+- Plain scalar resolution tries `i64` first and then falls through
+  to `f64`, so `18446744073709551615` becomes a float-shaped value
+  instead of a YAML integer.
+- `Value`'s serde bridge casts `visit_u64` through `i64`, which
+  wraps large unsigned values.
+
+The repository already has a safe, tested `parse_decimal_u64`
+implementation in `crates/noyalib/src/simd.rs`, so the parser does
+not need new dependencies or `unsafe` code. The hard part is the
+public API: `Number` is exported directly and through compatibility
+modules, and migration docs currently describe the model as the
+serde-yaml-like `Integer` / `Float` split.
+
+## Decision
+
+We will add lossless unsigned integer support as an opt-in surface.
+
+When the `lossless-u64` Cargo feature is enabled, `Number` gains:
+
+```rust
+#[cfg(feature = "lossless-u64")]
+Unsigned(u64)
+```
+
+The existing `Integer(i64)` variant stays in place. We will not
+rename it to `Signed`, because keeping the variant name minimizes
+source churn for callers that already construct or match signed
+integers.
+
+The feature is dependency-free and is not enabled by default. Runtime
+behavior is controlled by explicit configuration so default parser and
+compatibility behavior remain stable. The compatibility shim for
+`serde_yaml` keeps the legacy `Integer` / `Float` contract and does
+not opt into `Unsigned` values.
+
+When both compile-time and runtime opt-ins are active:
+
+- `u64` values in `(i64::MAX, u64::MAX]` serialize as plain YAML
+  integer scalars.
+- Plain and explicitly tagged `!!int` scalars in that range parse as
+  unsigned integers rather than floats or strings.
+- Typed `u64` deserialization round-trips those values losslessly.
+- Values above `u64::MAX` remain outside the integer model and must
+  not be rounded into `u64`.
+
+## Consequences
+
+- **Positive:** identifiers, counters, and other legitimate unsigned
+  YAML integers can round-trip without application-level string
+  workarounds.
+- **Positive:** the implementation can reuse existing safe integer
+  parsing primitives and preserves the workspace-wide zero-unsafe
+  invariant.
+- **Positive:** the default API and `compat-serde-yaml` migration
+  story remain stable for callers that do not opt in.
+- **Negative:** `--all-features` builds expose a third `Number`
+  variant. Because `Number` is not `#[non_exhaustive]`, exhaustive
+  downstream matches that enable this feature must add an `Unsigned`
+  arm.
+- **Negative:** parser, loader, streaming deserializer, borrowed AST,
+  serde bridge, schema helpers, and tests all need coordinated updates
+  to avoid reintroducing a lossy fallback.
+- **Neutral:** migration and architecture documentation must describe
+  the default `Integer` / `Float` model separately from the opt-in
+  `Unsigned` model.
+
+## Alternatives considered
+
+### Always add `Unsigned(u64)`
+
+This would make all valid `u64` scalars lossless by default.
+Rejected for this release because it changes parser output and the
+public `Number` enum shape for every user, contradicting the current
+migration docs and SemVer policy.
+
+### Rename `Integer(i64)` to `Signed(i64)`
+
+This is more explicit, but it breaks every caller that constructs or
+matches `Number::Integer`. Rejected in favour of adding
+`Unsigned(u64)` while keeping the established signed variant name.
+
+### Store large unsigned integers as strings
+
+This avoids a public enum change, but changes the YAML type from
+`!!int` to `!!str` and forces callers to recover numeric intent out of
+band. Rejected because the goal is lossless integer serialization, not
+lossless text preservation.
+
+### Continue using `Float(f64)` for overflow
+
+This preserves the current API, but it is lossy above `2^53` and makes
+valid YAML integer scalars indistinguishable from floating-point data.
+Rejected because it is the bug this ADR addresses.
+
+## References
+
+- YAML 1.2.2 core schema: <https://yaml.org/spec/1.2.2/#102-tags>
+- `doc/POLICIES.md` — SemVer, feature, and zero-unsafe policies.
+- `doc/adr/0002-yaml-1.2-default.md` — precedent for explicit runtime
+  opt-in when compatibility and correctness trade off.
+- `doc/adr/0003-zero-unsafe-policy.md` — safe numeric parsing
+  requirement.

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -26,7 +26,8 @@ reference back. Nothing is silently rewritten.
 | [0001](./0001-cst-rowan-shape.md) | CST shape: parallel green tree, not unified | accepted |
 | [0002](./0002-yaml-1.2-default.md) | YAML 1.2 strict semantics by default; 1.1 opt-in | accepted |
 | [0003](./0003-zero-unsafe-policy.md) | `#![forbid(unsafe_code)]` workspace-wide | accepted |
-| [0005](./0005-workspace-split.md) | Split the workspace into 4 satellite repos with strict-lockstep versioning | proposed |
+| [0004](./0004-lossless-u64-integers.md) | Opt in to lossless `u64` integers | proposed |
+| [0005](./0005-workspace-split.md) | Split workspace into 4 satellite repositories with strict-lockstep versioning | accepted |
 
 ## When to add an ADR
 


### PR DESCRIPTION
## Summary

Takeover of [PR #117](https://github.com/sebastienrousseau/noyalib/pull/117)
by @canardleteer. Zero-trust review surfaced three semver /
correctness issues that would have shipped a broken runtime
opt-in and set a semver trap for future variants. This PR bakes
in every fix so the feature ships correctly.

Author credit preserved via `--author` on the base commit
(`fd47105`); follow-up commits (`e92f82a`, `5bf4f11`, `1e23b7b`)
carry my SSH signature over the fixes.

## What ships

- New Cargo feature `lossless-u64` (opt-in, default off).
- New public variant `Number::Unsigned(u64)` — behind
  `cfg(feature = "lossless-u64")`.
- Runtime opt-in on the parser side via
  `ParserConfig::lossless_u64_integers(bool)` — correctly
  threaded through `Loader` / `NoSpanLoader` / `resolve_plain_ext`.
- Round-trip preserved for values ≤ `i64::MAX`.
- Hash discriminants stabilized so enabling the feature does not
  perturb existing float-key hashes.
- Full [ADR-0004](https://github.com/sebastienrousseau/noyalib/blob/main/doc/adr/0004-lossless-u64-integers.md)
  documenting design intent.
- Migration guides updated (`doc/MIGRATION-FROM-SERDE-YAML*.md`).
- Dedicated `examples/lossless_u64.rs` — runs in CI.
- `benches/lossless_u64.rs` — parser resolution overhead sweep.

## Fixes vs. #117

### S1 + S2 — dead runtime opt-in on the serializer side (fixed)

`SerializerConfig::lossless_u64_integers` was a runtime setter
that no code path ever read: `serialize_u64` gated purely on the
compile-time `cfg!(feature = "lossless-u64")` flag. Two
consequences:

1. The knob was dead code; setting or clearing it had no effect.
   The PR body claimed a runtime opt-in that didn't exist.
2. With the Cargo feature enabled, **any** `u64 > i64::MAX`
   silently auto-converted to `Number::Unsigned(v)` regardless of
   caller intent — the "opt-in" wording was misleading.

**Fix:** removed the setter, the field, and the `cfg!()` branch
in `serialize_u64`. The design is now honest: **the serializer
side of the feature is compile-time only**. Enabling the Cargo
feature is the opt-in.

### C1 — `#[non_exhaustive]` on `pub enum Number` (fixed)

Under `--all-features`, `cargo-semver-checks` flags a
non-non_exhaustive public enum with a cfg-added variant as a
major-breaking change. Marking `Number` as `#[non_exhaustive]`
lets `Unsigned` land safely under `cfg(feature = "lossless-u64")`
without breaking downstream match arms — future numeric variants
can follow the same pattern. Test suites that exhaustively
matched `Number` now include a `_ =>` arm.

### CP1 — dedicated CI feature-matrix job (added)

Standing rule from the v0.0.11 CI-integrity cut: every
specialised job MUST use its own `CARGO_TARGET_DIR` so a stale
artefact set cannot serve as a passing fingerprint. `lossless-u64`
had **no CI leg at all** in the original PR — it would have
shipped with zero coverage.

Adds `lossless-u64-matrix` (2 legs on isolated cache dirs):
1. `defaults` + lossless-u64 — typical opt-in user
2. `all-features` — feature × every other feature (including
   `compat-serde-yaml`), catches interference

Each leg runs `cargo check`, `cargo test --tests`, `cargo test --doc`.
The `examples/lossless_u64.rs` snippet also runs on the defaults
leg.

### S6 — DoS-budget × u64 proptest (added)

Zero-trust check: adding `Number::Unsigned` must not weaken any
of `max_depth`, `max_document_length`, `max_alias_expansions`,
`max_mapping_keys`, `max_sequence_length`. Adds 6 proptest
properties (`dos_limits_lossless_u64` module) that pair each
budget with a `u64::MAX`-adjacent scalar and assert the limit
fires. Also asserts that **no `u64::MAX`-adjacent scalar can
come back as `Number::Integer`** (wrap-to-negative is the classic
integer-confusion vector; explicitly banned).

All 6 pass.

## Retained but noted (not gated)

Two default-path improvements from the PR are retained:

- `value/serde_impl.rs:visit_u64` — routes through
  `Number::from(v)`. For `u64 > i64::MAX` on defaults it now
  produces `Number::Float` instead of the pre-PR wrapping
  `Number::Integer(v as i64)` (silent negative). The PR body's
  claim of "default parsing compatibility is unchanged" is
  technically false but the pre-PR behavior was silently wrong.
  Release notes will document.
- `BorrowedBuilder::plain_to_value` — extended plain-scalar
  handling (hex/oct/bin, legacy octals, sexagesimals) to reach
  parity with the owned path. Applies with the feature off; this
  is a legitimate borrowed-vs-owned parity fix.

## Test plan

- [ ] CI green on all checks (feature-matrix legs must land green)
- [ ] `cargo-semver-checks --features lossless-u64` clean against
      the just-published v0.0.12 baseline
- [ ] Manual review of the retained default-path improvements —
      decide whether to gate them or accept as intentional fixes
- [ ] Decide release cut: **not** v0.0.13 (that's the
      noyalib-mcp split per ADR-0005 pilot plan). Either v0.0.16
      after the split completes, or its own dedicated cut

## Verification (local)

- `cargo check --workspace` clean (feature off + on)
- `cargo test --workspace --lib` — 257 tests pass in both
  configurations
- `cargo test --workspace --tests` — full suite green with
  and without `--features lossless-u64`
- `cargo test -p noyalib --features lossless-u64 --test proptest dos_limits`
  — all 6 DoS × u64 properties pass
- `cargo run -p noyalib --example lossless_u64 --features lossless-u64`
  — runs cleanly

Refs #117 (original submission), ADR-0004.

Closes #117.