### PR TITLE
fix(cst): keep-chomped block scalars retain kept trailing blanks in span_at

### DIFF
--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -199,7 +199,7 @@ impl Document {
         // through `set` / `set_value` no longer warms the typed
         // cache between iterations.
         if let Some((s, e)) = resolve_path_in_green(&self.green, &segments, &self.source) {
-            return Some(trim_trailing_blank(&self.source, s, e));
+            return Some(trim_value_span(&self.source, s, e));
         }
         // Fallback for paths the green-tree walker doesn't
         // currently handle — e.g. quoted keys with escapes,
@@ -208,7 +208,7 @@ impl Document {
         let cache = self.cache.borrow();
         let (value, span_tree) = cache.as_ref().expect("ensure_cache populated");
         let (s, e) = resolve_span(value, span_tree, &segments)?;
-        Some(trim_trailing_blank(&self.source, s, e))
+        Some(trim_value_span(&self.source, s, e))
     }
 
     /// Populate the typed cache from `self.source` if it is empty.
@@ -1490,6 +1490,42 @@ fn trim_trailing_blank(source: &str, start: usize, mut end: usize) -> (usize, us
         }
     }
     (start, end)
+}
+
+/// Trim trailing separator whitespace from a *value* span, except for
+/// keep-chomped (`|+` / `>+`) block scalars, whose trailing line breaks are
+/// content rather than separation. Trimming those would yield a slice that
+/// re-parses to a shorter, different value (`"kept\n"` instead of the true
+/// `"kept\n\n\n"`).
+fn trim_value_span(source: &str, start: usize, end: usize) -> (usize, usize) {
+    if is_keep_chomped_block_scalar(source, start, end) {
+        (start, end)
+    } else {
+        trim_trailing_blank(source, start, end)
+    }
+}
+
+/// Whether `[start, end)` denotes a keep-chomped block scalar: it begins with
+/// a `|` / `>` block indicator carrying a `+` chomping indicator on the header
+/// line (`|+`, `>+`, `|+2`, `|2+`). A value span's start is the block
+/// indicator itself (the scanner marks it there), and no plain/quoted scalar
+/// or collection value begins with a bare `|` / `>`, so this cannot misfire on
+/// other node kinds.
+fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool {
+    let bytes = source.as_bytes();
+    if start >= end || (bytes[start] != b'|' && bytes[start] != b'>') {
+        return false;
+    }
+    // A `+` anywhere on the header line (before the first line break) is the
+    // keep-chomping indicator.
+    for &b in &bytes[start + 1..end] {
+        match b {
+            b'\n' | b'\r' => return false,
+            b'+' => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn resolve_span(

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -768,6 +768,44 @@ fn coverage_doc_span_at_mapping_value_is_a_sequence() {
     assert!(txt.contains("- one"));
 }
 
+// ── Keep-chomped block scalars retain their kept trailing blanks ────
+
+#[test]
+fn coverage_doc_span_at_keep_chomped_block_scalar_keeps_trailing_blanks() {
+    // `|+` chomping keeps trailing line breaks as *content*. The value
+    // span must include them; trimming (as clip/strip spans do) would
+    // yield a slice that re-parses to a shorter, different value.
+    let src = "key: |+\n  kept\n\n\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("key").unwrap();
+    assert_eq!(&doc.source()[s..e], "|+\n  kept\n\n\n");
+    // The slice re-parses to exactly the scalar's value.
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    assert_eq!(reparsed, Value::String("kept\n\n\n".to_string()));
+}
+
+#[test]
+fn coverage_doc_span_at_folded_keep_chomped_keeps_trailing_blanks() {
+    // Same for the folded (`>+`) keep-chomped form.
+    let src = "key: >+\n  kept\n\n\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("key").unwrap();
+    assert_eq!(&doc.source()[s..e], ">+\n  kept\n\n\n");
+}
+
+#[test]
+fn coverage_doc_span_at_clip_and_strip_block_scalars_still_trim() {
+    // Clip (`|`) and strip (`|-`) block scalars do NOT own trailing
+    // blank lines, so their value span is trimmed as before.
+    let clip = parse_document("key: |\n  kept\n\n\n").unwrap();
+    let (s, e) = clip.span_at("key").unwrap();
+    assert_eq!(&clip.source()[s..e], "|\n  kept");
+
+    let strip = parse_document("key: |-\n  kept\n\n\n").unwrap();
+    let (s, e) = strip.span_at("key").unwrap();
+    assert_eq!(&strip.source()[s..e], "|-\n  kept");
+}
+
 // ── resolve_span sequence index out-of-bounds typed-cache fallback ──
 
 #[test]


### PR DESCRIPTION
Found while building a byte-fidelity YAML tool on noyalib's lossless CST. One of a short, independent series of span/loader faithfulness fixes in the spirit of the accepted #143 (duplicate-key last-wins).

---

A `|+` / `>+` block scalar keeps its trailing line breaks as content
(chomping indicator `+`). span_at unconditionally passed every resolved
value span through trim_trailing_blank, which strips trailing
' '/'\t'/'\n'/'\r'. For keep-chomped scalars those trailing newlines are
value bytes, so the returned slice re-parsed to a shorter, different
value (`"kept\n"` instead of `"kept\n\n\n"`).

span_at now trims value spans via trim_value_span, which leaves
keep-chomped block-scalar spans intact and delegates every other node to
trim_trailing_blank unchanged. Detection keys on a leading `|`/`>` block
indicator (the value span's start, where the scanner marks it) carrying a
`+` on its header line, so clip (`|`,`>`), strip (`|-`,`>-`), and all
non-block scalars trim exactly as before.

span_at only reports byte indices and never mutates the source, so
source() and the byte-for-byte round-trip are unaffected; the fix only
widens the reported end back to the value bytes the green leaf already
owns.

Adds cst_document_coverage tests for `|+`/`>+` retention and `|`/`|-`
trimming.

