### PR TITLE
docs(npm): reflect actual @sebastienrousseau scope for noyalib-wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ convention.
   satellites; the `noyalib-wasm` cross-check moves to the
   satellite's own release workflow.
 - `release-binaries.yml` drops the `npm-publish` job for
-  `@noyalib/noyalib-wasm`. That publish now runs from the
+  `@sebastienrousseau/noyalib-wasm`. That publish now runs from the
   satellite repo.
 - Coverage `ignore-filename-regex` in `.github/workflows/ci.yml`,
   `shared-coverage.yml`, and `scripts/coverage-gap-report.sh`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ library's dependency graph for downstream embedders).
 | Scoop (Windows) | `scoop bucket add sebastienrousseau https://github.com/sebastienrousseau/scoop-bucket && scoop install noyalib` |
 | Nix / NixOS | `nix run github:sebastienrousseau/noyalib` |
 | Container (GHCR) | `docker run --rm ghcr.io/sebastienrousseau/noyafmt:latest --version` |
-| npm (WASM) | `npm install @noyalib/noyalib-wasm` |
+| npm (WASM) | `npm install @sebastienrousseau/noyalib-wasm` |
 | npm (MCP) | `npx noyalib-mcp` (no Rust toolchain needed) |
 | VS Code | search `noyalib` in the Marketplace |
 | Open VSX | search `noyalib` in [open-vsx.org](https://open-vsx.org) |
@@ -239,7 +239,7 @@ cargo install noyalib-lsp
 cargo install noyalib-mcp
 
 # WASM bundle
-npm install @noyalib/noyalib-wasm
+npm install @sebastienrousseau/noyalib-wasm
 ```
 
 Per-crate READMEs cover the surface specific to each artifact:

--- a/RELEASE-NOTES-v0.0.12.md
+++ b/RELEASE-NOTES-v0.0.12.md
@@ -19,7 +19,7 @@ change (still 1.85). Users pulling
 crates.io see no behaviour change beyond a version bump.
 Users pulling `noyalib-wasm` from crates.io / npm also see no
 behaviour change — the same `=0.0.12` version and same
-`@noyalib/noyalib-wasm` npm package continue to publish, just
+`@sebastienrousseau/noyalib-wasm` npm package continue to publish, just
 from
 [`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm)
 now instead of this repo's `crates/noyalib-wasm/`
@@ -77,7 +77,7 @@ they're built against.
   settle → `noya-cli`, `noyalib-mcp`, `noyalib-lsp` in
   parallel.
 - `release-binaries.yml` drops the `npm-publish` job for
-  `@noyalib/noyalib-wasm`. That npm publish moves to the
+  `@sebastienrousseau/noyalib-wasm`. That npm publish moves to the
   satellite repo's release workflow, still using Trusted
   Publishing + npm provenance.
 - Coverage `ignore-filename-regex` in `.github/workflows/ci.yml`
@@ -108,7 +108,7 @@ publishes:
 
 - The `noyalib-wasm` crate on crates.io (same name, same
   version as the workspace).
-- The `@noyalib/noyalib-wasm` npm package on npmjs.org (same
+- The `@sebastienrousseau/noyalib-wasm` npm package on npmjs.org (same
   name, same version).
 - SLSA L3 build provenance attestation (via
   `actions/attest-build-provenance`).
@@ -140,7 +140,7 @@ for downstream users.
   `0.0.12`. No API changes.
 - **`noyalib-wasm` users on crates.io**: same as above.
   Update from `0.0.11` to `0.0.12`.
-- **`@noyalib/noyalib-wasm` npm users**: same. The npm
+- **`@sebastienrousseau/noyalib-wasm` npm users**: same. The npm
   publish moved repositories but not identity.
 - **Downstream repos vendoring the monorepo**: if you had a
   `path = "crates/noyalib-wasm"` reference, switch to

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -568,7 +568,7 @@ Three satellite crates target specific deployment shapes:
 
 - **`noyalib-wasm`** ([`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm)).
   `wasm-pack` output published to npm as
-  `@noyalib/noyalib-wasm`. Browser IDEs use it for live YAML
+  `@sebastienrousseau/noyalib-wasm`. Browser IDEs use it for live YAML
   formatting / validation; the bundle is ~338 KB after LTO.
   Split to its own repo in v0.0.12 (ADR-0005); releases in
   strict lockstep with this workspace.


### PR DESCRIPTION
## Summary

Parent-repo docs still referenced the pre-publish plan of
`@noyalib/noyalib-wasm`. The v0.0.12 first-time npm publish
actually landed as
[`@sebastienrousseau/noyalib-wasm`](https://www.npmjs.com/package/@sebastienrousseau/noyalib-wasm)
(npm scopes must match the publisher's username unless an npm
org is registered first). This PR realigns the parent-repo docs
so anyone following the workspace-split narrative or ecosystem
table gets the correct npm install command.

## Files touched

- `README.md` — install snippets in the ecosystem table + Quick Start.
- `doc/USER-GUIDE.md` §12 (WASM/MCP/LSP) — npm package name.
- `RELEASE-NOTES-v0.0.12.md` — 4 refs in the workspace-split narrative.
- `CHANGELOG.md` — v0.0.12 entry only. Older entries (v0.0.6 etc.)
  are left alone since they describe pre-split plans and are
  historical.

Zero code changes. Zero changes to the crate side (crates.io
`noyalib-wasm` unaffected — Cargo doesn't have npm-style scopes).

Companion PR on the satellite:
[sebastienrousseau/noyalib-wasm#3](https://github.com/sebastienrousseau/noyalib-wasm/pull/3)
— updates `release.yml`'s `wasm-pack --scope sebastienrousseau`
flag and the satellite's own README badges + install snippets.

## Test plan

- [ ] CI green
- [ ] Merge (squash)
- [ ] Merge the satellite companion PR too
- [ ] Configure npm Trusted Publisher on npmjs.org for
      `@sebastienrousseau/noyalib-wasm` bound to
      `sebastienrousseau/noyalib-wasm` + `release.yml`

## Follow-up

If we ever register the `@noyalib` npm org, a follow-up PR
can rename back. Until then, `@sebastienrousseau/noyalib-wasm`
is the canonical npm name.

Refs #129 (v0.0.12 pilot), ADR-0005.