### PR TITLE
fix(cst): resolve alias references through to the anchor value span

### DIFF
--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1386,10 +1386,17 @@ fn entry_value(
                     if *kind == SyntaxKind::ColonIndicator {
                         after_colon = true;
                     }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // An alias reference (`*name`) is a single token with
+                    // no value node of its own; its bytes are a dangling
+                    // alias that does not re-parse standalone. Bail so
+                    // span_at falls back to the typed cache, whose SpanTree
+                    // resolves the alias through to its anchor definition's
+                    // self-contained value span.
+                    return None;
                 } else if is_value_property_kind(*kind) {
-                    // `!Tag` / `&anchor` / `*alias` prefix —
-                    // remember the earliest start and keep
-                    // scanning for the scalar that follows.
+                    // `!Tag` / `&anchor` prefix — remember the earliest
+                    // start and keep scanning for the scalar that follows.
                     let _ = prefix_start.get_or_insert(child_start);
                 } else if !is_trivia_kind(*kind) {
                     let start = prefix_start.unwrap_or(child_start);
@@ -1433,6 +1440,10 @@ fn item_value(
                     if *kind == SyntaxKind::DashIndicator {
                         after_dash = true;
                     }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // Alias reference as a sequence item: bail to the typed
+                    // cache, which resolves it to the anchor's value span.
+                    return None;
                 } else if is_value_property_kind(*kind) {
                     let _ = prefix_start.get_or_insert(child_start);
                 } else if !is_trivia_kind(*kind) {
@@ -1473,10 +1484,10 @@ fn is_trivia_kind(k: SyntaxKind) -> bool {
 /// tag and the quoted scalar) rather than `6..13` (the tag
 /// alone, which was the pre-fix behaviour).
 fn is_value_property_kind(k: SyntaxKind) -> bool {
-    matches!(
-        k,
-        SyntaxKind::AnchorMark | SyntaxKind::TagMark | SyntaxKind::AliasMark
-    )
+    // Alias marks are handled separately (they bail the green walk to the
+    // typed cache); only anchor/tag definition prefixes stretch the value
+    // span to cover the property plus the scalar / node that follows.
+    matches!(k, SyntaxKind::AnchorMark | SyntaxKind::TagMark)
 }
 
 // ── Path resolution ─────────────────────────────────────────────────

--- a/crates/noyalib/tests/cst_tag_span.rs
+++ b/crates/noyalib/tests/cst_tag_span.rs
@@ -41,3 +41,38 @@ fn entry_get_returns_full_tagged_value() {
     let entry = doc.entry("name");
     assert_eq!(entry.get(), Some("!Custom 'app-1'"));
 }
+
+// Regression: an alias *reference* must resolve through to its anchor
+// definition's self-contained value span, not slice as the dangling
+// `*name` lexeme (which does not re-parse standalone).
+
+#[test]
+fn span_at_alias_reference_resolves_through_to_anchor_collection() {
+    use noyalib::cst::parse_document;
+    let src = "a: &anc [1, 2]\nb: *anc\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("b").unwrap();
+    // The anchor definition's flow-sequence value, not `*anc`.
+    assert_eq!(&src[s..e], "[1, 2]");
+    // Anchor definition itself is unchanged.
+    let (s, e) = doc.span_at("a").unwrap();
+    assert_eq!(&src[s..e], "&anc [1, 2]");
+}
+
+#[test]
+fn span_at_alias_reference_resolves_through_to_anchor_scalar() {
+    use noyalib::cst::parse_document;
+    let src = "a: &x 1\nb: *x\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("b").unwrap();
+    assert_eq!(&src[s..e], "1");
+}
+
+#[test]
+fn span_at_alias_reference_as_sequence_item_resolves_through() {
+    use noyalib::cst::parse_document;
+    let src = "defs: &d [1, 2]\nuse:\n  - *d\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("use[0]").unwrap();
+    assert_eq!(&src[s..e], "[1, 2]");
+}


### PR DESCRIPTION
Found while building a byte-fidelity YAML tool on noyalib's lossless CST. One of a short, independent series of span/loader faithfulness fixes in the spirit of the accepted #143 (duplicate-key last-wins).

---

span_at on an alias reference (`b: *anc`) returned the dangling `*anc`
lexeme — a standalone alias that does not re-parse and is asymmetric with
anchor definitions (`&x 1`), whose slice is self-contained. An alias is a
single AliasMark token with no value node, and the green-tree walker
lumped AliasMark in with anchor/tag property prefixes, returning the
alias's own bytes instead of bailing.

The walker (entry_value / item_value) now returns None on an AliasMark so
span_at falls through to the typed cache, whose SpanTree carries the
alias node's cloned anchor-definition span (the loader resolves aliases
at load time). AliasMark is dropped from is_value_property_kind; anchor
and tag definition prefixes keep their inclusive span behavior.

Result: span_at("b") on `a: &anc [1, 2]\nb: *anc` returns `[1, 2]`
(re-parseable) instead of `*anc`; anchor definitions are unchanged.
span_at only reports byte offsets, so source() and round-trip are
unaffected.

Adds cst_tag_span regression tests for alias references to a collection,
to a scalar, and as a sequence item.

