### PR TITLE
fix(cst): block-collection value spans include their first line's indent

### DIFF
--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1324,6 +1324,32 @@ fn decode_single_quoted(raw: &str) -> Option<Cow<'_, str>> {
 /// Find the value position inside a `MappingEntry` and either
 /// return its byte range (if `tail` is empty) or recurse into it
 /// with `tail`.
+/// Whether a resolved value node is a block (indentation-structured)
+/// collection, whose span begins on its own source line.
+fn is_block_collection(k: SyntaxKind) -> bool {
+    matches!(k, SyntaxKind::BlockMapping | SyntaxKind::BlockSequence)
+}
+
+/// Back `start` up over the inline whitespace that indents a value's first
+/// line, but only when that value begins its own line (the whitespace run is
+/// preceded by a line break or the start of input). A value that shares its
+/// line with a `-` / `:` / `{` (e.g. the inner sequence of `- - a`) is left
+/// untouched. This makes a block collection's slice uniformly indented — its
+/// first line keeps the indentation the following lines already carry — so it
+/// re-parses to the selected value instead of silently re-nesting.
+fn extend_to_line_start(source: &str, start: usize) -> usize {
+    let b = source.as_bytes();
+    let mut i = start;
+    while i > 0 && matches!(b[i - 1], b' ' | b'\t') {
+        i -= 1;
+    }
+    if i == 0 || matches!(b[i - 1], b'\n' | b'\r') {
+        i
+    } else {
+        start
+    }
+}
+
 fn resolve_value_in_entry(
     entry: &GreenNode,
     base: usize,
@@ -1332,17 +1358,19 @@ fn resolve_value_in_entry(
 ) -> Option<(usize, usize)> {
     let (value_kind, value_range, value_node) = entry_value(entry, base)?;
     if tail.is_empty() {
-        return Some(value_range);
+        // A block collection's node starts at its first key/item token,
+        // leaving its first line's indentation just outside the span; widen
+        // to the line start so the slice is uniformly indented.
+        let start = if is_block_collection(value_kind) {
+            extend_to_line_start(source, value_range.0)
+        } else {
+            value_range.0
+        };
+        return Some((start, value_range.1));
     }
     // Recursing further requires the value to be a composite.
     let node = value_node?;
-    walk_path(node, tail, value_range.0, source).map(|(s, e)| {
-        // Defensive: ensure recursion stays inside the value's
-        // span — composite parents may contain trailing trivia
-        // that's outside the conceptual "value" range.
-        let _ = value_kind;
-        (s, e)
-    })
+    walk_path(node, tail, value_range.0, source)
 }
 
 fn resolve_value_in_item(
@@ -1351,9 +1379,14 @@ fn resolve_value_in_item(
     tail: &[QuerySegment],
     source: &str,
 ) -> Option<(usize, usize)> {
-    let (_, value_range, value_node) = item_value(item, base)?;
+    let (value_kind, value_range, value_node) = item_value(item, base)?;
     if tail.is_empty() {
-        return Some(value_range);
+        let start = if is_block_collection(value_kind) {
+            extend_to_line_start(source, value_range.0)
+        } else {
+            value_range.0
+        };
+        return Some((start, value_range.1));
     }
     let node = value_node?;
     walk_path(node, tail, value_range.0, source)

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -768,6 +768,51 @@ fn coverage_doc_span_at_mapping_value_is_a_sequence() {
     assert!(txt.contains("- one"));
 }
 
+// ── Block-collection value spans include their first line's indent ──
+
+#[test]
+fn coverage_doc_span_at_block_mapping_value_is_uniformly_indented() {
+    // The value span must include the first line's indentation so the
+    // slice is uniformly indented and re-parses to the selected value.
+    let src = "config:\n  debug: true\n  level: info\nafter: 1\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("config").unwrap();
+    assert_eq!(&doc.source()[s..e], "  debug: true\n  level: info");
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    assert_eq!(reparsed, doc.as_value().get("config").cloned().unwrap());
+}
+
+#[test]
+fn coverage_doc_span_at_nested_block_sequence_does_not_renest() {
+    // Regression: a dedented first line ('- alpha\n    - beta') silently
+    // re-parses as the single scalar ["alpha - beta"]. The uniformly
+    // indented slice re-parses to the real two-element sequence.
+    let src = "spec:\n  items:\n    - alpha\n    - beta\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("spec.items").unwrap();
+    assert_eq!(&doc.source()[s..e], "    - alpha\n    - beta");
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    // Two elements, not one folded scalar.
+    assert_eq!(reparsed.as_sequence().map(|s| s.len()), Some(2));
+    let expected = doc
+        .as_value()
+        .get("spec")
+        .and_then(|s| s.get("items"))
+        .cloned()
+        .unwrap();
+    assert_eq!(reparsed, expected);
+}
+
+#[test]
+fn coverage_doc_span_at_same_line_nested_sequence_not_extended() {
+    // The inner sequence of `- - a` shares its line with the outer `-`,
+    // so its span must NOT be widened over the `- ` prefix.
+    let src = "outer:\n  - - a\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("outer[0]").unwrap();
+    assert_eq!(&doc.source()[s..e], "- a");
+}
+
 // ── resolve_span sequence index out-of-bounds typed-cache fallback ──
 
 #[test]


### PR DESCRIPTION
Found while building a byte-fidelity YAML tool on noyalib's lossless CST. One of a short, independent series of span/loader faithfulness fixes in the spirit of the accepted #143 (duplicate-key last-wins).

---

span_at on a block mapping/sequence value returned a span starting at the
first key/item token, leaving the first line's indentation just outside
the span. The raw slice was dedented on line one only, so a nested
sequence like `- alpha\n    - beta` re-parsed as the single folded scalar
["alpha - beta"] and a mapping value came back mis-indented.

resolve_value_in_entry / resolve_value_in_item now widen a block
collection value's start to its line start (over the inline indentation),
but only when the value begins its own line — a value sharing its line
with a `-`/`:` (e.g. the inner sequence of `- - a`) is left untouched.
The slice is then uniformly indented and re-parses to the selected value.
Flow collections and scalars are unaffected.

span_at only reports byte offsets over existing source, so source() and
the byte-for-byte round-trip are unchanged; start only ever moves left
across pre-existing indentation, never past a line boundary.

Adds cst_document_coverage tests for block-mapping indent inclusion,
nested block-sequence non-renesting (with re-parse check), and the
same-line `- - a` no-extend case.

