### PR TITLE
fix(loader): resolve duplicate mapping keys last-wins across span views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet - `[v0.0.12]` is the cut.)
+### Fixed
+
+- Duplicate mapping keys now resolve consistently across the typed
+  and span views. Under the default `DuplicateKeyPolicy::Last`, the
+  loader replaced a re-inserted key's value in place but *appended* a
+  second span entry, de-synchronising `Value::Mapping` from its
+  parallel `SpanTree`: `span_at` / `get` returned the shadowed first
+  occurrence, `Spanned<T>` fields positioned after a duplicate
+  carried a neighbour's span, and `remove` on a key following a
+  duplicate deleted the wrong line. The green-tree walker behind
+  `span_at` likewise stopped at the first matching key. Both layers
+  now select the last occurrence — the node `as_value` keeps — and
+  the walker defers to the typed cache when an undecodable
+  (double-quoted / complex) key could hide a duplicate.
+
+### Added
+
+- `Mapping::get_index_of` — index lookup by key, mirroring
+  `IndexMap::get_index_of`.
 
 ## [v0.0.12] - 2026-07-02
 

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -162,6 +162,12 @@ impl Document {
     /// `items[0]`, `items[0].name`). Wildcard / recursive-descent
     /// segments are not supported here — they have no single span.
     ///
+    /// A duplicated mapping key resolves to its *last* occurrence,
+    /// the same occurrence the typed view keeps (`as_value` loads
+    /// with the default `DuplicateKeyPolicy::Last`, the YAML 1.2
+    /// behaviour) — the returned span always denotes the node that
+    /// `as_value` selects for the path.
+    ///
     /// # Examples
     ///
     /// ```
@@ -170,6 +176,18 @@ impl Document {
     /// let doc = parse_document("name: noyalib\nversion: 0.0.1\n").unwrap();
     /// let (s, e) = doc.span_at("version").unwrap();
     /// assert_eq!(&doc.source()[s..e], "0.0.1");
+    /// ```
+    ///
+    /// A duplicate key resolves to the occurrence the typed view
+    /// keeps:
+    ///
+    /// ```
+    /// use noyalib::cst::parse_document;
+    ///
+    /// let doc = parse_document("k: one\nk: two\n").unwrap();
+    /// let (s, e) = doc.span_at("k").unwrap();
+    /// assert_eq!(&doc.source()[s..e], "two");
+    /// assert_eq!(doc.get("k"), Some("two"));
     /// ```
     #[must_use]
     pub fn span_at(&self, path: &str) -> Option<(usize, usize)> {
@@ -1192,21 +1210,42 @@ fn walk_mapping(
     base: usize,
     source: &str,
 ) -> Option<(usize, usize)> {
+    // Duplicate keys resolve to the *last* occurrence, matching the
+    // typed view: under the default `DuplicateKeyPolicy::Last` (the
+    // YAML 1.2 behaviour, and the config `as_value` loads with),
+    // `k: one\nk: two` yields `k = "two"`, so the span for `k` must
+    // denote `two` — never the bytes of a node the typed view did
+    // not select. The whole mapping is scanned before committing.
+    //
+    // An entry whose key text cannot be decoded here (double-quoted
+    // escapes, complex keys) could be a hidden duplicate of `key`,
+    // making the green walk inconclusive — bail out and let the
+    // caller resolve via the typed cache, which sees every key in
+    // decoded form.
+    let mut found: Option<(&GreenNode, usize)> = None;
+    let mut undecodable_key = false;
     let mut pos = base;
     for child in node.children() {
         let len = child.text_len();
         if let GreenChild::Node(entry) = child {
             if entry.kind() == SyntaxKind::MappingEntry {
-                if let Some(entry_key) = entry_key_text(entry, source, pos) {
-                    if entry_key == key {
-                        return resolve_value_in_entry(entry, pos, tail, source);
+                match entry_key_text(entry, source, pos) {
+                    Some(entry_key) => {
+                        if entry_key == key {
+                            found = Some((entry, pos));
+                        }
                     }
+                    None => undecodable_key = true,
                 }
             }
         }
         pos += len;
     }
-    None
+    if undecodable_key {
+        return None;
+    }
+    let (entry, entry_pos) = found?;
+    resolve_value_in_entry(entry, entry_pos, tail, source)
 }
 
 fn walk_sequence(

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -595,8 +595,20 @@ impl<'a> Loader<'a> {
                             }
                         }
                         DuplicateKeyPolicy::Last => {
-                            let _ = map.insert(key, value);
-                            span_entries.push((*key_span, span));
+                            // `IndexMap::insert` keeps a re-inserted key at
+                            // its original index, so the parallel span entry
+                            // must be replaced in place: pushing a second
+                            // entry would leave the stale first-occurrence
+                            // span selected for this key and shift the
+                            // span pairing of every key that follows the
+                            // duplicate by one.
+                            if let Some(idx) = map.get_index_of(&key) {
+                                let _ = map.insert(key, value);
+                                span_entries[idx] = (*key_span, span);
+                            } else {
+                                let _ = map.insert(key, value);
+                                span_entries.push((*key_span, span));
+                            }
                         }
                         DuplicateKeyPolicy::Error => {
                             if map.contains_key(&key) {

--- a/crates/noyalib/src/value/mapping.rs
+++ b/crates/noyalib/src/value/mapping.rs
@@ -261,6 +261,27 @@ impl Mapping {
         self.0.get_index_mut(index)
     }
 
+    /// Returns the index of the given key, if present.
+    ///
+    /// Indexing follows insertion order (this is an `IndexMap`); a key
+    /// keeps its original index when its value is overwritten by a
+    /// later [`Mapping::insert`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::{Mapping, Value};
+    /// let mut m = Mapping::new();
+    /// m.insert("first", Value::from(1_i64));
+    /// m.insert("second", Value::from(2_i64));
+    /// assert_eq!(m.get_index_of("second"), Some(1));
+    /// assert_eq!(m.get_index_of("absent"), None);
+    /// ```
+    #[must_use]
+    pub fn get_index_of(&self, key: &str) -> Option<usize> {
+        self.0.get_index_of(key)
+    }
+
     /// Removes a key from the mapping, returning the value if the key was
     /// present.
     ///

--- a/crates/noyalib/tests/dup_key_spans.rs
+++ b/crates/noyalib/tests/dup_key_spans.rs
@@ -1,0 +1,174 @@
+//! Duplicate-key span resolution.
+//!
+//! Under the default `DuplicateKeyPolicy::Last`, the typed view
+//! (`as_value`, `from_str`) keeps the value of the *last* occurrence of
+//! a duplicated mapping key. Every span-shaped accessor of the same
+//! document — `span_at`, `get`, `Spanned<T>` deserialization — and the
+//! path-shaped edits built on them (`set`, `remove`) must select that
+//! same occurrence: a consumer must never be handed the bytes of a node
+//! the typed view did not select.
+
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+use noyalib::cst::parse_document;
+use noyalib::{Spanned, from_str};
+use serde::Deserialize;
+
+/// Parse `src`, resolve `path`, and return the raw source slice the
+/// span denotes.
+fn slice_at(src: &str, path: &str) -> String {
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc
+        .span_at(path)
+        .unwrap_or_else(|| panic!("no span for path {path:?} in {src:?}"));
+    doc.source()[s..e].to_owned()
+}
+
+#[test]
+fn span_at_duplicate_key_selects_last_occurrence() {
+    assert_eq!(slice_at("k: one\nk: two\n", "k"), "two");
+}
+
+#[test]
+fn get_matches_typed_view_for_duplicate_key() {
+    let doc = parse_document("k: one\nk: two\n").unwrap();
+    let typed = {
+        let value = doc.as_value();
+        let map = value.as_mapping().expect("root is a mapping");
+        map.get("k").and_then(|v| v.as_str()).unwrap().to_owned()
+    };
+    assert_eq!(typed, "two");
+    assert_eq!(doc.get("k"), Some("two"));
+}
+
+#[test]
+fn span_at_sibling_after_duplicate_is_unshifted() {
+    // A duplicate earlier in the mapping must not shift the span
+    // pairing of the keys that follow it.
+    assert_eq!(slice_at("k: one\nk: two\nz: 3\n", "z"), "3");
+}
+
+#[test]
+fn typed_fallback_stays_aligned_after_duplicate() {
+    // A double-quoted key is not decodable by the green-tree walker,
+    // so every path in this document resolves through the typed
+    // cache — this exercises the `Value`/`SpanTree` zip alignment.
+    let src = "\"q\": 0\nk: one\nk: two\nz: 3\n";
+    assert_eq!(slice_at(src, "q"), "0");
+    assert_eq!(slice_at(src, "k"), "two");
+    assert_eq!(slice_at(src, "z"), "3");
+}
+
+#[test]
+fn span_at_nested_duplicate_selects_last_occurrence() {
+    assert_eq!(slice_at("m:\n  k: one\n  k: two\n", "m.k"), "two");
+}
+
+#[test]
+fn span_at_flow_mapping_duplicate_selects_last_occurrence() {
+    assert_eq!(slice_at("m: {k: 1, k: 2}\n", "m.k"), "2");
+}
+
+#[test]
+fn span_at_duplicate_across_quote_styles() {
+    // Plain and single-quoted spellings of the same key are both
+    // decodable by the green-tree walker; last-wins applies across
+    // spellings, in either order.
+    assert_eq!(slice_at("'k': one\nk: two\n", "k"), "two");
+    assert_eq!(slice_at("k: one\n'k': two\n", "k"), "two");
+}
+
+#[test]
+fn span_at_double_quoted_duplicate_falls_back_to_typed_view() {
+    // The double-quoted occurrence is invisible to the green-tree
+    // walker. It must not silently resolve the plain occurrence —
+    // the typed view decides, and it keeps the last occurrence.
+    assert_eq!(slice_at("k: one\n\"k\": two\n", "k"), "two");
+    assert_eq!(slice_at("\"k\": one\nk: two\n", "k"), "two");
+}
+
+#[test]
+fn span_at_triple_duplicate_selects_final_occurrence() {
+    assert_eq!(slice_at("k: a\nk: b\nk: c\n", "k"), "c");
+}
+
+#[test]
+fn span_at_recurses_into_the_winning_occurrence() {
+    // The typed view keeps the last `k`, so `k.a` (present only in
+    // the shadowed first occurrence) is absent, while `k.b` resolves
+    // inside the second occurrence's subtree.
+    let src = "k:\n  a: 1\nk:\n  b: 2\n";
+    let doc = parse_document(src).unwrap();
+    assert_eq!(doc.span_at("k.a"), None);
+    assert_eq!(slice_at(src, "k.b"), "2");
+}
+
+#[test]
+fn set_edits_the_occurrence_the_typed_view_selects() {
+    let mut doc = parse_document("k: one\nk: two\n").unwrap();
+    doc.set("k", "three").unwrap();
+    assert_eq!(doc.to_string(), "k: one\nk: three\n");
+}
+
+#[test]
+fn remove_sibling_after_duplicate_removes_the_right_line() {
+    let mut doc = parse_document("k: 1\nk: 2\nz: 3\n").unwrap();
+    doc.remove("z").unwrap();
+    assert_eq!(doc.to_string(), "k: 1\nk: 2\n");
+}
+
+#[test]
+fn remove_sibling_after_duplicate_is_correct_with_a_merge_key() {
+    // A merge key (`<<`) is applied at mapping-end without a span
+    // entry, and a duplicate key collapses in the typed map — both
+    // stress the map/span-entry alignment `remove` relies on. The
+    // sibling `z` must still delete its own line, not a neighbour's.
+    let src = "base: &b\n  x: 1\nm:\n  <<: *b\n  k: one\n  k: two\n  z: 3\n";
+    let mut doc = parse_document(src).unwrap();
+    doc.remove("m.z").unwrap();
+    assert_eq!(
+        doc.to_string(),
+        "base: &b\n  x: 1\nm:\n  <<: *b\n  k: one\n  k: two\n"
+    );
+}
+
+#[test]
+fn remove_of_a_duplicated_key_targets_the_typed_view_occurrence() {
+    // `remove` resolves a single span, so it deletes one line — the
+    // last occurrence, the one the typed view keeps. The shadowed
+    // first occurrence is left in place (an inherent limit of
+    // single-span addressing for duplicate keys), but the line that
+    // *is* removed is the winning one.
+    let mut doc = parse_document("k: one\nk: two\nz: 3\n").unwrap();
+    doc.remove("k").unwrap();
+    assert_eq!(doc.to_string(), "k: one\nz: 3\n");
+}
+
+#[test]
+fn spanned_fields_stay_aligned_after_duplicate_key() {
+    #[derive(Debug, Deserialize)]
+    struct Config {
+        k: Spanned<String>,
+        z: Spanned<i64>,
+    }
+
+    let src = "k: one\nk: two\nz: 3\n";
+    let config: Config = from_str(src).unwrap();
+    // Raw event spans may include the scalar's trailing line break
+    // (only `span_at` trims trailing blanks), so compare trimmed:
+    // what these assertions pin is occurrence selection and
+    // alignment, not the exact extent.
+    assert_eq!(config.k.value, "two");
+    assert_eq!(
+        src[config.k.start.index()..config.k.end.index()].trim_end(),
+        "two",
+        "Spanned span for a duplicated key must cover the winning occurrence"
+    );
+    assert_eq!(config.z.value, 3);
+    assert_eq!(
+        src[config.z.start.index()..config.z.end.index()].trim_end(),
+        "3",
+        "Spanned span after a duplicate key must not be shifted"
+    );
+}


### PR DESCRIPTION
## Summary

Under the default `DuplicateKeyPolicy::Last`, the typed view (`as_value` / `from_str`) keeps the value of the **last** occurrence of a duplicated mapping key — the YAML 1.2 behaviour, matching every other loader and jq. But the span-shaped accessors disagreed:

```yaml
k: one
k: two
```

`as_value()["k"]` is `"two"`, yet `span_at("k")` returned the span of the **first** `k` (`one`). A consumer that reads the typed value and then asks for its bytes was handed a node the typed view did not select — a wrong-node hazard.

## Root cause

A de-synchronisation between `Value::Mapping` and its parallel `SpanTree`. `IndexMap::insert` overwrites a re-inserted key's value in place (keeping its original index), but the loader **appended** a second span entry for every source occurrence. After a duplicate the two structures had different lengths, so the zip-based resolvers (`resolve_span`, `build_span_map`, `entry_line_span`) paired each key with the wrong span tree. For keys at or after a duplicate this broke:

- `span_at` / `get` returned the shadowed first occurrence;
- `Spanned<T>` fields carried a neighbouring field's span;
- `Document::remove` deleted the wrong line (removing a sibling after a duplicate spliced out the duplicate's line instead).

The green-tree fast path behind `span_at` (`walk_mapping`) had the same first-wins bug independently — it returned on the first key match.

## Fix

Both layers now select the last occurrence:

- **Loader** (`DuplicateKeyPolicy::Last`): replace the span entry in place at the key's existing `IndexMap` index instead of pushing a duplicate, keeping the map and span-entry vectors the same length and order. `First` and `Error` policies are unchanged.
- **Green walker** (`walk_mapping`): scan the whole mapping and keep the last matching key. If any entry key is undecodable here (double-quoted escapes, complex keys) it could hide a duplicate, so it bails to the typed cache, which sees every key decoded.

Adds `Mapping::get_index_of` (delegates to `IndexMap::get_index_of`) for the in-place replacement, a `span_at` doc paragraph + doctest, and a 15-case regression suite (`tests/dup_key_spans.rs`).

## Tests

`tests/dup_key_spans.rs` covers block / flow / nested / mixed-quote / triple duplicates, typed-cache fallback for double-quoted duplicates, recursion into the winning occurrence, and the `set` / `remove` / merge-key-coexistence / `Spanned<T>` alignment paths. All 15 fail on `main` and pass with this change; the full suite (`make`: check + clippy + test, 476 tests + doctests) is green.

Follows the precedent set by #118 / #123 (single-theme span/scanner fix; upstream issues are disabled).