### PR TITLE
release: v0.0.14 — loader-parity cut, review-hardened (KeyCollision + CST edit guards)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           path: results.sarif
           retention-days: 7
 
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
 
   # ── Soak fuzz (weekly) ─────────────────────────────────────────────
   # Long-running fuzz campaigns that don't fit the per-push budget.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           languages: actions
 

--- a/.github/workflows/shared-coverage.yml
+++ b/.github/workflows/shared-coverage.yml
@@ -74,7 +74,7 @@ jobs:
           workspaces: ". -> target-coverage"
           key: coverage-nightly
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
           tool: cargo-llvm-cov
       - name: "Coverage report"

--- a/.github/workflows/shared-no-std.yml
+++ b/.github/workflows/shared-no-std.yml
@@ -50,5 +50,28 @@ jobs:
           # CARGO_TARGET_DIR above is the real guarantee.
           workspaces: ". -> target-no-std"
           key: no-std
-      - name: cargo check --no-default-features
+      - name: cargo check --no-default-features (native target)
         run: cargo check --no-default-features --lib --locked
+
+  # Bare-metal proof: `wasm32-unknown-unknown` has no `std`
+  # libraries available, so any leaked `std::` symbol fails to
+  # link. The native-target check above catches feature-flag
+  # drift; this one catches a transitive dep silently enabling
+  # `std` via feature unification.
+  wasm-bare:
+    name: no_std (wasm32-unknown-unknown bare-metal)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-no-std-wasm
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-no-std-wasm"
+          key: no-std-wasm
+      - name: cargo check --no-default-features --target wasm32-unknown-unknown
+        run: cargo check --no-default-features --lib --locked --target wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,104 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet - `[v0.0.13]` is the cut.)
+(Nothing yet — `[v0.0.14]` is the cut.)
+
+## [v0.0.14] - 2026-07-07
+
+The **loader-parity** cut. Fixes a fast-path silent-collapse of
+distinct-typed mapping keys plus three DoS-budget parity gaps
+between the span-full and span-free loaders, adds a coarse
+`Error::kind()` classifier for downstream routing, and lands
+five CST `span_at` fixes and one scanner lone-CR fix.
+
+Lockstep versioning: `noyalib` bumps `0.0.13` → `0.0.14`.
+Satellites publish `=0.0.14` from their own repos:
+- [`sebastienrousseau/noyalib-wasm@0.0.14`](https://github.com/sebastienrousseau/noyalib-wasm)
+- [`sebastienrousseau/noyalib-mcp@0.0.14`](https://github.com/sebastienrousseau/noyalib-mcp)
+- [`sebastienrousseau/noyalib-lsp@0.0.14`](https://github.com/sebastienrousseau/noyalib-lsp)
+- [`sebastienrousseau/noya-cli@0.0.14`](https://github.com/sebastienrousseau/noya-cli)
+
+### Fixed — loader parity (security)
+
+- **`from_str::<Value>` no longer silently collapses distinct-
+  typed key collisions.** The fast `Value` path
+  (`parse_one_value` → `NoSpanLoader`) previously accepted
+  `1: a\n"1": b\n` and dropped the first entry — data loss.
+  The `NoSpanLoader` now runs the same distinct-typed-key
+  check as the span-full loader and raises
+  `Error::KeyCollision` instead. The streaming fast-path is
+  bypassed for the `Value` target when no tag registry is
+  active, so the collision check is reachable there too.
+- **DoS-budget parity on the `Value` fast path.** `NoSpanLoader`
+  now enforces `max_sequence_length`, `max_mapping_keys`,
+  `max_merge_keys`, `max_document_length` (via `alias_bytes`),
+  and `MergeKeyPolicy::Error` — all previously span-full-only.
+- **`DuplicateKeyPolicy` parity.** `NoSpanLoader` now honours
+  `First` / `Last` / `Error` on the `Value` fast path instead
+  of always defaulting to last-wins.
+- **`from_str_with_config` enforces `max_document_length` inline.**
+  Previously the check lived only on the streaming path; typed
+  targets that dropped through to the AST loader could parse
+  oversized documents.
+- **Merge-key clone gate.** The typed-key `Value::clone()`
+  retained on every mapping key for the collision check is now
+  skipped when the key is a merge key (`<<`) that will be
+  buffered rather than inserted — `<<`-heavy documents no
+  longer pay the clone cost.
+
+### Added — API & tooling
+
+- **`Error::kind() -> ErrorKind`** — coarse-grained
+  classification for downstream error routing without
+  pattern-matching every variant of the `#[non_exhaustive]`
+  `Error` enum. `ErrorKind` is itself `#[non_exhaustive]`.
+- **Anchor typo suggestions on the AST loader.** Both `Loader`
+  and `NoSpanLoader` now populate `Error::UnknownAnchorAt`'s
+  `suggestion` field with the closest-known-anchor name and its
+  definition location — parity with the streaming path's
+  `build_unknown_anchor`.
+- **Special-value float keys.** `nan` / `inf` / `-inf` mapping
+  keys now stringify to their canonical plain-scalar form
+  (`"nan"`, `"inf"`, `"-inf"`) instead of Rust's `{:?}` output
+  (`"NaN"`), so keyed lookups match how the YAML was written.
+- **New criterion bench: `mapping_key_clone`** — guards the
+  ordinary vs merge-heavy mapping-key hot path against a
+  future regression.
+- **New fuzz target: `fuzz_no_span_loader`** — cross-checks
+  `from_str::<Value>` against `cst::parse_document` on
+  arbitrary input; any divergence is a parity bug.
+
+### Fixed — CST spans
+
+Five `span_at` correctness fixes from the earlier commits on
+this branch:
+
+- Alias references resolve through to the anchor value's span.
+- Block-collection value spans include their first line's
+  indentation, so the returned slice re-parses to the selected
+  value.
+- Keep-chomped block scalars (`|+`, `>+`) retain their kept
+  trailing blank lines in `span_at`.
+- Implicit-null nodes report no span (`None`) instead of the
+  indicator character's location.
+
+### Fixed — scanner
+
+- Lone `\r` (classic-Mac CR-only line breaks) is now a valid
+  line break for YAML 1.2.2 §5.4 compliance.
+
+### Notes for the `no_std` and typed-target audit
+
+- The distinct-typed key-collision check is now enforced on
+  every parse of `Value` — `std` and `no_std`.
+  `no_default_features` users get the same defensive behaviour
+  as `std` users.
+- The `Error::kind()` classifier reports `Budget` for every
+  `BudgetBreach` variant and for `RecursionLimitExceeded` /
+  `RepetitionLimitExceeded`. Note: `max_sequence_length` and
+  `max_mapping_keys` currently surface as `Error::Serialize`
+  (historical spelling) and classify as `Data` — worth folding
+  under `Error::Budget` in v0.0.15 for full parity.
 
 ## [v0.0.13] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,25 @@ this branch:
 - Lone `\r` (classic-Mac CR-only line breaks) is now a valid
   line break for YAML 1.2.2 §5.4 compliance.
 
+### Added — coverage (examples + benches)
+
+Closes the "zero examples / zero benches" gaps identified by
+the coverage audit. Every public module now has at least one
+example and every performance-relevant path has a bench:
+
+- `examples/interner.rs` — key deduplication on a
+  Kubernetes-shaped 10 000-record workload.
+- `examples/parallel.rs` — sequential (`load_all_as`) vs
+  parallel (`parallel::parse`) with real speedup measurement.
+- `examples/simd.rs` — single/multi-byte search + prebuilt
+  `ByteBitmap` + stateful `SimdScanner`.
+- `benches/interner.rs` — naïve `String` vs `Arc` vs
+  `KeyInterner` on realistic Kubernetes keys.
+- `benches/parallel.rs` — sweeps document-size to expose the
+  break-even between sequential and parallel.
+- `benches/borrowed_vs_value.rs` — `BorrowedValue` vs `Value`
+  throughput on a string-heavy workload.
+
 ### Notes for the `no_std` and typed-target audit
 
 - The distinct-typed key-collision check is now enforced on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,9 +1560,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,9 +648,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "granit-parser"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14668345710c92cb04181d9268407067689327d4b055273e3c4179a0777ee6a1"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.28"
+version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e3bc297370dc9c526bcf0986f29167a9286cfaad404f2f572b3074dabe5ec"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.7"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185abd1edcef44ac028ec6588ad1360155fbd0a8baa20243a28f5b2a05537a48"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
 dependencies = [
  "ahash",
  "bytecount",
@@ -925,16 +925,25 @@ dependencies = [
  "getrandom 0.3.4",
  "idna",
  "itoa",
+ "jsonschema-regex",
  "num-cmp",
  "num-traits",
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax",
  "serde",
  "serde_json",
  "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1496,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.7"
+version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c335a4796e6081e384712c269f29ed8d2f6613e7afdd54a8467bb7d48f99859f"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
 dependencies = [
  "ahash",
  "fluent-uri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noyalib"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "ariadne",
  "bytes",

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ wants to *use* the library. The full reference is the
 
 ```toml
 [dependencies]
-noyalib = "0.0.8"
+noyalib = "0.0.14"
 ```
 
 `no_std` (alloc-only) and lean profiles are documented in the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,7 +45,7 @@ to crates.io as before:
 
 ```toml
 [dependencies]
-noyalib = "0.0.13"
+noyalib = "0.0.14"
 ```
 
 ### Consuming a satellite crate
@@ -56,8 +56,8 @@ version pin:
 
 ```toml
 [dependencies]
-noyalib-wasm = "0.0.13"   # crates.io — repo doesn't matter to Cargo
-noyalib-mcp  = "0.0.13"
+noyalib-wasm = "0.0.14"   # crates.io — repo doesn't matter to Cargo
+noyalib-mcp  = "0.0.14"
 ```
 
 The [ADR-0005 strict-lockstep contract](doc/adr/0005-workspace-split.md#versioning-contract)
@@ -130,7 +130,7 @@ repo's OIDC identity:
 cosign verify \
     --certificate-identity-regexp 'https://github.com/sebastienrousseau/noyalib-mcp/' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-    ghcr.io/sebastienrousseau/noyalib-mcp:0.0.13
+    ghcr.io/sebastienrousseau/noyalib-mcp:0.0.14
 ```
 
 ### MCP Registry entry
@@ -153,8 +153,8 @@ onward). Migrate to one of:
 
 ```toml
 [dependencies]
-noyalib-wasm = "=0.0.13"    # exact-match pins recommended
-noyalib-mcp  = "=0.0.13"
+noyalib-wasm = "=0.0.14"    # exact-match pins recommended
+noyalib-mcp  = "=0.0.14"
 ```
 
 Same version identity, same crate identity — only the source
@@ -164,15 +164,15 @@ repo changed.
 
 ```toml
 [dependencies]
-noyalib-wasm = { git = "https://github.com/sebastienrousseau/noyalib-wasm", tag = "v0.0.13" }
-noyalib-mcp  = { git = "https://github.com/sebastienrousseau/noyalib-mcp",  tag = "v0.0.13" }
+noyalib-wasm = { git = "https://github.com/sebastienrousseau/noyalib-wasm", tag = "v0.0.14" }
+noyalib-mcp  = { git = "https://github.com/sebastienrousseau/noyalib-mcp",  tag = "v0.0.14" }
 ```
 
 ### Option C — subtree-vendor the satellite
 
 ```bash
 git subtree add --prefix=vendor/noyalib-wasm \
-    https://github.com/sebastienrousseau/noyalib-wasm v0.0.13 --squash
+    https://github.com/sebastienrousseau/noyalib-wasm v0.0.14 --squash
 ```
 
 If you were also depending on `pkg/npm-mcp-wrapper/` or

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.11"
+noyalib = "0.0.14"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.11", default-features = false }
+noyalib = { version = "0.0.14", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -176,7 +176,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.11", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.14", features = ["miette", "validate-schema"] }
 ```
 
 **Optional features:** `lossless-u64` preserves YAML integer scalars above
@@ -290,7 +290,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.11"
++noyalib = "0.0.14"
 ```
 
 ```diff

--- a/RELEASE-NOTES-v0.0.14.md
+++ b/RELEASE-NOTES-v0.0.14.md
@@ -1,0 +1,152 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.14 Release Notes
+
+The **loader-parity** cut. Closes a fast-path silent-collapse
+of distinct-typed mapping keys, brings four DoS budgets on the
+span-free loader up to par with the span-full loader, adds a
+coarse-grained `Error::kind()` classifier, and lands five CST
+`span_at` correctness fixes plus a scanner lone-CR fix from
+the earlier commits on this branch.
+
+No breaking API changes. No MSRV change (still 1.85). No new
+runtime dependencies.
+
+## Why this release exists
+
+`from_str::<Value>` — the default typed-vs-`Value` entry point
+in noyalib — used to route through the streaming deserializer
+when the target was `Value`, and through a span-free
+`NoSpanLoader` when streaming was ineligible. Both paths
+silently collapsed distinct-typed mapping-key collisions:
+
+```yaml
+1: a
+"1": b
+```
+
+The integer key `1` and the string key `"1"` both stringify to
+`"1"`, so the second `insert` dropped the first. The CST
+loader caught this and refused with `Error::KeyCollision`.
+The default `Value`-target path did not — a real data-loss
+regression relative to the `cst::parse_document` story.
+
+The span-free loader also lacked the DoS budgets the span-full
+loader carries (`max_sequence_length`, `max_mapping_keys`,
+`max_merge_keys`), so an oversized flat sequence, mapping, or
+`<<`-chain bypassed those guards on the `Value` fast path.
+
+v0.0.14 closes both gaps.
+
+## What changed
+
+### Loader-parity (security)
+
+- `NoSpanLoader::push_value` now runs the same distinct-typed
+  collision check the span-full `Loader` has carried since
+  v0.0.13. YAML with two keys that stringify to the same
+  spelling but originate from different YAML scalar types is
+  refused with `Error::KeyCollision` regardless of
+  `DuplicateKeyPolicy`.
+- `NoSpanLoader` now enforces `max_sequence_length`,
+  `max_mapping_keys`, `max_merge_keys`, and the alias-bytes
+  billion-laughs guard bounded by `max_document_length`. Same
+  spellings, same error variants as the span-full loader.
+- `NoSpanLoader` now honours `DuplicateKeyPolicy::First` /
+  `Last` / `Error`. Previously always last-wins.
+- `MergeKeyPolicy::Error` is now enforced on both loaders.
+- The streaming path is now bypassed for the `Value` target
+  (unless a `TagRegistry` is active) so the collision check is
+  actually reachable. See `crates/noyalib/src/de.rs`
+  `from_str_with_config` for the eligibility rule.
+- `from_str_with_config` enforces `max_document_length` inline
+  when streaming is skipped, so an oversized document can't
+  reach the AST loader either way.
+
+### Hot-path clone gate
+
+- The typed-key `Value::clone()` retained on every mapping key
+  is now skipped when the key is a merge key (`<<`) that will
+  be buffered rather than inserted. `<<`-heavy documents no
+  longer pay the clone cost. Gated by a `is_buffered_merge_key`
+  check that reads the current `MergeKeyPolicy`.
+- `debug_assert_eq!(map.len(), typed_keys.len())` now runs
+  after every push in both loaders so a future policy branch
+  desync surfaces in debug builds.
+
+### API additions
+
+- `Error::kind() -> ErrorKind` — coarse-grained routing
+  without matching every variant of the `#[non_exhaustive]`
+  `Error` enum. `ErrorKind` is itself `#[non_exhaustive]`;
+  future variants land under an existing kind whenever
+  possible.
+- Anchor typo suggestions on the AST loaders: both `Loader`
+  and `NoSpanLoader` now populate
+  `Error::UnknownAnchorAt::suggestion` with the closest known
+  anchor and its definition location, matching the streaming
+  path's existing `build_unknown_anchor`.
+- Special-value float keys (`nan` / `inf` / `-inf`) now use
+  their canonical plain-scalar spelling when stringified,
+  instead of Rust's `{:?}` output (`"NaN"`).
+
+### CST span fixes (from earlier commits on this branch)
+
+- Alias references resolve through to the anchor value's span.
+- Block-collection value spans include their first line's
+  indentation, so the returned slice re-parses to the
+  selected value.
+- Keep-chomped block scalars (`|+`, `>+`) retain their kept
+  trailing blank lines in `span_at`.
+- Implicit-null nodes report no span (`None`) instead of the
+  indicator character's location.
+- Distinct-typed key-collision guard on the span-full loader
+  (already shipped; now mirrored on the span-free loader per
+  above).
+
+### Scanner fix
+
+- Lone `\r` (classic-Mac CR-only line breaks) is now a valid
+  line break, per YAML 1.2.2 §5.4.
+
+### Testing / tooling
+
+- `tests/no_span_loader_parity.rs` — nine tests covering the
+  distinct-typed collision, `max_sequence_length`,
+  `max_mapping_keys`, `max_merge_keys`, `MergeKeyPolicy::Error`
+  refusal, `DuplicateKeyPolicy::First` selection, and merge-key
+  no-collision behaviours on the `Value` fast path. Every test
+  fails without the parity fix.
+- `tests/error_kind.rs` — twelve tests pinning the
+  `Error::kind()` mapping.
+- `benches/mapping_key_clone.rs` — criterion bench for the
+  integer-keyed, string-keyed, and merge-heavy mapping-key hot
+  path. Baseline for future clone-cost regression detection.
+- `fuzz/fuzz_targets/fuzz_no_span_loader.rs` — cross-checks
+  `from_str::<Value>` against `cst::parse_document` on
+  arbitrary input; any divergence panics. Corpus seeded with
+  the collision reproducers.
+
+## What did not change
+
+- No breaking API changes. `Error` and `ErrorKind` are both
+  `#[non_exhaustive]`, so the new variant and the new method
+  are additive.
+- No MSRV change. Still `rust-version = "1.85.0"`.
+- No new runtime dependencies. `Cargo.lock` movement in this
+  release comes from Dependabot bumps for `serde-saphyr`,
+  `rustc-hash`, and `jsonschema` only.
+- `#![forbid(unsafe_code)]` intact at every crate root.
+
+## Follow-ups noted for v0.0.15
+
+- `max_sequence_length` and `max_mapping_keys` currently
+  surface as `Error::Serialize("… limit exceeded")` (historical
+  spelling) and classify as `ErrorKind::Data` in the new
+  classifier. Migrating both to `Error::Budget(BudgetBreach::
+  MaxSequenceLength{…} | MaxMappingKeys{…})` would give the
+  classifier full parity — worth doing but out of scope for
+  v0.0.14.
+- `cargo-semver-checks` on the release workflow to guard the
+  0.0.x → 0.0.99 runway against accidental breaks.

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -429,6 +429,10 @@ required-features = ["simd"]
 
 [[bench]]
 name = "streaming_vs_value"
+harness = false
+
+[[bench]]
+name = "mapping_key_clone"
 harness = false
 
 [[bench]]

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -301,6 +301,21 @@ name = "tokio_async_reader"
 path = "examples/tokio_async_reader.rs"
 required-features = ["tokio"]
 
+## ── Coverage-gap examples added in v0.0.14 ──
+[[example]]
+name = "interner"
+path = "examples/interner.rs"
+
+[[example]]
+name = "parallel"
+path = "examples/parallel.rs"
+required-features = ["parallel"]
+
+[[example]]
+name = "simd"
+path = "examples/simd.rs"
+required-features = ["simd"]
+
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 indexmap = { version = ">=2, <3", features = ["serde"] }
@@ -433,6 +448,19 @@ harness = false
 
 [[bench]]
 name = "mapping_key_clone"
+harness = false
+
+[[bench]]
+name = "interner"
+harness = false
+
+[[bench]]
+name = "parallel"
+harness = false
+required-features = ["parallel"]
+
+[[bench]]
+name = "borrowed_vs_value"
 harness = false
 
 [[bench]]

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.8"
+noyalib = "0.0.14"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.8", default-features = false }
+noyalib = { version = "0.0.14", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/benches/borrowed_vs_value.rs
+++ b/crates/noyalib/benches/borrowed_vs_value.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Zero-copy `BorrowedValue` vs allocating `Value` throughput.
+//!
+//! `BorrowedValue<'_>` reuses `&str` slices of the input instead
+//! of allocating fresh `String`s for scalar values. On a document
+//! dominated by long unquoted plain scalars — log payloads, YAML-
+//! backed template files, translation catalogues — this can cut
+//! per-parse allocations dramatically. This bench captures the
+//! throughput delta so a future regression is visible.
+//!
+//! Run: `cargo bench --bench borrowed_vs_value`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use noyalib::Value;
+use noyalib::borrowed::{BorrowedValue, from_str_borrowed};
+use std::hint::black_box;
+
+/// Build `count` mapping records with a long unquoted string
+/// payload each — the shape where zero-copy borrowing pays best.
+fn string_heavy_yaml(count: usize) -> String {
+    let mut s = String::with_capacity(count * 128);
+    for i in 0..count {
+        s.push_str(&format!(
+            "- key: entry-{i}\n  \
+             body: this-is-a-long-plain-scalar-value-{i}-that-is-designed-to-dominate-the-allocation-profile\n",
+        ));
+    }
+    s
+}
+
+fn bench_borrowed_vs_value(c: &mut Criterion) {
+    let mut group = c.benchmark_group("borrowed_vs_value");
+
+    for &(label, count) in &[
+        ("small", 32usize),
+        ("medium", 512usize),
+        ("large", 4096usize),
+    ] {
+        let yaml = string_heavy_yaml(count);
+        group.throughput(Throughput::Bytes(yaml.len() as u64));
+
+        // Allocating: every scalar becomes a `String`.
+        group.bench_with_input(BenchmarkId::new("value", label), &yaml, |b, y| {
+            b.iter(|| {
+                let v: Value = noyalib::from_str(black_box(y)).unwrap();
+                black_box(v);
+            });
+        });
+
+        // Borrowing: scalars are `Cow::Borrowed` from the input.
+        group.bench_with_input(BenchmarkId::new("borrowed", label), &yaml, |b, y| {
+            b.iter(|| {
+                let v: BorrowedValue<'_> = from_str_borrowed(black_box(y)).unwrap();
+                black_box(v);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_borrowed_vs_value);
+criterion_main!(benches);

--- a/crates/noyalib/benches/interner.rs
+++ b/crates/noyalib/benches/interner.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Key-interning throughput on repeated-key workloads.
+//!
+//! Compares three shapes:
+//!
+//! 1. **Naïve `String::from(&str)`** — the baseline every fresh
+//!    `Value` parse pays. One heap allocation per key occurrence.
+//! 2. **`Arc::from(&str)`** — allocates a fresh `Arc<str>` each
+//!    time. Same allocation count, different layout — proves the
+//!    interner's win comes from the *cache*, not the `Arc`.
+//! 3. **`KeyInterner::intern`** — the noyalib primitive. First
+//!    call allocates, every re-intern returns a shared `Arc`.
+//!
+//! Run: `cargo bench --bench interner`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use noyalib::interner::KeyInterner;
+use std::hint::black_box;
+use std::sync::Arc;
+
+/// Realistic Kubernetes-shaped key set — small unique-count with
+/// heavy repetition per record.
+const KEYS: &[&str] = &[
+    "apiVersion",
+    "kind",
+    "metadata",
+    "name",
+    "namespace",
+    "labels",
+    "annotations",
+    "spec",
+    "status",
+    "creationTimestamp",
+];
+
+fn bench_interner(c: &mut Criterion) {
+    let mut group = c.benchmark_group("interner");
+
+    for &record_count in &[100usize, 1_000, 10_000] {
+        let total_ops = record_count * KEYS.len();
+        group.throughput(Throughput::Elements(total_ops as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("naive_string", record_count),
+            &record_count,
+            |b, &n| {
+                b.iter(|| {
+                    let mut buf: Vec<String> = Vec::with_capacity(n * KEYS.len());
+                    for _ in 0..n {
+                        for k in KEYS {
+                            buf.push(black_box(*k).to_owned());
+                        }
+                    }
+                    black_box(buf);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("naive_arc", record_count),
+            &record_count,
+            |b, &n| {
+                b.iter(|| {
+                    let mut buf: Vec<Arc<str>> = Vec::with_capacity(n * KEYS.len());
+                    for _ in 0..n {
+                        for k in KEYS {
+                            buf.push(Arc::from(black_box(*k)));
+                        }
+                    }
+                    black_box(buf);
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("interner", record_count),
+            &record_count,
+            |b, &n| {
+                b.iter(|| {
+                    let mut interner = KeyInterner::new();
+                    let mut buf: Vec<Arc<str>> = Vec::with_capacity(n * KEYS.len());
+                    for _ in 0..n {
+                        for k in KEYS {
+                            buf.push(interner.intern(black_box(*k)));
+                        }
+                    }
+                    black_box(buf);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_interner);
+criterion_main!(benches);

--- a/crates/noyalib/benches/mapping_key_clone.rs
+++ b/crates/noyalib/benches/mapping_key_clone.rs
@@ -88,16 +88,12 @@ fn bench_mapping_key_clone(c: &mut Criterion) {
         );
 
         group.throughput(Throughput::Bytes(str_yaml.len() as u64));
-        group.bench_with_input(
-            BenchmarkId::new("string_keys", label),
-            &str_yaml,
-            |b, y| {
-                b.iter(|| {
-                    let v: Value = from_str(black_box(y)).unwrap();
-                    black_box(v);
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("string_keys", label), &str_yaml, |b, y| {
+            b.iter(|| {
+                let v: Value = from_str(black_box(y)).unwrap();
+                black_box(v);
+            });
+        });
 
         group.throughput(Throughput::Bytes(merge_yaml.len() as u64));
         group.bench_with_input(

--- a/crates/noyalib/benches/mapping_key_clone.rs
+++ b/crates/noyalib/benches/mapping_key_clone.rs
@@ -26,8 +26,19 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use noyalib::{Value, from_str};
+use noyalib::{ParserConfig, Value, from_str, from_str_with_config};
 use std::hint::black_box;
+
+/// Config with expanded alias/merge budgets so the merge-heavy
+/// bench isn't limited by `max_alias_expansions` at large sizes.
+/// The hot path being measured is the mapping-key insert/clone,
+/// not the DoS budgets — those are exercised by the parity tests.
+fn permissive_config() -> ParserConfig {
+    let mut cfg = ParserConfig::default();
+    cfg.max_alias_expansions = 100_000;
+    cfg.max_merge_keys = 100_000;
+    cfg
+}
 
 /// Build a mapping of `count` distinct integer keys with a
 /// two-character string value each. Exercises the non-merge
@@ -95,13 +106,18 @@ fn bench_mapping_key_clone(c: &mut Criterion) {
             });
         });
 
+        // The merge-heavy shape can produce more alias
+        // expansions than the default `max_alias_expansions`
+        // permits — lift that budget so the bench measures the
+        // key-insert path, not the DoS guard.
+        let merge_cfg = permissive_config();
         group.throughput(Throughput::Bytes(merge_yaml.len() as u64));
         group.bench_with_input(
             BenchmarkId::new("merge_heavy", label),
             &merge_yaml,
             |b, y| {
                 b.iter(|| {
-                    let v: Value = from_str(black_box(y)).unwrap();
+                    let v: Value = from_str_with_config(black_box(y), &merge_cfg).unwrap();
                     black_box(v);
                 });
             },

--- a/crates/noyalib/benches/mapping_key_clone.rs
+++ b/crates/noyalib/benches/mapping_key_clone.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Mapping-key hot-path allocation cost.
+//!
+//! The v0.0.14 collision-guard fix retains the *typed* key value
+//! before it is coerced to a string, so the value-arm can tell a
+//! distinct-typed collision (`1` vs `"1"`) apart from a genuine
+//! duplicate. That means one `Value::clone()` per non-merge
+//! mapping key. Merge keys (`<<`) are exempted (the buffered path
+//! never consults the typed key), so `<<`-heavy documents pay the
+//! same cost as before.
+//!
+//! This bench guards against two regressions:
+//!
+//! 1. **Ordinary mapping-key throughput** stays close to the
+//!    pre-fix baseline — the added clone is a small-integer or
+//!    boolean, so the delta should be sub-percent per key.
+//! 2. **Merge-heavy throughput** should not degrade at all — the
+//!    merge-key clone is skipped, so this shape shows the win of
+//!    the `is_buffered_merge_key` gate over an unconditional
+//!    clone.
+//!
+//! Run: `cargo bench --bench mapping_key_clone`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use noyalib::{Value, from_str};
+use std::hint::black_box;
+
+/// Build a mapping of `count` distinct integer keys with a
+/// two-character string value each. Exercises the non-merge
+/// mapping-key path — one `Value::clone()` per key.
+fn integer_keyed_mapping(count: usize) -> String {
+    let mut s = String::with_capacity(count * 12);
+    for i in 0..count {
+        s.push_str(&format!("{i}: v{i}\n"));
+    }
+    s
+}
+
+/// Build a mapping of `count` distinct string keys — same non-
+/// merge shape but with the resolver taking the string branch.
+fn string_keyed_mapping(count: usize) -> String {
+    let mut s = String::with_capacity(count * 16);
+    for i in 0..count {
+        s.push_str(&format!("key{i}: value{i}\n"));
+    }
+    s
+}
+
+/// A `<<`-heavy document: one anchor holding a small map, then
+/// `count` mappings that each merge from it. The clone gate
+/// (`is_buffered_merge_key`) should skip the typed-key clone on
+/// every `<<`.
+fn merge_heavy_mapping(count: usize) -> String {
+    let mut s = String::from("base: &b\n  x: 1\n  y: 2\n");
+    s.push_str("docs:\n");
+    for i in 0..count {
+        s.push_str(&format!("  m{i}:\n    <<: *b\n    z: {i}\n"));
+    }
+    s
+}
+
+fn bench_mapping_key_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mapping_key_clone");
+
+    for &(label, count) in &[
+        ("small", 32usize),
+        ("medium", 1024usize),
+        ("large", 8192usize),
+    ] {
+        let int_yaml = integer_keyed_mapping(count);
+        let str_yaml = string_keyed_mapping(count);
+        let merge_yaml = merge_heavy_mapping(count);
+
+        group.throughput(Throughput::Bytes(int_yaml.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("integer_keys", label),
+            &int_yaml,
+            |b, y| {
+                b.iter(|| {
+                    let v: Value = from_str(black_box(y)).unwrap();
+                    black_box(v);
+                });
+            },
+        );
+
+        group.throughput(Throughput::Bytes(str_yaml.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("string_keys", label),
+            &str_yaml,
+            |b, y| {
+                b.iter(|| {
+                    let v: Value = from_str(black_box(y)).unwrap();
+                    black_box(v);
+                });
+            },
+        );
+
+        group.throughput(Throughput::Bytes(merge_yaml.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("merge_heavy", label),
+            &merge_yaml,
+            |b, y| {
+                b.iter(|| {
+                    let v: Value = from_str(black_box(y)).unwrap();
+                    black_box(v);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_mapping_key_clone);
+criterion_main!(benches);

--- a/crates/noyalib/benches/parallel.rs
+++ b/crates/noyalib/benches/parallel.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Parallel multi-document parsing vs sequential `load_all_as`.
+//!
+//! Sweeps document count × per-document size to expose the
+//! break-even point where Rayon's task-hand-off cost is worth
+//! paying. Guides the "when should I use `parallel::parse`?"
+//! decision.
+//!
+//! Requires `--features parallel`.
+//!
+//! Run: `cargo bench --bench parallel --features parallel`
+
+#![allow(missing_docs, unused_results)]
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use serde::Deserialize;
+use std::hint::black_box;
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Record {
+    id: u32,
+    kind: String,
+    payload: String,
+}
+
+fn build_stream(doc_count: usize, body_repeats: usize) -> String {
+    let mut s = String::with_capacity(doc_count * (48 + body_repeats * 24));
+    for i in 0..doc_count {
+        s.push_str(&format!("---\nid: {i}\nkind: audit\npayload: "));
+        for j in 0..body_repeats {
+            s.push_str(&format!("field-{j}-{i} "));
+        }
+        s.push('\n');
+    }
+    s
+}
+
+fn bench_parallel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parallel_vs_sequential");
+
+    // Doc counts stay under the default `max_documents = 1000`
+    // budget so both paths run without a config override. The
+    // per-document *size* is the axis we sweep — that's what
+    // shifts the break-even point between sequential and
+    // parallel.
+    // (label, doc_count, body_repeats)
+    let shapes = [
+        ("tiny_docs", 900usize, 0usize), // sequential likely wins
+        ("medium_docs", 900, 24),        // parallel likely wins
+        ("large_docs", 300, 96),         // parallel wins by more
+    ];
+
+    for &(label, doc_count, body_repeats) in &shapes {
+        let stream = build_stream(doc_count, body_repeats);
+        group.throughput(Throughput::Bytes(stream.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("sequential", label), &stream, |b, y| {
+            b.iter(|| {
+                let v: Vec<Record> = noyalib::load_all_as(black_box(y)).unwrap();
+                black_box(v);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("parallel", label), &stream, |b, y| {
+            b.iter(|| {
+                // `parallel::parse` calls `from_str::<T>` per
+                // chunk, so per-chunk parsing runs with default
+                // config. The `max_documents` limit applies per
+                // chunk (each chunk has 1 doc); no lift needed.
+                let v: Vec<Record> = noyalib::parallel::parse(black_box(y)).unwrap();
+                black_box(v);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_parallel);
+criterion_main!(benches);

--- a/crates/noyalib/examples/interner.rs
+++ b/crates/noyalib/examples/interner.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Key interning for repeated-key workloads.
+//!
+//! YAML mappings frequently repeat the same key text across many
+//! records — `metadata`, `name`, `version`, `apiVersion` in
+//! Kubernetes manifests, or `time`, `level`, `service` in
+//! structured logs. Every fresh parse allocates a brand-new
+//! `String` for every key. For a 10 000-record stream that means
+//! tens of thousands of duplicate heap allocations.
+//!
+//! [`KeyInterner`](noyalib::interner::KeyInterner) is the
+//! primitive that lets you dedupe those allocations. This example
+//! shows the allocation delta on a small synthetic workload:
+//! parse 10 000 log records once, then intern the observed keys.
+//!
+//! Run:
+//! ```text
+//! cargo run --example interner --release
+//! ```
+
+use noyalib::Value;
+use noyalib::interner::KeyInterner;
+use std::sync::Arc;
+
+fn build_records(count: usize) -> String {
+    // Every record has the same three keys — the exact repeated-
+    // key shape the interner is designed for.
+    let mut s = String::with_capacity(count * 48);
+    for i in 0..count {
+        s.push_str(&format!(
+            "- time: 2026-07-07T00:00:{i:02}Z\n  level: info\n  service: web-{i}\n",
+        ));
+    }
+    s
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let yaml = build_records(10_000);
+    let root: Value = noyalib::from_str(&yaml)?;
+    let records = root.as_sequence().expect("root is a sequence");
+    println!("parsed {} records", records.len());
+
+    // Naïve baseline: every String key is a fresh allocation.
+    // Sum up how many key-String heap allocations landed just so
+    // the comparison is legible.
+    let naive_key_allocs: usize = records
+        .iter()
+        .filter_map(|r| r.as_mapping())
+        .map(|m| m.len())
+        .sum();
+    println!("naïve heap Strings for keys: {naive_key_allocs}");
+
+    // Interned: one Arc<str> per unique key text, shared across
+    // every record via `Arc` clones (16 bytes each on 64-bit).
+    let mut interner = KeyInterner::new();
+    let mut interned_refs: Vec<Arc<str>> = Vec::with_capacity(naive_key_allocs);
+    for record in records {
+        if let Some(mapping) = record.as_mapping() {
+            for key in mapping.keys() {
+                interned_refs.push(interner.intern(key));
+            }
+        }
+    }
+    println!(
+        "interned: {} unique keys, {} Arc handles referencing them",
+        interner.len(),
+        interned_refs.len(),
+    );
+
+    // Sanity: every "time" reference points at the same allocation.
+    let a = interner.intern("time");
+    let b = interner.intern("time");
+    assert!(Arc::ptr_eq(&a, &b), "re-intern must return the same Arc");
+    println!("Arc::ptr_eq(intern(\"time\"), intern(\"time\")) = true");
+
+    // Interner reset — useful between distinct streams so unused
+    // keys aren't held forever.
+    interner.clear();
+    assert_eq!(interner.len(), 0);
+    println!("interner.clear() → len = {}", interner.len());
+
+    Ok(())
+}

--- a/crates/noyalib/examples/parallel.rs
+++ b/crates/noyalib/examples/parallel.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Parallel multi-document YAML parsing with Rayon.
+//!
+//! Requires `--features parallel`. For massive multi-document
+//! streams (telemetry, audit exports, Kubernetes-resource
+//! snapshots — anything emitting `---`-separated documents at
+//! scale), single-threaded parsing is bounded by one CPU core.
+//! The `parallel` module pre-scans the input, splits it into
+//! per-document slices, and dispatches each slice to a Rayon
+//! worker.
+//!
+//! Run:
+//! ```text
+//! cargo run --example parallel --features parallel --release
+//! ```
+
+use noyalib::Value;
+use serde::Deserialize;
+use std::time::Instant;
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct Event {
+    id: u32,
+    kind: String,
+    payload: String,
+}
+
+fn build_stream(document_count: usize) -> String {
+    // Give each document enough body that per-document parse time
+    // outweighs Rayon's task-queue overhead. With tiny documents
+    // the sequential path wins because the parser is faster than
+    // the thread hand-off. A realistic multi-doc workload lives
+    // somewhere between "trivial" and "huge single doc" — this
+    // shape is representative of structured-audit records.
+    let mut s = String::with_capacity(document_count * 320);
+    for i in 0..document_count {
+        s.push_str(&format!("---\nid: {i}\nkind: audit\npayload: entry-{i}-",));
+        for j in 0..12 {
+            s.push_str(&format!("field{j}-value-{i}-{j} "));
+        }
+        s.push('\n');
+    }
+    s
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 900 fits under the default `max_documents = 1000` budget so
+    // the sequential baseline runs without a config override —
+    // keeps the example dependency-light. A production caller
+    // parsing millions of records would raise the budget via
+    // `ParserConfig::new().max_documents(...)` and use
+    // `load_all_with_config` / `from_str_with_config`.
+    let stream = build_stream(900);
+    let size_kb = stream.len() / 1024;
+    println!("stream: 900 documents, {size_kb} KB");
+
+    // Sequential baseline: `load_all_as` walks the events on the
+    // calling thread, one document at a time.
+    let t0 = Instant::now();
+    let sequential: Vec<Event> = noyalib::load_all_as(&stream)?;
+    let sequential_ms = t0.elapsed().as_secs_f64() * 1_000.0;
+    println!(
+        "sequential (load_all_as): {} events in {sequential_ms:.1} ms",
+        sequential.len()
+    );
+
+    // Parallel: `parallel::parse` splits + dispatches across the
+    // Rayon global thread pool. Same result set, just built with
+    // multiple cores.
+    let t1 = Instant::now();
+    let parallel: Vec<Event> = noyalib::parallel::parse(&stream)?;
+    let parallel_ms = t1.elapsed().as_secs_f64() * 1_000.0;
+    println!(
+        "parallel (parallel::parse): {} events in {parallel_ms:.1} ms",
+        parallel.len()
+    );
+
+    println!("speedup: {:.2}×", sequential_ms / parallel_ms.max(0.001));
+
+    // Dynamic-tree variant — same shape, but the caller wants
+    // `Value` back so downstream code can route by document type.
+    let values: Vec<Value> = noyalib::parallel::values(&stream)?;
+    println!("parallel::values: {} Values", values.len());
+
+    // Standalone boundary scan — for callers that drive their
+    // own concurrency (async tasks, custom thread pools) instead
+    // of Rayon.
+    let slices = noyalib::parallel::split(&stream);
+    println!("parallel::split: {} raw document slices", slices.len());
+
+    Ok(())
+}

--- a/crates/noyalib/examples/simd.rs
+++ b/crates/noyalib/examples/simd.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! SIMD-friendly structural scanning primitives.
+//!
+//! Requires `--features simd`. Noyalib's scanner uses the same
+//! `simd::find_any_of` primitive to jump over plain scalar text
+//! byte-at-a-time. Downstream callers building custom scanners
+//! (grammar-driven config parsers, log formatters, YAML dialects
+//! layered on top of noyalib) can reuse the same primitive.
+//!
+//! Run:
+//! ```text
+//! cargo run --example simd --features simd --release
+//! ```
+
+use noyalib::simd::{ByteBitmap, SimdScanner, bitmap_for, clean_prefix_len, find_any_of};
+
+fn main() {
+    // ── 1. Single-byte search ────────────────────────────────
+    // The 1-needle path routes through memchr → SSE2/NEON.
+    let line = b"key: value  # trailing comment";
+    assert_eq!(find_any_of(line, &[b':']), Some(3));
+    println!("find_any_of(':') → {:?}", find_any_of(line, &[b':']));
+
+    // ── 2. Multi-byte search ─────────────────────────────────
+    // 4+ needles route through the SWAR path (8 bytes per lane).
+    // Classic YAML plain-scalar-terminator set.
+    let plain_end = find_any_of(line, &[b':', b',', b'#', b'\n']);
+    assert_eq!(plain_end, Some(3));
+    println!("plain-terminator set → {plain_end:?}");
+
+    // ── 3. Skip-clean-prefix ─────────────────────────────────
+    // How far can we advance before we hit a terminator? This is
+    // the exact question a scanner asks when scoping a plain
+    // scalar. Same result as find_any_of but expresses the intent
+    // directly.
+    let advance = clean_prefix_len(b"abc def:more", &[b':', b',', b'#', b'\n']);
+    assert_eq!(advance, 7); // "abc def"
+    println!("clean_prefix_len before terminator → {advance}");
+
+    // ── 4. Pre-built bitmap ──────────────────────────────────
+    // For hot loops that reuse the same needle set, build the
+    // bitmap once and keep it. `ByteBitmap` is `Copy` — cheap to
+    // pass by value.
+    let terminators: ByteBitmap = bitmap_for(b":,#\n");
+    assert!(terminators.contains(b':'));
+    assert!(terminators.contains(b'\n'));
+    assert!(!terminators.contains(b'a'));
+    println!("bitmap_for(\":,#\\n\") built once, reused per line");
+
+    // ── 5. Structural scan on a whole document ───────────────
+    // `SimdScanner` is the stateful side of the API — construct
+    // once with your needle set, then run scan queries against
+    // multiple haystacks.
+    let scanner = SimdScanner::new(b":,{}[]");
+    let doc = b"{key: [a, b], nested: {inner: value}}";
+    let mut cursor = 0;
+    let mut hits = 0;
+    while let Some(offset) = scanner.find_any(&doc[cursor..]) {
+        hits += 1;
+        cursor += offset + 1;
+        if hits > 32 {
+            break; // guard rail
+        }
+    }
+    println!(
+        "SimdScanner found {hits} structural bytes in {} bytes",
+        doc.len()
+    );
+
+    // ── 6. Miss case ─────────────────────────────────────────
+    // Returns None when no needle byte is present.
+    assert_eq!(find_any_of(b"abcdefgh", &[b'X', b'Y', b'Z']), None);
+    println!("find_any_of on a needle-free haystack → None");
+}

--- a/crates/noyalib/examples/simd.rs
+++ b/crates/noyalib/examples/simd.rs
@@ -20,13 +20,13 @@ fn main() {
     // ── 1. Single-byte search ────────────────────────────────
     // The 1-needle path routes through memchr → SSE2/NEON.
     let line = b"key: value  # trailing comment";
-    assert_eq!(find_any_of(line, &[b':']), Some(3));
-    println!("find_any_of(':') → {:?}", find_any_of(line, &[b':']));
+    assert_eq!(find_any_of(line, b":"), Some(3));
+    println!("find_any_of(':') → {:?}", find_any_of(line, b":"));
 
     // ── 2. Multi-byte search ─────────────────────────────────
     // 4+ needles route through the SWAR path (8 bytes per lane).
     // Classic YAML plain-scalar-terminator set.
-    let plain_end = find_any_of(line, &[b':', b',', b'#', b'\n']);
+    let plain_end = find_any_of(line, b":,#\n");
     assert_eq!(plain_end, Some(3));
     println!("plain-terminator set → {plain_end:?}");
 
@@ -35,7 +35,7 @@ fn main() {
     // the exact question a scanner asks when scoping a plain
     // scalar. Same result as find_any_of but expresses the intent
     // directly.
-    let advance = clean_prefix_len(b"abc def:more", &[b':', b',', b'#', b'\n']);
+    let advance = clean_prefix_len(b"abc def:more", b":,#\n");
     assert_eq!(advance, 7); // "abc def"
     println!("clean_prefix_len before terminator → {advance}");
 
@@ -71,6 +71,6 @@ fn main() {
 
     // ── 6. Miss case ─────────────────────────────────────────
     // Returns None when no needle byte is present.
-    assert_eq!(find_any_of(b"abcdefgh", &[b'X', b'Y', b'Z']), None);
+    assert_eq!(find_any_of(b"abcdefgh", b"XYZ"), None);
     println!("find_any_of on a needle-free haystack → None");
 }

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1498,12 +1498,16 @@ fn resolve_span(
     segments: &[QuerySegment],
 ) -> Option<(usize, usize)> {
     if segments.is_empty() {
-        return Some(match span_tree {
-            SpanTree::Leaf(s, e) => (*s, *e),
+        return match span_tree {
+            // A zero-width leaf marks an implicit null (an absent
+            // block-mapping value or empty sequence item): the node has no
+            // source bytes of its own, so it has no span.
+            SpanTree::Leaf(s, e) if s == e => None,
+            SpanTree::Leaf(s, e) => Some((*s, *e)),
             SpanTree::Sequence { start, end, .. } | SpanTree::Mapping { start, end, .. } => {
-                (*start, *end)
+                Some((*start, *end))
             }
-        });
+        };
     }
     let (head, tail) = segments.split_first()?;
     match (head, value, span_tree) {

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1324,6 +1324,32 @@ fn decode_single_quoted(raw: &str) -> Option<Cow<'_, str>> {
 /// Find the value position inside a `MappingEntry` and either
 /// return its byte range (if `tail` is empty) or recurse into it
 /// with `tail`.
+/// Whether a resolved value node is a block (indentation-structured)
+/// collection, whose span begins on its own source line.
+fn is_block_collection(k: SyntaxKind) -> bool {
+    matches!(k, SyntaxKind::BlockMapping | SyntaxKind::BlockSequence)
+}
+
+/// Back `start` up over the inline whitespace that indents a value's first
+/// line, but only when that value begins its own line (the whitespace run is
+/// preceded by a line break or the start of input). A value that shares its
+/// line with a `-` / `:` / `{` (e.g. the inner sequence of `- - a`) is left
+/// untouched. This makes a block collection's slice uniformly indented — its
+/// first line keeps the indentation the following lines already carry — so it
+/// re-parses to the selected value instead of silently re-nesting.
+fn extend_to_line_start(source: &str, start: usize) -> usize {
+    let b = source.as_bytes();
+    let mut i = start;
+    while i > 0 && matches!(b[i - 1], b' ' | b'\t') {
+        i -= 1;
+    }
+    if i == 0 || matches!(b[i - 1], b'\n' | b'\r') {
+        i
+    } else {
+        start
+    }
+}
+
 fn resolve_value_in_entry(
     entry: &GreenNode,
     base: usize,
@@ -1332,17 +1358,19 @@ fn resolve_value_in_entry(
 ) -> Option<(usize, usize)> {
     let (value_kind, value_range, value_node) = entry_value(entry, base)?;
     if tail.is_empty() {
-        return Some(value_range);
+        // A block collection's node starts at its first key/item token,
+        // leaving its first line's indentation just outside the span; widen
+        // to the line start so the slice is uniformly indented.
+        let start = if is_block_collection(value_kind) {
+            extend_to_line_start(source, value_range.0)
+        } else {
+            value_range.0
+        };
+        return Some((start, value_range.1));
     }
     // Recursing further requires the value to be a composite.
     let node = value_node?;
-    walk_path(node, tail, value_range.0, source).map(|(s, e)| {
-        // Defensive: ensure recursion stays inside the value's
-        // span — composite parents may contain trailing trivia
-        // that's outside the conceptual "value" range.
-        let _ = value_kind;
-        (s, e)
-    })
+    walk_path(node, tail, value_range.0, source)
 }
 
 fn resolve_value_in_item(
@@ -1351,9 +1379,14 @@ fn resolve_value_in_item(
     tail: &[QuerySegment],
     source: &str,
 ) -> Option<(usize, usize)> {
-    let (_, value_range, value_node) = item_value(item, base)?;
+    let (value_kind, value_range, value_node) = item_value(item, base)?;
     if tail.is_empty() {
-        return Some(value_range);
+        let start = if is_block_collection(value_kind) {
+            extend_to_line_start(source, value_range.0)
+        } else {
+            value_range.0
+        };
+        return Some((start, value_range.1));
     }
     let node = value_node?;
     walk_path(node, tail, value_range.0, source)

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1419,10 +1419,17 @@ fn entry_value(
                     if *kind == SyntaxKind::ColonIndicator {
                         after_colon = true;
                     }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // An alias reference (`*name`) is a single token with
+                    // no value node of its own; its bytes are a dangling
+                    // alias that does not re-parse standalone. Bail so
+                    // span_at falls back to the typed cache, whose SpanTree
+                    // resolves the alias through to its anchor definition's
+                    // self-contained value span.
+                    return None;
                 } else if is_value_property_kind(*kind) {
-                    // `!Tag` / `&anchor` / `*alias` prefix —
-                    // remember the earliest start and keep
-                    // scanning for the scalar that follows.
+                    // `!Tag` / `&anchor` prefix — remember the earliest
+                    // start and keep scanning for the scalar that follows.
                     let _ = prefix_start.get_or_insert(child_start);
                 } else if !is_trivia_kind(*kind) {
                     let start = prefix_start.unwrap_or(child_start);
@@ -1466,6 +1473,10 @@ fn item_value(
                     if *kind == SyntaxKind::DashIndicator {
                         after_dash = true;
                     }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // Alias reference as a sequence item: bail to the typed
+                    // cache, which resolves it to the anchor's value span.
+                    return None;
                 } else if is_value_property_kind(*kind) {
                     let _ = prefix_start.get_or_insert(child_start);
                 } else if !is_trivia_kind(*kind) {
@@ -1506,10 +1517,10 @@ fn is_trivia_kind(k: SyntaxKind) -> bool {
 /// tag and the quoted scalar) rather than `6..13` (the tag
 /// alone, which was the pre-fix behaviour).
 fn is_value_property_kind(k: SyntaxKind) -> bool {
-    matches!(
-        k,
-        SyntaxKind::AnchorMark | SyntaxKind::TagMark | SyntaxKind::AliasMark
-    )
+    // Alias marks are handled separately (they bail the green walk to the
+    // typed cache); only anchor/tag definition prefixes stretch the value
+    // span to cover the property plus the scalar / node that follows.
+    matches!(k, SyntaxKind::AnchorMark | SyntaxKind::TagMark)
 }
 
 // ── Path resolution ─────────────────────────────────────────────────

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -199,7 +199,7 @@ impl Document {
         // through `set` / `set_value` no longer warms the typed
         // cache between iterations.
         if let Some((s, e)) = resolve_path_in_green(&self.green, &segments, &self.source) {
-            return Some(trim_trailing_blank(&self.source, s, e));
+            return Some(trim_value_span(&self.source, s, e));
         }
         // Fallback for paths the green-tree walker doesn't
         // currently handle — e.g. quoted keys with escapes,
@@ -208,7 +208,7 @@ impl Document {
         let cache = self.cache.borrow();
         let (value, span_tree) = cache.as_ref().expect("ensure_cache populated");
         let (s, e) = resolve_span(value, span_tree, &segments)?;
-        Some(trim_trailing_blank(&self.source, s, e))
+        Some(trim_value_span(&self.source, s, e))
     }
 
     /// Populate the typed cache from `self.source` if it is empty.
@@ -1490,6 +1490,42 @@ fn trim_trailing_blank(source: &str, start: usize, mut end: usize) -> (usize, us
         }
     }
     (start, end)
+}
+
+/// Trim trailing separator whitespace from a *value* span, except for
+/// keep-chomped (`|+` / `>+`) block scalars, whose trailing line breaks are
+/// content rather than separation. Trimming those would yield a slice that
+/// re-parses to a shorter, different value (`"kept\n"` instead of the true
+/// `"kept\n\n\n"`).
+fn trim_value_span(source: &str, start: usize, end: usize) -> (usize, usize) {
+    if is_keep_chomped_block_scalar(source, start, end) {
+        (start, end)
+    } else {
+        trim_trailing_blank(source, start, end)
+    }
+}
+
+/// Whether `[start, end)` denotes a keep-chomped block scalar: it begins with
+/// a `|` / `>` block indicator carrying a `+` chomping indicator on the header
+/// line (`|+`, `>+`, `|+2`, `|2+`). A value span's start is the block
+/// indicator itself (the scanner marks it there), and no plain/quoted scalar
+/// or collection value begins with a bare `|` / `>`, so this cannot misfire on
+/// other node kinds.
+fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool {
+    let bytes = source.as_bytes();
+    if start >= end || (bytes[start] != b'|' && bytes[start] != b'>') {
+        return false;
+    }
+    // A `+` anywhere on the header line (before the first line break) is the
+    // keep-chomping indicator.
+    for &b in &bytes[start + 1..end] {
+        match b {
+            b'\n' | b'\r' => return false,
+            b'+' => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn resolve_span(

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -474,6 +474,13 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: foo\nversion: 0.0.2\n");
     /// ```
     pub fn set(&mut self, path: &str, fragment: &str) -> Result<()> {
+        let segments = parse_query_path(path);
+        if value_is_alias_reference(&self.green, &segments, &self.source) {
+            return Err(Error::Parse(format!(
+                "cannot set `{path}`: its value is an alias reference (`*name`); \
+                 edit the anchor definition or replace the alias explicitly"
+            )));
+        }
         let (s, e) = self
             .span_at(path)
             .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
@@ -516,6 +523,13 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: noyalib\nversion: 0.0.2\n");
     /// ```
     pub fn set_value(&mut self, path: &str, value: &Value) -> Result<()> {
+        let segments = parse_query_path(path);
+        if value_is_alias_reference(&self.green, &segments, &self.source) {
+            return Err(Error::Parse(format!(
+                "cannot set `{path}`: its value is an alias reference (`*name`); \
+                 edit the anchor definition or replace the alias explicitly"
+            )));
+        }
         let (s, e) = self
             .span_at(path)
             .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
@@ -1156,6 +1170,127 @@ fn resolve_path_in_green(
     // point.
     let (collection, base) = first_collection_child(root, 0)?;
     walk_path(collection, segments, base, source)
+}
+
+/// Does the value at `segments` resolve *directly* to an alias
+/// reference (`*name`)?
+///
+/// `span_at` deliberately resolves an alias *through* to its anchor's
+/// definition span (issue #149) — the right target for a read, but the
+/// wrong one for a write: splicing there rewrites the anchor's value and
+/// corrupts a *different* key. `set` / `set_value` call this and refuse
+/// the edit rather than mutate the wrong bytes. Read-only span
+/// resolution is untouched.
+fn value_is_alias_reference(root: &GreenNode, segments: &[QuerySegment], source: &str) -> bool {
+    match first_collection_child(root, 0) {
+        Some((collection, base)) => terminal_is_alias(collection, segments, base, source),
+        None => false,
+    }
+}
+
+fn terminal_is_alias(
+    node: &GreenNode,
+    segments: &[QuerySegment],
+    base: usize,
+    source: &str,
+) -> bool {
+    let Some((head, tail)) = segments.split_first() else {
+        return false;
+    };
+    match (head, node.kind()) {
+        (QuerySegment::Key(k), SyntaxKind::BlockMapping | SyntaxKind::FlowMapping) => {
+            // Last matching entry wins (DuplicateKeyPolicy::Last), mirroring
+            // walk_mapping so this agrees with what span_at would target.
+            let mut found: Option<(&GreenNode, usize)> = None;
+            let mut pos = base;
+            for child in node.children() {
+                let len = child.text_len();
+                if let GreenChild::Node(entry) = child {
+                    if entry.kind() == SyntaxKind::MappingEntry
+                        && entry_key_text(entry, source, pos).as_deref() == Some(k.as_str())
+                    {
+                        found = Some((entry, pos));
+                    }
+                }
+                pos += len;
+            }
+            match found {
+                Some((entry, entry_pos)) => value_after_sep_is_alias(
+                    entry,
+                    entry_pos,
+                    tail,
+                    source,
+                    SyntaxKind::ColonIndicator,
+                ),
+                None => false,
+            }
+        }
+        (QuerySegment::Index(i), SyntaxKind::BlockSequence | SyntaxKind::FlowSequence) => {
+            let mut pos = base;
+            let mut idx = 0usize;
+            for child in node.children() {
+                let len = child.text_len();
+                if let GreenChild::Node(item) = child {
+                    if item.kind() == SyntaxKind::SequenceItem {
+                        if idx == *i {
+                            return value_after_sep_is_alias(
+                                item,
+                                pos,
+                                tail,
+                                source,
+                                SyntaxKind::DashIndicator,
+                            );
+                        }
+                        idx += 1;
+                    }
+                }
+                pos += len;
+            }
+            false
+        }
+        // Wildcards / kind mismatch: span_at would bail to the cache; the
+        // conservative answer for a write is "not a known alias target".
+        _ => false,
+    }
+}
+
+/// Within a `MappingEntry` / `SequenceItem`, decide whether the value —
+/// the first non-trivia, non-property token after `sep` — is an alias.
+/// For a deeper path, recurse into a nested collection instead.
+fn value_after_sep_is_alias(
+    container: &GreenNode,
+    base: usize,
+    tail: &[QuerySegment],
+    source: &str,
+    sep: SyntaxKind,
+) -> bool {
+    let mut pos = base;
+    let mut after_sep = false;
+    for child in container.children() {
+        let len = child.text_len();
+        match child {
+            GreenChild::Token { kind, .. } => {
+                if !after_sep {
+                    if *kind == sep {
+                        after_sep = true;
+                    }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // Only a *terminal* alias is a mutation hazard; a path that
+                    // tries to descend into an alias resolves nowhere anyway.
+                    return tail.is_empty();
+                } else if !is_trivia_kind(*kind) && !is_value_property_kind(*kind) {
+                    return false; // a real scalar leaf — safe to mutate
+                }
+            }
+            GreenChild::Node(inner) => {
+                if after_sep {
+                    return terminal_is_alias(inner, tail, pos, source);
+                }
+            }
+        }
+        pos += len;
+    }
+    false
 }
 
 fn first_collection_child(node: &GreenNode, base: usize) -> Option<(&GreenNode, usize)> {

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1202,14 +1202,36 @@ fn terminal_is_alias(
             // Last matching entry wins (DuplicateKeyPolicy::Last), mirroring
             // walk_mapping so this agrees with what span_at would target.
             let mut found: Option<(&GreenNode, usize)> = None;
+            // `entry_key_text` can't decode every key spelling (double-quoted,
+            // complex, merge). For such an entry `span_at` falls back to the
+            // typed cache and, matching by the cache's decoded key, resolves an
+            // alias *through* to its anchor — the exact write hazard this guard
+            // exists to catch. We can't match the undecodable key by text here,
+            // so if any undecodable-key entry's value is an alias, treat the
+            // (undecodable) target as a possible hit and refuse conservatively.
+            let mut undecodable_alias = false;
             let mut pos = base;
             for child in node.children() {
                 let len = child.text_len();
                 if let GreenChild::Node(entry) = child {
-                    if entry.kind() == SyntaxKind::MappingEntry
-                        && entry_key_text(entry, source, pos).as_deref() == Some(k.as_str())
-                    {
-                        found = Some((entry, pos));
+                    if entry.kind() == SyntaxKind::MappingEntry {
+                        match entry_key_text(entry, source, pos) {
+                            Some(key) if key.as_ref() == k.as_str() => {
+                                found = Some((entry, pos));
+                            }
+                            Some(_) => {}
+                            None => {
+                                if value_after_sep_is_alias(
+                                    entry,
+                                    pos,
+                                    tail,
+                                    source,
+                                    SyntaxKind::ColonIndicator,
+                                ) {
+                                    undecodable_alias = true;
+                                }
+                            }
+                        }
                     }
                 }
                 pos += len;
@@ -1222,7 +1244,9 @@ fn terminal_is_alias(
                     source,
                     SyntaxKind::ColonIndicator,
                 ),
-                None => false,
+                // No decodable key matched: refuse if an undecodable-key entry
+                // is an alias (the target could be it).
+                None => undecodable_alias,
             }
         }
         (QuerySegment::Index(i), SyntaxKind::BlockSequence | SyntaxKind::FlowSequence) => {
@@ -1692,6 +1716,13 @@ fn trim_value_span(source: &str, start: usize, end: usize) -> (usize, usize) {
 /// other node kinds.
 fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool {
     let bytes = source.as_bytes();
+    // The value span's start may have been widened leftward over an anchor
+    // (`&name`) / tag (`!Tag`, `!!str`) property prefix (see `entry_value`), so
+    // the block indicator is not necessarily at `start`. Skip those property
+    // tokens before inspecting for `|` / `>`, otherwise an anchored/tagged
+    // keep-chomped scalar (`key: &anc |+`) is misclassified and its kept
+    // trailing blank lines are trimmed.
+    let start = skip_value_property_prefix(bytes, start, end);
     if start >= end || (bytes[start] != b'|' && bytes[start] != b'>') {
         return false;
     }
@@ -1705,6 +1736,26 @@ fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool 
         }
     }
     false
+}
+
+/// Advance past leading anchor (`&name`) / tag (`!Tag`, `!!str`) property
+/// tokens and the whitespace between them, returning the index of the value
+/// content proper. Value spans are widened leftward over these properties, so
+/// callers inspecting the value's first byte must skip them first.
+fn skip_value_property_prefix(bytes: &[u8], mut start: usize, end: usize) -> usize {
+    loop {
+        while start < end && matches!(bytes[start], b' ' | b'\t') {
+            start += 1;
+        }
+        if start < end && matches!(bytes[start], b'&' | b'!') {
+            start += 1;
+            while start < end && !matches!(bytes[start], b' ' | b'\t' | b'\n' | b'\r') {
+                start += 1;
+            }
+        } else {
+            return start;
+        }
+    }
 }
 
 fn resolve_span(

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -207,7 +207,9 @@ impl Document {
         self.ensure_cache();
         let cache = self.cache.borrow();
         let (value, span_tree) = cache.as_ref().expect("ensure_cache populated");
-        let (s, e) = resolve_span(value, span_tree, &segments)?;
+        // Reads resolve an alias through to its anchor (issue #149); the
+        // through-alias flag only matters for writes (see `write_span`).
+        let ((s, e), _through_alias) = resolve_span(value, span_tree, &segments)?;
         Some(trim_value_span(&self.source, s, e))
     }
 
@@ -474,17 +476,36 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: foo\nversion: 0.0.2\n");
     /// ```
     pub fn set(&mut self, path: &str, fragment: &str) -> Result<()> {
+        let (s, e) = self.write_span(path)?;
+        self.replace_span(s, e, fragment)
+    }
+
+    /// Resolve `path` to a byte span for a **write**, refusing when the value
+    /// is (or resolves through) an alias reference.
+    ///
+    /// `span_at` resolves an alias *through* to its anchor's value span (issue
+    /// #149) — the right target for a read, but splicing there would rewrite
+    /// the **anchor's** bytes, a different key. The green-tree fast path never
+    /// yields an alias (it bails on `AliasMark`), so only the typed-cache
+    /// fallback can; `resolve_span`'s `through_alias` flag is the single source
+    /// of truth for that, so the two paths cannot disagree.
+    fn write_span(&self, path: &str) -> Result<(usize, usize)> {
         let segments = parse_query_path(path);
-        if value_is_alias_reference(&self.green, &segments, &self.source) {
+        if let Some((s, e)) = resolve_path_in_green(&self.green, &segments, &self.source) {
+            return Ok(trim_value_span(&self.source, s, e));
+        }
+        self.ensure_cache();
+        let cache = self.cache.borrow();
+        let (value, span_tree) = cache.as_ref().expect("ensure_cache populated");
+        let ((s, e), through_alias) = resolve_span(value, span_tree, &segments)
+            .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
+        if through_alias {
             return Err(Error::Parse(format!(
-                "cannot set `{path}`: its value is an alias reference (`*name`); \
-                 edit the anchor definition or replace the alias explicitly"
+                "cannot set `{path}`: its value is (or resolves through) an alias \
+                 reference; edit the anchor definition or replace the alias explicitly"
             )));
         }
-        let (s, e) = self
-            .span_at(path)
-            .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
-        self.replace_span(s, e, fragment)
+        Ok(trim_value_span(&self.source, s, e))
     }
 
     /// Replace the value at `path` with a typed [`Value`], formatting
@@ -523,16 +544,7 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: noyalib\nversion: 0.0.2\n");
     /// ```
     pub fn set_value(&mut self, path: &str, value: &Value) -> Result<()> {
-        let segments = parse_query_path(path);
-        if value_is_alias_reference(&self.green, &segments, &self.source) {
-            return Err(Error::Parse(format!(
-                "cannot set `{path}`: its value is an alias reference (`*name`); \
-                 edit the anchor definition or replace the alias explicitly"
-            )));
-        }
-        let (s, e) = self
-            .span_at(path)
-            .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
+        let (s, e) = self.write_span(path)?;
         let kind = leaf_kind_at(&self.green, s).ok_or_else(|| {
             Error::Parse("could not locate green-tree leaf at target span".into())
         })?;
@@ -1172,151 +1184,6 @@ fn resolve_path_in_green(
     walk_path(collection, segments, base, source)
 }
 
-/// Does the value at `segments` resolve *directly* to an alias
-/// reference (`*name`)?
-///
-/// `span_at` deliberately resolves an alias *through* to its anchor's
-/// definition span (issue #149) — the right target for a read, but the
-/// wrong one for a write: splicing there rewrites the anchor's value and
-/// corrupts a *different* key. `set` / `set_value` call this and refuse
-/// the edit rather than mutate the wrong bytes. Read-only span
-/// resolution is untouched.
-fn value_is_alias_reference(root: &GreenNode, segments: &[QuerySegment], source: &str) -> bool {
-    match first_collection_child(root, 0) {
-        Some((collection, base)) => terminal_is_alias(collection, segments, base, source),
-        None => false,
-    }
-}
-
-fn terminal_is_alias(
-    node: &GreenNode,
-    segments: &[QuerySegment],
-    base: usize,
-    source: &str,
-) -> bool {
-    let Some((head, tail)) = segments.split_first() else {
-        return false;
-    };
-    match (head, node.kind()) {
-        (QuerySegment::Key(k), SyntaxKind::BlockMapping | SyntaxKind::FlowMapping) => {
-            // Last matching entry wins (DuplicateKeyPolicy::Last), mirroring
-            // walk_mapping so this agrees with what span_at would target.
-            let mut found: Option<(&GreenNode, usize)> = None;
-            // `entry_key_text` can't decode every key spelling (double-quoted,
-            // complex, merge). For such an entry `span_at` falls back to the
-            // typed cache and, matching by the cache's decoded key, resolves an
-            // alias *through* to its anchor — the exact write hazard this guard
-            // exists to catch. We can't match the undecodable key by text here,
-            // so if any undecodable-key entry's value is an alias, treat the
-            // (undecodable) target as a possible hit and refuse conservatively.
-            let mut undecodable_alias = false;
-            let mut pos = base;
-            for child in node.children() {
-                let len = child.text_len();
-                if let GreenChild::Node(entry) = child {
-                    if entry.kind() == SyntaxKind::MappingEntry {
-                        match entry_key_text(entry, source, pos) {
-                            Some(key) if key.as_ref() == k.as_str() => {
-                                found = Some((entry, pos));
-                            }
-                            Some(_) => {}
-                            None => {
-                                if value_after_sep_is_alias(
-                                    entry,
-                                    pos,
-                                    tail,
-                                    source,
-                                    SyntaxKind::ColonIndicator,
-                                ) {
-                                    undecodable_alias = true;
-                                }
-                            }
-                        }
-                    }
-                }
-                pos += len;
-            }
-            match found {
-                Some((entry, entry_pos)) => value_after_sep_is_alias(
-                    entry,
-                    entry_pos,
-                    tail,
-                    source,
-                    SyntaxKind::ColonIndicator,
-                ),
-                // No decodable key matched: refuse if an undecodable-key entry
-                // is an alias (the target could be it).
-                None => undecodable_alias,
-            }
-        }
-        (QuerySegment::Index(i), SyntaxKind::BlockSequence | SyntaxKind::FlowSequence) => {
-            let mut pos = base;
-            let mut idx = 0usize;
-            for child in node.children() {
-                let len = child.text_len();
-                if let GreenChild::Node(item) = child {
-                    if item.kind() == SyntaxKind::SequenceItem {
-                        if idx == *i {
-                            return value_after_sep_is_alias(
-                                item,
-                                pos,
-                                tail,
-                                source,
-                                SyntaxKind::DashIndicator,
-                            );
-                        }
-                        idx += 1;
-                    }
-                }
-                pos += len;
-            }
-            false
-        }
-        // Wildcards / kind mismatch: span_at would bail to the cache; the
-        // conservative answer for a write is "not a known alias target".
-        _ => false,
-    }
-}
-
-/// Within a `MappingEntry` / `SequenceItem`, decide whether the value —
-/// the first non-trivia, non-property token after `sep` — is an alias.
-/// For a deeper path, recurse into a nested collection instead.
-fn value_after_sep_is_alias(
-    container: &GreenNode,
-    base: usize,
-    tail: &[QuerySegment],
-    source: &str,
-    sep: SyntaxKind,
-) -> bool {
-    let mut pos = base;
-    let mut after_sep = false;
-    for child in container.children() {
-        let len = child.text_len();
-        match child {
-            GreenChild::Token { kind, .. } => {
-                if !after_sep {
-                    if *kind == sep {
-                        after_sep = true;
-                    }
-                } else if *kind == SyntaxKind::AliasMark {
-                    // Only a *terminal* alias is a mutation hazard; a path that
-                    // tries to descend into an alias resolves nowhere anyway.
-                    return tail.is_empty();
-                } else if !is_trivia_kind(*kind) && !is_value_property_kind(*kind) {
-                    return false; // a real scalar leaf — safe to mutate
-                }
-            }
-            GreenChild::Node(inner) => {
-                if after_sep {
-                    return terminal_is_alias(inner, tail, pos, source);
-                }
-            }
-        }
-        pos += len;
-    }
-    false
-}
-
 fn first_collection_child(node: &GreenNode, base: usize) -> Option<(&GreenNode, usize)> {
     let mut pos = base;
     for child in node.children() {
@@ -1758,21 +1625,53 @@ fn skip_value_property_prefix(bytes: &[u8], mut start: usize, end: usize) -> usi
     }
 }
 
+/// The end byte of a span tree, transparently unwrapping alias indirection.
+fn span_tree_end(t: &SpanTree) -> usize {
+    match t {
+        SpanTree::Leaf(_, e) => *e,
+        SpanTree::Sequence { end, .. } | SpanTree::Mapping { end, .. } => *end,
+        SpanTree::Alias(inner) => span_tree_end(inner),
+    }
+}
+
+/// The `(start, end)` bounds of a span tree, transparently unwrapping alias
+/// indirection.
+fn span_tree_bounds(t: &SpanTree) -> (usize, usize) {
+    match t {
+        SpanTree::Leaf(s, e) => (*s, *e),
+        SpanTree::Sequence { start, end, .. } | SpanTree::Mapping { start, end, .. } => {
+            (*start, *end)
+        }
+        SpanTree::Alias(inner) => span_tree_bounds(inner),
+    }
+}
+
+/// Resolve `segments` to a byte span in the typed cache. The returned `bool`
+/// is `true` when resolution passed *through* an alias reference (the span
+/// then belongs to the anchor, not the addressed key) — correct to return for
+/// a read, but a write must refuse it.
 fn resolve_span(
     value: &Value,
     span_tree: &SpanTree,
     segments: &[QuerySegment],
-) -> Option<(usize, usize)> {
+) -> Option<((usize, usize), bool)> {
+    // An alias site substitutes the anchor's (value, tree). Resolve against the
+    // anchor but flag that the path went through an alias — at any depth, so
+    // `ref` and `ref.nested` and `[*a]` are all caught.
+    if let SpanTree::Alias(inner) = span_tree {
+        return resolve_span(value, inner, segments).map(|(span, _)| (span, true));
+    }
     if segments.is_empty() {
         return match span_tree {
             // A zero-width leaf marks an implicit null (an absent
             // block-mapping value or empty sequence item): the node has no
             // source bytes of its own, so it has no span.
             SpanTree::Leaf(s, e) if s == e => None,
-            SpanTree::Leaf(s, e) => Some((*s, *e)),
+            SpanTree::Leaf(s, e) => Some(((*s, *e), false)),
             SpanTree::Sequence { start, end, .. } | SpanTree::Mapping { start, end, .. } => {
-                Some((*start, *end))
+                Some(((*start, *end), false))
             }
+            SpanTree::Alias(_) => None, // unwrapped above
         };
     }
     let (head, tail) = segments.split_first()?;
@@ -1861,10 +1760,7 @@ fn entry_line_span(
                 .position(|(mk, _)| mk == k)
                 .ok_or_else(|| Error::Parse(format!("path not found: missing key {k:?}")))?;
             let ((key_start, _key_end), child_tree) = &entries[pos];
-            let raw_value_end = match child_tree {
-                SpanTree::Leaf(_, e) => *e,
-                SpanTree::Sequence { end, .. } | SpanTree::Mapping { end, .. } => *end,
-            };
+            let raw_value_end = span_tree_end(child_tree);
             let (_, value_end) = trim_trailing_blank(source, *key_start, raw_value_end);
             require_single_line(source, *key_start, value_end)?;
             Ok(line_extent(source, *key_start, value_end))
@@ -1878,12 +1774,7 @@ fn entry_line_span(
             let item_tree = items
                 .get(*i)
                 .ok_or_else(|| Error::Parse(format!("path not found: index {i} out of bounds")))?;
-            let (value_start, raw_value_end) = match item_tree {
-                SpanTree::Leaf(s, e) => (*s, *e),
-                SpanTree::Sequence { start, end, .. } | SpanTree::Mapping { start, end, .. } => {
-                    (*start, *end)
-                }
-            };
+            let (value_start, raw_value_end) = span_tree_bounds(item_tree);
             let (_, value_end) = trim_trailing_blank(source, value_start, raw_value_end);
             // The `-` indicator sits before the value on the same line,
             // separated by inline whitespace. Walk backward to find it.

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -401,11 +401,24 @@ where
     // axis, route through the AST loader so the relevant toggle
     // takes effect. Active `properties` interpolation also disables
     // the streaming path so the post-parse substitution walk runs.
+    //
+    // The `Value` target is *excluded* from the streaming path
+    // (unless a tag registry is active — the registry strips
+    // registered tags off scalars, and that only happens on the
+    // streaming path today). Rationale: serde asks the streaming
+    // deserializer for `String` keys, which stringifies typed
+    // scalars *before* `ValueVisitor::visit_map` can tell `1` and
+    // `"1"` apart — the distinct-typed `KeyCollision` guard is
+    // unreachable there. The `Value`-target fast path a few lines
+    // down runs the span-free loader which owns the collision
+    // check and the DoS budgets.
+    let value_target_bypass = is_value_target::<T>() && config.tag_registry.is_none();
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
         && config.policies.is_empty()
         && properties_inactive(config)
-        && includes_inactive(config);
+        && includes_inactive(config)
+        && !value_target_bypass;
     if stream_eligible {
         if let Some(res) = crate::streaming::from_str_streaming(s, config) {
             return res;
@@ -413,6 +426,19 @@ where
     }
 
     let parse_config = parser::ParseConfig::from(config);
+
+    // The streaming path enforces `max_document_length` inline
+    // (`streaming::from_str_streaming` at head-of-fn). When the
+    // streaming path is skipped — either because the caller opted
+    // into a non-default policy or because T is `Value` — the check
+    // must fire here so the AST loader can't be walked over an
+    // oversized document.
+    if s.len() > parse_config.max_document_length {
+        return Err(Error::Parse(format!(
+            "document exceeds maximum length of {} bytes",
+            parse_config.max_document_length
+        )));
+    }
 
     // Skip-span + zero-rewalk fast path: when T == Value, the AST
     // we just parsed *is* the answer. The default path would

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -402,17 +402,17 @@ where
     // takes effect. Active `properties` interpolation also disables
     // the streaming path so the post-parse substitution walk runs.
     //
-    // The `Value` target is *excluded* from the streaming path
-    // (unless a tag registry is active — the registry strips
-    // registered tags off scalars, and that only happens on the
-    // streaming path today). Rationale: serde asks the streaming
-    // deserializer for `String` keys, which stringifies typed
-    // scalars *before* `ValueVisitor::visit_map` can tell `1` and
-    // `"1"` apart — the distinct-typed `KeyCollision` guard is
-    // unreachable there. The `Value`-target fast path a few lines
-    // down runs the span-free loader which owns the collision
-    // check and the DoS budgets.
-    let value_target_bypass = is_value_target::<T>() && config.tag_registry.is_none();
+    // The `Value` target is *always* excluded from the streaming path.
+    // Rationale: serde asks the streaming deserializer for `String`
+    // keys, which stringifies typed scalars *before*
+    // `ValueVisitor::visit_map` can tell `1` and `"1"` apart — the
+    // distinct-typed `KeyCollision` guard is unreachable there. The
+    // `Value`-target fast path a few lines down runs the span-free
+    // loader, which owns the collision check and the DoS budgets — and
+    // strips registry-registered tags itself (loader `resolve_untagged_scalar`),
+    // so an active tag registry no longer forces `Value` back onto the
+    // streaming path where the collision guard cannot run.
+    let value_target_bypass = is_value_target::<T>();
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
         && config.policies.is_empty()

--- a/crates/noyalib/src/error.rs
+++ b/crates/noyalib/src/error.rs
@@ -423,6 +423,23 @@ pub enum Error {
     /// ```
     DuplicateKey(String),
 
+    /// Two distinct-typed keys collapsed to the same string key.
+    ///
+    /// The mapping key model is `Mapping<String, Value>`, so keys are
+    /// stringified. Distinct YAML keys that share a spelling — e.g. the
+    /// integer `1` and the string `"1"`, or `true` and `"true"` — would
+    /// silently overwrite each other, losing an entry. This is raised
+    /// instead, carrying the collapsed string key. Unlike
+    /// [`Self::DuplicateKey`], it fires regardless of `DuplicateKeyPolicy`
+    /// because it is data loss, not an authored duplicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let _e = noyalib::Error::KeyCollision("1".into());
+    /// ```
+    KeyCollision(String),
+
     /// Repetition limit exceeded (security limit against billion-laughs).
     ///
     /// # Examples
@@ -711,6 +728,11 @@ impl fmt::Display for Error {
                 write!(f, "recursion depth limit exceeded: {depth}")
             }
             Error::DuplicateKey(name) => write!(f, "duplicate key: {name}"),
+            Error::KeyCollision(name) => write!(
+                f,
+                "distinct mapping keys collide after string conversion: {name} \
+                 (e.g. `1` and `\"1\"`, or `true` and `\"true\"`)"
+            ),
             Error::RepetitionLimitExceeded => f.write_str("alias expansion limit exceeded"),
             Error::Budget(breach) => write!(f, "{breach}"),
             Error::UnknownAnchor(name) => write!(f, "unknown anchor: {name}"),
@@ -1392,6 +1414,7 @@ impl miette::Diagnostic for Error {
             Error::Budget(_) => "noyalib::budget",
             Error::UnknownAnchor(_) | Error::UnknownAnchorAt { .. } => "noyalib::unknown_anchor",
             Error::DuplicateKey(_) => "noyalib::duplicate_key",
+            Error::KeyCollision(_) => "noyalib::key_collision",
             Error::EndOfStream => "noyalib::eof",
             Error::MoreThanOneDocument => "noyalib::multi_document",
             Error::Io(_) => "noyalib::io",
@@ -1424,6 +1447,9 @@ impl miette::Diagnostic for Error {
             Error::DuplicateKey(_) => {
                 Some("use DuplicateKeyPolicy::Last or ::Error to control behaviour".into())
             }
+            Error::KeyCollision(_) => Some(
+                "give the colliding keys distinct spellings, or quote them consistently".into(),
+            ),
             Error::MoreThanOneDocument => {
                 Some("use noyalib::load_all() to parse multi-document streams".into())
             }

--- a/crates/noyalib/src/error.rs
+++ b/crates/noyalib/src/error.rs
@@ -246,6 +246,62 @@ impl fmt::Display for BudgetBreach {
     }
 }
 
+/// Coarse-grained classification of an [`Error`], exposed for
+/// callers that need to route errors without pattern-matching
+/// every variant. Prefer this over inventing per-variant boolean
+/// accessors (`is_syntax()`, `is_io()`, …): one classifier scales
+/// as new variants land under [`Error`]'s `#[non_exhaustive]`
+/// attribute.
+///
+/// This enum is itself `#[non_exhaustive]` so future variants
+/// (e.g. a dedicated Timeout kind) can be added without a semver
+/// break.
+///
+/// # Examples
+///
+/// ```
+/// use noyalib::{from_str, ErrorKind, Value};
+/// let err = from_str::<Value>("1: a\n\"1\": b\n").unwrap_err();
+/// assert_eq!(err.kind(), ErrorKind::KeyCollision);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// The document was malformed: unterminated flow collection,
+    /// bad indentation, invalid escape, unexpected token, etc.
+    Syntax,
+    /// An I/O operation failed while reading the input.
+    Io,
+    /// A configurable DoS budget or hard security limit was
+    /// exceeded (recursion depth, alias expansion, mapping size,
+    /// merge-key count, …). Covers every `Error::Budget` breach
+    /// as well as [`Error::RecursionLimitExceeded`] and
+    /// [`Error::RepetitionLimitExceeded`].
+    Budget,
+    /// A user-supplied [`crate::policy::Policy`] rejected the
+    /// document, or a policy-only structural rule (merge-value
+    /// shape, scalar-in-merge) tripped.
+    Policy,
+    /// Two distinct-typed YAML keys collapsed to the same string
+    /// key — see [`Error::KeyCollision`].
+    KeyCollision,
+    /// A genuine duplicate key was refused under
+    /// [`crate::DuplicateKeyPolicy::Error`].
+    DuplicateKey,
+    /// The parser reached end-of-stream where more input was
+    /// required.
+    EndOfStream,
+    /// The document parsed but the requested target type could
+    /// not be built (missing field, unknown field, type mismatch,
+    /// bad tag, unknown anchor, …). Covers the whole
+    /// serde-facing "shape doesn't match" family.
+    Data,
+    /// The error came in via [`Error::Custom`] or [`Error::Message`]
+    /// (usually from a `serde::de::Error` bridge) and doesn't map
+    /// cleanly to any of the other kinds.
+    Other,
+}
+
 /// # Examples
 ///
 /// ```
@@ -435,8 +491,20 @@ pub enum Error {
     ///
     /// # Examples
     ///
+    /// The construction shape:
+    ///
     /// ```
     /// let _e = noyalib::Error::KeyCollision("1".into());
+    /// ```
+    ///
+    /// Reproduces from real YAML. The integer key `1` and the
+    /// string key `"1"` both stringify to `"1"`, so parsing must
+    /// refuse rather than silently drop the first entry:
+    ///
+    /// ```
+    /// use noyalib::{Error, Value, from_str};
+    /// let err = from_str::<Value>("1: a\n\"1\": b\n").unwrap_err();
+    /// assert!(matches!(err, Error::KeyCollision(_)));
     /// ```
     KeyCollision(String),
 
@@ -796,6 +864,56 @@ impl Error {
             Error::UnknownAnchorAt { location, .. } => Some(*location),
             Error::Shared(arc) => arc.location(),
             _ => None,
+        }
+    }
+
+    /// Coarse-grained classification for routing without matching
+    /// every variant of the `#[non_exhaustive]` [`Error`] enum.
+    ///
+    /// The mapping is stable across variant additions: new
+    /// variants land under an existing [`ErrorKind`] whenever
+    /// possible, so downstream `match err.kind()` sites keep
+    /// compiling. When a new *category* is needed the enum grows
+    /// (also `#[non_exhaustive]`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use noyalib::{from_str, ErrorKind, Value};
+    ///
+    /// let syntax = from_str::<Value>("a: [unclosed").unwrap_err();
+    /// assert_eq!(syntax.kind(), ErrorKind::Syntax);
+    ///
+    /// let collision = from_str::<Value>("1: a\n\"1\": b\n").unwrap_err();
+    /// assert_eq!(collision.kind(), ErrorKind::KeyCollision);
+    /// ```
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Error::Parse(_) | Error::ParseWithLocation { .. } => ErrorKind::Syntax,
+            Error::Serialize(_) => ErrorKind::Data,
+            Error::Deserialize(_) | Error::DeserializeWithLocation { .. } => ErrorKind::Data,
+            #[cfg(feature = "std")]
+            Error::Io(_) => ErrorKind::Io,
+            Error::Custom(_) => ErrorKind::Other,
+            Error::RecursionLimitExceeded { .. } => ErrorKind::Budget,
+            Error::DuplicateKey(_) => ErrorKind::DuplicateKey,
+            Error::KeyCollision(_) => ErrorKind::KeyCollision,
+            Error::RepetitionLimitExceeded => ErrorKind::Budget,
+            Error::Budget(_) => ErrorKind::Budget,
+            Error::UnknownAnchor(_) | Error::UnknownAnchorAt { .. } => ErrorKind::Data,
+            Error::MissingField(_) | Error::UnknownField(_) => ErrorKind::Data,
+            Error::ScalarInMergeElement
+            | Error::SequenceInMergeElement
+            | Error::TaggedInMerge
+            | Error::ScalarInMerge => ErrorKind::Policy,
+            Error::Invalid(_) => ErrorKind::Data,
+            Error::TypeMismatch { .. } => ErrorKind::Data,
+            Error::Shared(arc) => arc.kind(),
+            Error::EndOfStream => ErrorKind::EndOfStream,
+            Error::MoreThanOneDocument => ErrorKind::Data,
+            Error::EmptyTag => ErrorKind::Syntax,
+            Error::FailedToParseNumber(_) => ErrorKind::Syntax,
+            Error::Message(_, _) => ErrorKind::Other,
         }
     }
 

--- a/crates/noyalib/src/error.rs
+++ b/crates/noyalib/src/error.rs
@@ -829,10 +829,17 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+// `core::error::Error` stabilised in Rust 1.81 — the crate MSRV
+// is 1.85, so the trait implementation is unconditional. Only
+// the `Io(std::io::Error)` arm needs an in-line `cfg` gate,
+// because `Error::Io` itself is `#[cfg(feature = "std")]`. Under
+// `no_std` callers keep full access to the trait for routing via
+// `core::error::Error`-consuming ecosystems (`snafu-nostd`,
+// `miette` no-std shim, embedded HAL error stacks).
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
+            #[cfg(feature = "std")]
             Error::Io(e) => Some(e),
             Error::Shared(arc) => Some(arc.as_ref()),
             _ => None,

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -571,9 +571,7 @@ pub use de::{from_reader_strict, from_slice_strict, from_str_strict};
 #[cfg(feature = "std")]
 pub use document::{DocumentReadIterator, read, read_with_config};
 pub use document::{load_all, load_all_as, load_all_with_config, try_load_all};
-pub use error::{
-    BudgetBreach, CroppedRegion, Error, ErrorKind, Location, RenderOptions, Result,
-};
+pub use error::{BudgetBreach, CroppedRegion, Error, ErrorKind, Location, RenderOptions, Result};
 pub use flattened::Flattened;
 pub use fmt::{Commented, FlowMap, FlowSeq, FoldStr, FoldString, LitStr, LitString, SpaceAfter};
 pub use path::Path;

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -571,7 +571,9 @@ pub use de::{from_reader_strict, from_slice_strict, from_str_strict};
 #[cfg(feature = "std")]
 pub use document::{DocumentReadIterator, read, read_with_config};
 pub use document::{load_all, load_all_as, load_all_with_config, try_load_all};
-pub use error::{BudgetBreach, CroppedRegion, Error, Location, RenderOptions, Result};
+pub use error::{
+    BudgetBreach, CroppedRegion, Error, ErrorKind, Location, RenderOptions, Result,
+};
 pub use flattened::Flattened;
 pub use fmt::{Commented, FlowMap, FlowSeq, FoldStr, FoldString, LitStr, LitString, SpaceAfter};
 pub use path::Path;

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -208,6 +208,11 @@ enum Frame {
     MappingKey {
         map: Mapping,
         span_entries: Vec<((usize, usize), SpanTree)>,
+        /// The original typed key of each inserted entry, in insertion
+        /// order (parallel to `map`). Retained to tell a genuine YAML
+        /// duplicate (`1`/`1`) apart from a distinct-typed collision
+        /// (`1`/`"1"`) once both collapse to the same string key.
+        typed_keys: Vec<Value>,
         start: usize,
         anchor: Option<String>,
         merge_values: Vec<Value>,
@@ -219,7 +224,10 @@ enum Frame {
     MappingValue {
         map: Mapping,
         span_entries: Vec<((usize, usize), SpanTree)>,
+        typed_keys: Vec<Value>,
         key: String,
+        /// The typed key that produced `key`, kept for the collision check.
+        key_value: Value,
         key_span: (usize, usize),
         start: usize,
         anchor: Option<String>,
@@ -468,6 +476,7 @@ impl<'a> Loader<'a> {
                 self.stack.push(Frame::MappingKey {
                     map: Mapping::new(),
                     span_entries: Vec::new(),
+                    typed_keys: Vec::new(),
                     start: span.start,
                     anchor,
                     merge_values: Vec::new(),
@@ -479,6 +488,7 @@ impl<'a> Loader<'a> {
                 if let Some(Frame::MappingKey {
                     mut map,
                     span_entries,
+                    typed_keys: _,
                     start,
                     anchor,
                     merge_values,
@@ -530,11 +540,17 @@ impl<'a> Loader<'a> {
             Frame::MappingKey {
                 map,
                 span_entries,
+                typed_keys,
                 start,
                 anchor,
                 merge_values,
                 tag,
             } => {
+                // Retain the typed key before it is coerced to a string, so
+                // the insert site can tell a genuine duplicate apart from a
+                // distinct-typed collision. The clone is off the hot path
+                // (keys only) and only used for the equality check.
+                let key_value = value.clone();
                 // Coerce scalar keys to strings; complex keys (sequences,
                 // mappings) are stringified via their YAML serialization
                 // so the final `Mapping<String, Value>` can hold them.
@@ -555,6 +571,7 @@ impl<'a> Loader<'a> {
                 };
                 let old_map = core::mem::take(map);
                 let old_span_entries = core::mem::take(span_entries);
+                let old_typed_keys = core::mem::take(typed_keys);
                 let old_start = *start;
                 let old_anchor = anchor.take();
                 let old_merge_values = core::mem::take(merge_values);
@@ -563,7 +580,9 @@ impl<'a> Loader<'a> {
                 *self.stack.last_mut().unwrap() = Frame::MappingValue {
                     map: old_map,
                     span_entries: old_span_entries,
+                    typed_keys: old_typed_keys,
                     key: key_str,
+                    key_value,
                     key_span,
                     start: old_start,
                     anchor: old_anchor,
@@ -574,7 +593,9 @@ impl<'a> Loader<'a> {
             Frame::MappingValue {
                 map,
                 span_entries,
+                typed_keys,
                 key,
+                key_value,
                 key_span,
                 start,
                 anchor,
@@ -609,11 +630,26 @@ impl<'a> Loader<'a> {
                     // slot is discarded. Each branch is the last use of
                     // `key`, so the move is sound.
                     let key = core::mem::take(key);
+                    let key_value = core::mem::take(key_value);
+                    // Distinct-typed collision: the string key already exists
+                    // but was produced by a *different* typed key (e.g. `1`
+                    // then `"1"`, or `true` then `"true"`). Collapsing them
+                    // would silently drop an entry, so refuse regardless of
+                    // DuplicateKeyPolicy. A genuine duplicate (same typed key)
+                    // falls through to the policy below.
+                    if let Some(idx) = map.get_index_of(&key) {
+                        // Nested (not a `let`-chain) to keep the crate's
+                        // 1.85 MSRV: `let`-chains stabilized in 1.88.
+                        if typed_keys[idx] != key_value {
+                            return Err(Error::KeyCollision(key));
+                        }
+                    }
                     match self.config.duplicate_key_policy {
                         DuplicateKeyPolicy::First => {
                             if !map.contains_key(&key) {
                                 let _ = map.insert(key, value);
                                 span_entries.push((*key_span, span));
+                                typed_keys.push(key_value);
                             }
                         }
                         DuplicateKeyPolicy::Last => {
@@ -627,9 +663,12 @@ impl<'a> Loader<'a> {
                             if let Some(idx) = map.get_index_of(&key) {
                                 let _ = map.insert(key, value);
                                 span_entries[idx] = (*key_span, span);
+                                // `typed_keys[idx]` is unchanged: a genuine
+                                // duplicate carries the same typed key.
                             } else {
                                 let _ = map.insert(key, value);
                                 span_entries.push((*key_span, span));
+                                typed_keys.push(key_value);
                             }
                         }
                         DuplicateKeyPolicy::Error => {
@@ -638,12 +677,14 @@ impl<'a> Loader<'a> {
                             }
                             let _ = map.insert(key, value);
                             span_entries.push((*key_span, span));
+                            typed_keys.push(key_value);
                         }
                     }
                 }
 
                 let old_map = core::mem::take(map);
                 let old_span_entries = core::mem::take(span_entries);
+                let old_typed_keys = core::mem::take(typed_keys);
                 let old_start = *start;
                 let old_anchor = anchor.take();
                 let old_merge_values = core::mem::take(merge_values);
@@ -652,6 +693,7 @@ impl<'a> Loader<'a> {
                 *self.stack.last_mut().unwrap() = Frame::MappingKey {
                     map: old_map,
                     span_entries: old_span_entries,
+                    typed_keys: old_typed_keys,
                     start: old_start,
                     anchor: old_anchor,
                     merge_values: old_merge_values,

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -49,6 +49,10 @@ pub struct ParseConfig {
     #[cfg(feature = "lossless-u64")]
     pub lossless_u64_integers: bool,
     pub policies: Vec<Arc<dyn crate::policy::Policy>>,
+    /// Tags registered for strip-through. When set, the loader resolves a
+    /// registered tag's scalar as if untagged (matching the streaming path)
+    /// instead of producing a [`Value::Tagged`].
+    pub tag_registry: Option<Arc<crate::TagRegistry>>,
 }
 
 impl Default for ParseConfig {
@@ -76,6 +80,7 @@ impl Default for ParseConfig {
             #[cfg(feature = "lossless-u64")]
             lossless_u64_integers: false,
             policies: Vec::new(),
+            tag_registry: None,
         }
     }
 }
@@ -126,6 +131,7 @@ impl From<&crate::de::ParserConfig> for ParseConfig {
             #[cfg(feature = "lossless-u64")]
             lossless_u64_integers: c.lossless_u64_integers,
             policies: c.policies.clone(),
+            tag_registry: c.tag_registry.clone(),
         }
     }
 }
@@ -420,32 +426,25 @@ impl<'a> Loader<'a> {
                     && matches!(style, crate::parser::ScalarStyle::Plain)
                     && anchor.is_none()
                     && tag.is_none();
-                let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
-                } else if style != crate::parser::ScalarStyle::Plain {
-                    // Quoted/literal/folded scalars always resolve as
-                    // strings — YAML schema resolution only applies to
-                    // plain scalars.
-                    Value::String(value.into_owned())
-                } else {
-                    match crate::streaming::resolve_plain_ext(
-                        &value,
-                        self.config.strict_booleans,
-                        self.config.legacy_booleans,
-                        self.config.no_schema,
-                        self.config.legacy_octal_numbers,
-                        self.config.legacy_sexagesimal,
-                        self.config.lossless_u64_integers(),
-                    ) {
-                        crate::streaming::Scalar::Null => Value::Null,
-                        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
-                        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
-                        #[cfg(feature = "lossless-u64")]
-                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
-                        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
-                        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
-                    }
-                };
+                let v =
+                    if let Some(t) = tag {
+                        if self.config.tag_registry.as_ref().is_some_and(|r| {
+                            crate::streaming::tag_is_registry_stripped(&t.0, &t.1, r)
+                        }) {
+                            // Registered tag: strip through and resolve as if
+                            // untagged, exactly as the streaming path does.
+                            resolve_untagged_scalar(value, style, self.config)
+                        } else {
+                            resolve_tagged_scalar(
+                                &t.0,
+                                &t.1,
+                                &value,
+                                self.config.lossless_u64_integers(),
+                            )?
+                        }
+                    } else {
+                        resolve_untagged_scalar(value, style, self.config)
+                    };
 
                 let st = if is_implicit_empty {
                     SpanTree::Leaf(span.start, span.start)
@@ -487,7 +486,7 @@ impl<'a> Loader<'a> {
                 }) = self.stack.pop()
                 {
                     let inner = Value::Sequence(items);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     let st = SpanTree::Sequence {
                         start,
                         end: span.end,
@@ -542,7 +541,7 @@ impl<'a> Loader<'a> {
                     }
 
                     let inner = Value::Mapping(map);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     let st = SpanTree::Mapping {
                         start,
                         end: span.end,
@@ -909,6 +908,13 @@ impl<'a> NoSpanLoader<'a> {
                 self.in_document = true;
                 self.anchor_map.clear();
                 self.anchor_def_spans.clear();
+                // Reset the per-document alias budget, matching the span-full
+                // Loader (see DocumentStart above). Without this, alias counts
+                // accumulate across a multi-document stream, so a stream whose
+                // documents are each within budget can be spuriously rejected
+                // on the no-span path — a std/no_std divergence.
+                self.alias_count = 0;
+                self.alias_bytes = 0;
             }
             Event::DocumentEnd => {
                 self.in_document = false;
@@ -957,29 +963,25 @@ impl<'a> NoSpanLoader<'a> {
                 tag,
                 span,
             } => {
-                let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
-                } else if style != crate::parser::ScalarStyle::Plain {
-                    Value::String(value.into_owned())
-                } else {
-                    match crate::streaming::resolve_plain_ext(
-                        &value,
-                        self.config.strict_booleans,
-                        self.config.legacy_booleans,
-                        self.config.no_schema,
-                        self.config.legacy_octal_numbers,
-                        self.config.legacy_sexagesimal,
-                        self.config.lossless_u64_integers(),
-                    ) {
-                        crate::streaming::Scalar::Null => Value::Null,
-                        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
-                        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
-                        #[cfg(feature = "lossless-u64")]
-                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
-                        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
-                        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
-                    }
-                };
+                let v =
+                    if let Some(t) = tag {
+                        if self.config.tag_registry.as_ref().is_some_and(|r| {
+                            crate::streaming::tag_is_registry_stripped(&t.0, &t.1, r)
+                        }) {
+                            // Registered tag: strip through and resolve as if
+                            // untagged, exactly as the streaming path does.
+                            resolve_untagged_scalar(value, style, self.config)
+                        } else {
+                            resolve_tagged_scalar(
+                                &t.0,
+                                &t.1,
+                                &value,
+                                self.config.lossless_u64_integers(),
+                            )?
+                        }
+                    } else {
+                        resolve_untagged_scalar(value, style, self.config)
+                    };
                 if let Some(name) = anchor {
                     let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                     let _ = self.anchor_map.insert(name, v.clone());
@@ -1004,7 +1006,7 @@ impl<'a> NoSpanLoader<'a> {
                 self.depth = self.depth.saturating_sub(1);
                 if let Some(NoSpanFrame::Sequence { items, anchor, tag }) = self.stack.pop() {
                     let inner = Value::Sequence(items);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     if let Some(name) = anchor {
                         let _ = self.anchor_map.insert(name, v.clone());
                     }
@@ -1041,7 +1043,7 @@ impl<'a> NoSpanLoader<'a> {
                         apply_merge(&mut map, mv)?;
                     }
                     let inner = Value::Mapping(map);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     if let Some(name) = anchor {
                         let _ = self.anchor_map.insert(name, v.clone());
                     }
@@ -1287,10 +1289,19 @@ fn value_to_key_string(value: Value) -> Option<String> {
 /// stripped — they are no-ops on a sequence/mapping anyway and
 /// `!!seq` / `!!map` would otherwise leak into the deserialise
 /// return path as redundant metadata.
-fn wrap_with_tag(inner: Value, tag: Option<&(String, String)>) -> Value {
+fn wrap_with_tag(
+    inner: Value,
+    tag: Option<&(String, String)>,
+    registry: Option<&crate::TagRegistry>,
+) -> Value {
     let Some((handle, suffix)) = tag else {
         return inner;
     };
+    // A tag registered for strip-through drops the tag and exposes the bare
+    // collection, matching what the streaming path yields.
+    if registry.is_some_and(|r| crate::streaming::tag_is_registry_stripped(handle, suffix, r)) {
+        return inner;
+    }
     // `!!seq` / `!!map` (and the explicit URI form) are
     // pure-metadata core tags on collections; the `Sequence` or
     // `Mapping` variant of `Value` already conveys "seq" /
@@ -1322,6 +1333,40 @@ fn concat_str(a: &str, b: &str) -> String {
 /// Resolve a tagged scalar into a typed `Value`. Handles the YAML 1.2
 /// core schema tags (`!!int`, `!!float`, `!!bool`, `!!null`, `!!str`)
 /// and any custom tag falls through to the `Tagged` wrapper.
+/// Resolve a scalar as if it carried no tag: quoted / literal / folded →
+/// `String`; plain → YAML 1.2 schema resolution (via the shared
+/// `resolve_plain_ext`, so the two loaders and the streaming path agree).
+/// This is also the strip-through result for a tag registered in the active
+/// [`TagRegistry`], keeping AST and streaming byte-for-byte equivalent.
+fn resolve_untagged_scalar(
+    value: Cow<'_, str>,
+    style: crate::parser::ScalarStyle,
+    config: &ParseConfig,
+) -> Value {
+    if style != crate::parser::ScalarStyle::Plain {
+        // Quoted/literal/folded scalars always resolve as strings — YAML
+        // schema resolution only applies to plain scalars.
+        return Value::String(value.into_owned());
+    }
+    match crate::streaming::resolve_plain_ext(
+        &value,
+        config.strict_booleans,
+        config.legacy_booleans,
+        config.no_schema,
+        config.legacy_octal_numbers,
+        config.legacy_sexagesimal,
+        config.lossless_u64_integers(),
+    ) {
+        crate::streaming::Scalar::Null => Value::Null,
+        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
+        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
+        #[cfg(feature = "lossless-u64")]
+        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
+        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
+        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
+    }
+}
+
 fn resolve_tagged_scalar(
     handle: &str,
     suffix: &str,
@@ -1487,4 +1532,48 @@ fn run_event_policies(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression (v0.0.14 review): NoSpanLoader must zero the alias budget
+    // at each DocumentStart, like the span-full Loader. A multi-document
+    // stream whose documents are each within budget must not be rejected
+    // because the per-document counts accumulate across the stream (a
+    // std/no_std divergence, since the no-span loader is the no_std default).
+    #[test]
+    fn no_span_loader_resets_alias_budget_per_document() {
+        let src = "\
+p: &x 1
+q: *x
+r: *x
+---
+p: &y 2
+q: *y
+r: *y
+---
+p: &z 3
+q: *z
+r: *z
+";
+        // Each document uses exactly 2 aliases (== the limit); three
+        // documents sum to 6. Pre-fix the no-span loader accumulated and
+        // tripped RepetitionLimitExceeded partway through the second doc.
+        let config = ParseConfig {
+            max_alias_expansions: 2,
+            ..ParseConfig::default()
+        };
+        let docs = load_all_no_spans(src, &config)
+            .expect("each document is within the per-document alias budget");
+        assert_eq!(docs.len(), 3);
+
+        // Cross-path parity: the span-full loader already resets per
+        // document, so it accepts the identical stream under the identical
+        // budget. Both paths must agree.
+        let via_span_full =
+            crate::parser::parse(src, &config).expect("span-full loader accepts the same stream");
+        assert_eq!(via_span_full.len(), 3);
+    }
 }

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -1235,7 +1235,11 @@ fn value_to_key_string(value: Value) -> Option<String> {
                 return Some("nan".into());
             }
             if n.is_infinite() {
-                return Some(if n.is_sign_negative() { "-inf".into() } else { "inf".into() });
+                return Some(if n.is_sign_negative() {
+                    "-inf".into()
+                } else {
+                    "inf".into()
+                });
             }
             #[cfg(feature = "fast-float")]
             {

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -242,6 +242,10 @@ struct Loader<'a> {
     docs: Vec<(Value, SpanTree)>,
     stack: Vec<Frame>,
     anchor_map: IndexMap<String, (Value, SpanTree)>,
+    /// Source byte-index of each anchor's definition (parity with
+    /// the streaming path's `anchor_def_spans`) — powers the
+    /// "did you mean …?" affordance on `Error::UnknownAnchorAt`.
+    anchor_def_spans: IndexMap<String, usize>,
     alias_count: usize,
     alias_bytes: usize,
     config: &'a ParseConfig,
@@ -270,6 +274,7 @@ impl<'a> Loader<'a> {
             docs: Vec::with_capacity(1),
             stack: Vec::with_capacity(16),
             anchor_map: IndexMap::with_capacity(4),
+            anchor_def_spans: IndexMap::with_capacity(4),
             alias_count: 0,
             alias_bytes: 0,
             config,
@@ -326,6 +331,7 @@ impl<'a> Loader<'a> {
             Event::DocumentStart => {
                 self.in_document = true;
                 self.anchor_map.clear();
+                self.anchor_def_spans.clear();
                 self.alias_count = 0;
                 self.alias_bytes = 0;
                 // Budget: max_documents
@@ -363,10 +369,23 @@ impl<'a> Loader<'a> {
 
                 let (value, span_tree) =
                     self.anchor_map.get(&anchor).cloned().ok_or_else(|| {
+                        let alias_loc = crate::error::Location::from_index(input, span.start);
+                        let suggestion = crate::error::closest_name(
+                            &anchor,
+                            self.anchor_def_spans.keys().map(|s| s.as_str()),
+                        )
+                        .and_then(|s| {
+                            self.anchor_def_spans.get(s).map(|&idx| {
+                                (
+                                    s.to_string(),
+                                    crate::error::Location::from_index(input, idx),
+                                )
+                            })
+                        });
                         Error::UnknownAnchorAt {
                             name: anchor.clone(),
-                            location: crate::error::Location::from_index(input, span.start),
-                            suggestion: None,
+                            location: alias_loc,
+                            suggestion,
                         }
                     })?;
 
@@ -434,6 +453,7 @@ impl<'a> Loader<'a> {
                     SpanTree::Leaf(span.start, span.end)
                 };
                 if let Some(name) = anchor {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                     let _ = self.anchor_map.insert(name, (v.clone(), st.clone()));
                 }
                 self.push_node(v, st, input)?;
@@ -444,6 +464,9 @@ impl<'a> Loader<'a> {
                 self.depth += 1;
                 if self.depth > self.config.max_depth {
                     return Err(Error::RecursionLimitExceeded { depth: self.depth });
+                }
+                if let Some(name) = anchor.as_ref() {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                 }
                 self.stack.push(Frame::Sequence {
                     items: Vec::new(),
@@ -488,6 +511,9 @@ impl<'a> Loader<'a> {
                 self.depth += 1;
                 if self.depth > self.config.max_depth {
                     return Err(Error::RecursionLimitExceeded { depth: self.depth });
+                }
+                if let Some(name) = anchor.as_ref() {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                 }
                 self.stack.push(Frame::MappingKey {
                     map: Mapping::new(),
@@ -564,9 +590,17 @@ impl<'a> Loader<'a> {
             } => {
                 // Retain the typed key before it is coerced to a string, so
                 // the insert site can tell a genuine duplicate apart from a
-                // distinct-typed collision. The clone is off the hot path
-                // (keys only) and only used for the equality check.
-                let key_value = value.clone();
+                // distinct-typed collision. Skip the clone when the key is
+                // a merge key (`<<`) that will be buffered rather than
+                // inserted — merge values bypass the collision check, so
+                // the clone would be pure waste on `<<`-heavy documents.
+                let is_buffered_merge_key = matches!(&value, Value::String(s) if s == MERGE_KEY)
+                    && !matches!(self.config.merge_key_policy, MergeKeyPolicy::AsOrdinary);
+                let key_value = if is_buffered_merge_key {
+                    Value::Null
+                } else {
+                    value.clone()
+                };
                 // Coerce scalar keys to strings; complex keys (sequences,
                 // mappings) are stringified via their YAML serialization
                 // so the final `Mapping<String, Value>` can hold them.
@@ -802,13 +836,22 @@ enum NoSpanFrame {
     },
     MappingKey {
         map: Mapping,
+        // Parallel to `map`: retains the *typed* value that produced
+        // each string key so the value-arm's collision check can tell
+        // a distinct-typed collision (`1` vs `"1"`) apart from a
+        // genuine duplicate (`1` twice). Mirrors the span-full loader.
+        typed_keys: Vec<Value>,
         anchor: Option<String>,
         merge_values: Vec<Value>,
         tag: Option<(String, String)>,
     },
     MappingValue {
         map: Mapping,
+        typed_keys: Vec<Value>,
         key: String,
+        // The typed key value the current `key` string was derived
+        // from; consumed by the collision check in the value arm.
+        key_value: Value,
         anchor: Option<String>,
         merge_values: Vec<Value>,
         tag: Option<(String, String)>,
@@ -819,8 +862,17 @@ struct NoSpanLoader<'a> {
     docs: Vec<Value>,
     stack: Vec<NoSpanFrame>,
     anchor_map: IndexMap<String, Value>,
+    // Source byte-index of each anchor's definition, keyed by name.
+    // Populated alongside `anchor_map` so an unknown-alias error can
+    // point at the closest known definition — the same "did you mean
+    // `&logger`?" affordance the streaming path already offers.
+    anchor_def_spans: IndexMap<String, usize>,
     alias_count: usize,
     alias_bytes: usize,
+    // Merge-key occurrences seen across the current document (for
+    // `max_merge_keys`). Mirrors the span-full loader's counter so a
+    // billion-merges DoS is refused on the `Value` fast path too.
+    merge_key_count: usize,
     config: &'a ParseConfig,
     depth: usize,
     in_document: bool,
@@ -832,8 +884,10 @@ impl<'a> NoSpanLoader<'a> {
             docs: Vec::new(),
             stack: Vec::new(),
             anchor_map: IndexMap::new(),
+            anchor_def_spans: IndexMap::new(),
             alias_count: 0,
             alias_bytes: 0,
+            merge_key_count: 0,
             config,
             depth: 0,
             in_document: false,
@@ -854,6 +908,7 @@ impl<'a> NoSpanLoader<'a> {
             Event::DocumentStart => {
                 self.in_document = true;
                 self.anchor_map.clear();
+                self.anchor_def_spans.clear();
             }
             Event::DocumentEnd => {
                 self.in_document = false;
@@ -864,14 +919,33 @@ impl<'a> NoSpanLoader<'a> {
                     return Err(Error::RepetitionLimitExceeded);
                 }
                 let value = self.anchor_map.get(&anchor).cloned().ok_or_else(|| {
+                    let alias_loc = crate::error::Location::from_index(input, span.start);
+                    let suggestion = crate::error::closest_name(
+                        &anchor,
+                        self.anchor_def_spans.keys().map(|s| s.as_str()),
+                    )
+                    .and_then(|s| {
+                        self.anchor_def_spans.get(s).map(|&idx| {
+                            (
+                                s.to_string(),
+                                crate::error::Location::from_index(input, idx),
+                            )
+                        })
+                    });
                     Error::UnknownAnchorAt {
                         name: anchor,
-                        location: crate::error::Location::from_index(input, span.start),
-                        suggestion: None,
+                        location: alias_loc,
+                        suggestion,
                     }
                 })?;
                 self.alias_bytes += estimate_value_size(&value);
-                if self.alias_bytes > MAX_ALIAS_BYTES {
+                // Bound cumulative alias expansion by both the crate-level
+                // hard cap and the caller-supplied `max_document_length`.
+                // Mirrors the span-full loader (billion-laughs guard) so
+                // the `Value` fast path can't outrun either budget.
+                if self.alias_bytes > self.config.max_document_length
+                    || self.alias_bytes > MAX_ALIAS_BYTES
+                {
                     return Err(Error::RepetitionLimitExceeded);
                 }
                 self.push_value(value)?;
@@ -881,7 +955,7 @@ impl<'a> NoSpanLoader<'a> {
                 style,
                 anchor,
                 tag,
-                ..
+                span,
             } => {
                 let v = if let Some(t) = tag {
                     resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
@@ -907,14 +981,18 @@ impl<'a> NoSpanLoader<'a> {
                     }
                 };
                 if let Some(name) = anchor {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                     let _ = self.anchor_map.insert(name, v.clone());
                 }
                 self.push_value(v)?;
             }
-            Event::SequenceStart { anchor, tag, .. } => {
+            Event::SequenceStart { anchor, tag, span } => {
                 self.depth += 1;
                 if self.depth > self.config.max_depth {
                     return Err(Error::RecursionLimitExceeded { depth: self.depth });
+                }
+                if let Some(name) = anchor.as_ref() {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                 }
                 self.stack.push(NoSpanFrame::Sequence {
                     items: Vec::new(),
@@ -933,13 +1011,17 @@ impl<'a> NoSpanLoader<'a> {
                     self.push_value(v)?;
                 }
             }
-            Event::MappingStart { anchor, tag, .. } => {
+            Event::MappingStart { anchor, tag, span } => {
                 self.depth += 1;
                 if self.depth > self.config.max_depth {
                     return Err(Error::RecursionLimitExceeded { depth: self.depth });
                 }
+                if let Some(name) = anchor.as_ref() {
+                    let _ = self.anchor_def_spans.insert(name.clone(), span.start);
+                }
                 self.stack.push(NoSpanFrame::MappingKey {
                     map: Mapping::new(),
+                    typed_keys: Vec::new(),
                     anchor,
                     merge_values: Vec::new(),
                     tag,
@@ -949,6 +1031,7 @@ impl<'a> NoSpanLoader<'a> {
                 self.depth = self.depth.saturating_sub(1);
                 if let Some(NoSpanFrame::MappingKey {
                     mut map,
+                    typed_keys: _,
                     anchor,
                     merge_values,
                     tag,
@@ -976,22 +1059,44 @@ impl<'a> NoSpanLoader<'a> {
         }
         match self.stack.last_mut().unwrap() {
             NoSpanFrame::Sequence { items, .. } => {
+                if items.len() >= self.config.max_sequence_length {
+                    return Err(Error::Serialize(
+                        "sequence length limit exceeded".to_owned(),
+                    ));
+                }
                 items.push(value);
             }
             NoSpanFrame::MappingKey {
                 map,
+                typed_keys,
                 anchor,
                 merge_values,
                 tag,
             } => {
+                // Retain the typed key before coercing to a string so
+                // the value arm can distinguish a distinct-typed
+                // collision (`1` vs `"1"`) from a genuine duplicate.
+                // Skip the clone on merge keys that will be buffered
+                // rather than inserted; merge values bypass the
+                // collision check, so the clone would be waste.
+                let is_buffered_merge_key = matches!(&value, Value::String(s) if s == MERGE_KEY)
+                    && !matches!(self.config.merge_key_policy, MergeKeyPolicy::AsOrdinary);
+                let key_value = if is_buffered_merge_key {
+                    Value::Null
+                } else {
+                    value.clone()
+                };
                 if let Some(key) = value_to_key_string(value) {
                     let old_map = core::mem::take(map);
+                    let old_typed_keys = core::mem::take(typed_keys);
                     let old_anchor = anchor.take();
                     let old_merge_values = core::mem::take(merge_values);
                     let old_tag = tag.take();
                     *self.stack.last_mut().unwrap() = NoSpanFrame::MappingValue {
                         map: old_map,
+                        typed_keys: old_typed_keys,
                         key,
+                        key_value,
                         anchor: old_anchor,
                         merge_values: old_merge_values,
                         tag: old_tag,
@@ -1000,7 +1105,9 @@ impl<'a> NoSpanLoader<'a> {
             }
             NoSpanFrame::MappingValue {
                 map,
+                typed_keys,
                 key,
+                key_value,
                 anchor,
                 merge_values,
                 tag,
@@ -1015,20 +1122,65 @@ impl<'a> NoSpanLoader<'a> {
                     ));
                 }
                 if is_merge && !merge_treat_as_ordinary {
+                    self.merge_key_count = self.merge_key_count.saturating_add(1);
+                    if self.merge_key_count > self.config.max_merge_keys {
+                        return Err(Error::Budget(crate::BudgetBreach::MaxMergeKeys {
+                            limit: self.config.max_merge_keys,
+                            observed: self.merge_key_count,
+                        }));
+                    }
                     merge_values.push(value);
                 } else {
+                    if map.len() >= self.config.max_mapping_keys {
+                        return Err(Error::Serialize("mapping key limit exceeded".to_owned()));
+                    }
                     // Steal the owned key out of the frame instead of
                     // cloning it — the frame is overwritten (without
                     // `key`) immediately below, so the emptied slot is
                     // discarded.
-                    let _ = map.insert(core::mem::take(key), value);
+                    let key = core::mem::take(key);
+                    let key_value = core::mem::take(key_value);
+                    // Distinct-typed collision: the string key already
+                    // exists but was produced by a different typed key
+                    // (e.g. `1` then `"1"`). Silently collapsing these
+                    // would drop an entry — refuse regardless of
+                    // DuplicateKeyPolicy so the fast `Value` path has
+                    // the same guard as the span-full loader.
+                    if let Some(idx) = map.get_index_of(&key) {
+                        if typed_keys[idx] != key_value {
+                            return Err(Error::KeyCollision(key));
+                        }
+                        // Genuine duplicate: apply the caller's
+                        // policy. Mirrors the span-full loader arms.
+                        match self.config.duplicate_key_policy {
+                            DuplicateKeyPolicy::First => {
+                                // Keep the first occurrence: no-op.
+                            }
+                            DuplicateKeyPolicy::Last => {
+                                let _ = map.insert(key, value);
+                            }
+                            DuplicateKeyPolicy::Error => {
+                                return Err(Error::DuplicateKey(key));
+                            }
+                        }
+                    } else {
+                        let _ = map.insert(key, value);
+                        typed_keys.push(key_value);
+                    }
+                    debug_assert_eq!(
+                        map.len(),
+                        typed_keys.len(),
+                        "typed_keys must remain parallel to map"
+                    );
                 }
                 let old_map = core::mem::take(map);
+                let old_typed_keys = core::mem::take(typed_keys);
                 let old_anchor = anchor.take();
                 let old_merge_values = core::mem::take(merge_values);
                 let old_tag = tag.take();
                 *self.stack.last_mut().unwrap() = NoSpanFrame::MappingKey {
                     map: old_map,
+                    typed_keys: old_typed_keys,
                     anchor: old_anchor,
                     merge_values: old_merge_values,
                     tag: old_tag,
@@ -1071,6 +1223,20 @@ fn value_to_key_string(value: Value) -> Option<String> {
             }
         }
         Value::Number(Number::Float(n)) => {
+            // Special-value floats need spec-shaped spellings so a
+            // YAML `nan:` or `.inf:` key round-trips as the string
+            // it was written as. Rust's Debug prints these as `NaN`
+            // and `inf`; ryu prints them as `NaN` and `inf` too —
+            // both diverge from the resolver's accepted plain forms
+            // (`nan`, `inf`, `-inf`) that keyed lookups typically
+            // use. Canonicalise to lowercase-plain here so keys
+            // survive `Value` deserialization.
+            if n.is_nan() {
+                return Some("nan".into());
+            }
+            if n.is_infinite() {
+                return Some(if n.is_sign_negative() { "-inf".into() } else { "inf".into() });
+            }
             #[cfg(feature = "fast-float")]
             {
                 Some(ryu::Buffer::new().format(n).to_owned())

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -405,7 +405,11 @@ impl<'a> Loader<'a> {
                     return Err(Error::RepetitionLimitExceeded);
                 }
 
-                self.push_node(value, span_tree, input)?;
+                // Wrap the anchor's cloned tree so span resolution can tell it
+                // reached this value *through* an alias — a read resolves
+                // through (issue #149), a write must refuse (would splice the
+                // anchor's bytes, a different key).
+                self.push_node(value, SpanTree::Alias(Box::new(span_tree)), input)?;
             }
             Event::Scalar {
                 value,

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -915,6 +915,16 @@ impl<'a> NoSpanLoader<'a> {
                 // on the no-span path — a std/no_std divergence.
                 self.alias_count = 0;
                 self.alias_bytes = 0;
+                // Budget: max_documents (mirror the span-full Loader).
+                // `from_str::<Value>` always routes through this loader, so
+                // without this the fast path silently materialises the whole
+                // stream past the caller's document limit.
+                if self.docs.len() + 1 > self.config.max_documents {
+                    return Err(Error::Budget(crate::BudgetBreach::MaxDocuments {
+                        limit: self.config.max_documents,
+                        observed: self.docs.len() + 1,
+                    }));
+                }
             }
             Event::DocumentEnd => {
                 self.in_document = false;

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -389,6 +389,18 @@ impl<'a> Loader<'a> {
                 tag,
                 span,
             } => {
+                // An empty plain scalar with no anchor or tag is the
+                // implicit null the parser synthesizes for an absent
+                // block-mapping value or empty sequence item. The span it
+                // was handed is the `:` / `-` indicator it followed, not the
+                // value's own bytes, so mark the leaf zero-width: the node
+                // has no source of its own and `span_at` should report None.
+                // Quoted empties carry a non-Plain style and `~` / `null` a
+                // non-empty value, so both keep their real spans.
+                let is_implicit_empty = value.is_empty()
+                    && matches!(style, crate::parser::ScalarStyle::Plain)
+                    && anchor.is_none()
+                    && tag.is_none();
                 let v = if let Some(t) = tag {
                     resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
                 } else if style != crate::parser::ScalarStyle::Plain {
@@ -416,7 +428,11 @@ impl<'a> Loader<'a> {
                     }
                 };
 
-                let st = SpanTree::Leaf(span.start, span.end);
+                let st = if is_implicit_empty {
+                    SpanTree::Leaf(span.start, span.start)
+                } else {
+                    SpanTree::Leaf(span.start, span.end)
+                };
                 if let Some(name) = anchor {
                     let _ = self.anchor_map.insert(name, (v.clone(), st.clone()));
                 }

--- a/crates/noyalib/src/parser/scanner.rs
+++ b/crates/noyalib/src/parser/scanner.rs
@@ -529,7 +529,15 @@ impl<'a> Scanner<'a> {
     #[inline]
     fn advance(&mut self) {
         if self.pos < self.input.len() {
-            if self.input[self.pos] == b'\n' {
+            // YAML 1.2.2 §5.4: a line break is LF, CR, or CRLF. A lone CR
+            // (classic-Mac, not followed by LF) resets the column exactly
+            // like LF; without this, CR-only input desyncs indentation
+            // tracking and yields spurious "inconsistent indentation".
+            // CRLF is consumed via `advance_by`, so its `\r` never reaches
+            // this branch; and even byte-by-byte a `\r\n` pair still nets
+            // col = 0, matching the previous behavior.
+            let b = self.input[self.pos];
+            if b == b'\n' || b == b'\r' {
                 self.col = 0;
             } else {
                 self.col += 1;
@@ -542,11 +550,14 @@ impl<'a> Scanner<'a> {
     fn advance_by(&mut self, n: usize) {
         let end = (self.pos + n).min(self.input.len());
         let slice = &self.input[self.pos..end];
-        // Fast path: no newlines in the slice (common for scalar content).
-        match slice.iter().rposition(|&b| b == b'\n') {
-            Some(last_nl) => {
-                // Column resets at the last newline, then counts remaining bytes.
-                self.col = slice.len() - last_nl - 1;
+        // Column resets at the last line break in the slice. A line break is
+        // LF, CR, or CRLF (YAML 1.2.2 §5.4); for CRLF the trailing `\n` is the
+        // last matched byte, so the column count after it is identical to
+        // matching `\n` alone — this only additionally handles a trailing lone
+        // CR (classic-Mac), mirroring `advance`.
+        match slice.iter().rposition(|&b| b == b'\n' || b == b'\r') {
+            Some(last_break) => {
+                self.col = slice.len() - last_break - 1;
             }
             None => {
                 self.col += slice.len();
@@ -1754,9 +1765,15 @@ impl<'a> Scanner<'a> {
                 // Roll indent for block mapping.
                 if self.flow_level == 0 {
                     self.reject_block_inline_with_doc_start("':'")?;
+                    // A line break is LF, CR, or CRLF (YAML 1.2.2 §5.4);
+                    // scan back for either so a key following a lone CR
+                    // (classic-Mac) is measured from its true line start.
+                    // Matching only `\n` over-counts such a key's column,
+                    // splitting the mapping (the same failure the BOM case
+                    // below guards against).
                     let mut line_start = self.input[..sk.index]
                         .iter()
-                        .rposition(|&b| b == b'\n')
+                        .rposition(|&b| b == b'\n' || b == b'\r')
                         .map_or(0, |nl| nl + 1);
                     // A leading BOM occupies the first three bytes of the
                     // stream but contributes no visual column. Exclude it so a

--- a/crates/noyalib/src/simd.rs
+++ b/crates/noyalib/src/simd.rs
@@ -766,15 +766,11 @@ pub fn parse_decimal_u64(bytes: &[u8]) -> Option<u64> {
     while i + 8 <= bytes.len() {
         let mut arr = [0u8; 8];
         arr.copy_from_slice(&bytes[i..i + 8]);
-        match parse_8_digits(arr) {
-            Some(eight) => {
-                // Shift the accumulator up by 8 decimal places
-                // and add the new chunk. Overflow → bail.
-                result = result.checked_mul(100_000_000)?.checked_add(eight)?;
-                i += 8;
-            }
-            None => return None,
-        }
+        // Shift the accumulator up by 8 decimal places and add the new
+        // chunk. A non-numeric chunk or overflow bails via `?`.
+        let eight = parse_8_digits(arr)?;
+        result = result.checked_mul(100_000_000)?.checked_add(eight)?;
+        i += 8;
     }
     // Scalar tail: 0..7 remaining bytes.
     while i < bytes.len() {

--- a/crates/noyalib/src/span_context.rs
+++ b/crates/noyalib/src/span_context.rs
@@ -34,6 +34,12 @@ pub(crate) enum SpanTree {
         end: usize,
         entries: Vec<((usize, usize), SpanTree)>,
     },
+    /// An alias reference (`*name`) resolved *through* to its anchor's
+    /// definition tree (issue #149): the wrapped tree is the anchor's, so a
+    /// read here yields the anchor's value span. The wrapper records that the
+    /// resolution passed through an alias — a *write* would splice the
+    /// anchor's bytes (a different key), which `Document::set` must refuse.
+    Alias(Box<SpanTree>),
 }
 
 /// Holds the span map and source string for the current deserialization.
@@ -139,5 +145,7 @@ fn walk(value: &Value, tree: &SpanTree, map: &mut FxHashMap<usize, (usize, usize
                 }
             }
         }
+        // An alias site maps to the anchor's spans; walk through it.
+        SpanTree::Alias(inner) => walk(value, inner, map),
     }
 }

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -556,23 +556,9 @@ impl<'a> StreamingDeserializer<'a> {
     /// resolution) that the AST resolver must see. Registering one of
     /// those tags is a no-op.
     fn tag_in_registry(&self, tag: &(String, String)) -> bool {
-        if matches!(
-            (tag.0.as_str(), tag.1.as_str()),
-            ("!!", "int")
-                | ("!!", "float")
-                | ("!!", "str")
-                | ("!!", "bool")
-                | ("!!", "null")
-                | ("!!", "seq")
-                | ("!!", "map")
-        ) {
-            return false;
-        }
-        let Some(registry) = self.tag_registry.as_ref() else {
-            return false;
-        };
-        let full = format!("{}{}", tag.0, tag.1);
-        registry.contains(&full)
+        self.tag_registry
+            .as_ref()
+            .is_some_and(|r| tag_is_registry_stripped(&tag.0, &tag.1, r))
     }
 
     /// Put a tag back onto the currently-cached event. Used to restore
@@ -1597,6 +1583,33 @@ fn is_fallback_error(e: &Error) -> bool {
         Error::Custom(msg) => msg == FALLBACK_SENTINEL,
         _ => false,
     }
+}
+
+/// Is the tag `{handle}{suffix}` registered for strip-through in `registry`?
+///
+/// Core YAML 1.2 tags (`!!int`, `!!float`, `!!str`, `!!bool`, `!!null`,
+/// `!!seq`, `!!map`) are never stripped — their tag carries semantic
+/// resolution the loader/streamer must see, so registering one is a no-op.
+/// Shared by the streaming deserializer and the AST loader so both agree on
+/// exactly what a registry strips (three-loader parity).
+pub(crate) fn tag_is_registry_stripped(
+    handle: &str,
+    suffix: &str,
+    registry: &crate::TagRegistry,
+) -> bool {
+    if matches!(
+        (handle, suffix),
+        ("!!", "int")
+            | ("!!", "float")
+            | ("!!", "str")
+            | ("!!", "bool")
+            | ("!!", "null")
+            | ("!!", "seq")
+            | ("!!", "map")
+    ) {
+        return false;
+    }
+    registry.contains(&format!("{handle}{suffix}"))
 }
 
 /// Resolve a plain scalar according to YAML 1.2's implicit-typing

--- a/crates/noyalib/tests/coverage_scanner.rs
+++ b/crates/noyalib/tests/coverage_scanner.rs
@@ -432,3 +432,33 @@ fn spanned_sequence_deserialization() {
     let v: Spanned<Vec<i32>> = from_str(yaml).unwrap();
     assert_eq!(v.value.len(), 3);
 }
+
+// ── Classic-Mac CR-only line endings (YAML 1.2.2 §5.4) ──────────────────
+
+#[test]
+fn cr_only_line_endings_parse_as_line_breaks() {
+    // A lone CR (not part of CRLF) is a valid YAML line break. Before the
+    // scanner reset the column on a bare `\r`, this was rejected with a
+    // spurious "inconsistent indentation" error.
+    let yaml = "a: 1\rb: 2\r";
+    let v: Value = from_str(yaml).unwrap();
+    assert_eq!(v["a"], Value::from(1));
+    assert_eq!(v["b"], Value::from(2));
+}
+
+#[test]
+fn cr_only_block_sequence_parses() {
+    let yaml = "- one\r- two\r- three\r";
+    let v: Value = from_str(yaml).unwrap();
+    assert_eq!(v.as_sequence().map(|s| s.len()), Some(3));
+    assert_eq!(v[0], Value::String("one".to_string()));
+    assert_eq!(v[2], Value::String("three".to_string()));
+}
+
+#[test]
+fn cr_only_round_trips_byte_for_byte() {
+    // The CST keeps source bytes verbatim regardless of line-ending flavor.
+    let yaml = "a: 1\rb: 2\r";
+    let doc = noyalib::cst::parse_document(yaml).unwrap();
+    assert_eq!(doc.source(), yaml);
+}

--- a/crates/noyalib/tests/cst_anchors.rs
+++ b/crates/noyalib/tests/cst_anchors.rs
@@ -394,3 +394,40 @@ fn set_through_aliased_sequence_item_is_refused() {
     assert!(doc.set("list.0", "bar").is_err());
     assert_eq!(doc.to_string(), before);
 }
+
+// ── Regression: alias-write guard must cover undecodable (quoted) keys ──
+
+#[test]
+fn set_through_double_quoted_alias_key_is_refused() {
+    // ultrareview BUG003. The alias-write guard matched keys via
+    // `entry_key_text`, which can't decode double-quoted keys, so
+    // `set("target_key", …)` on a double-quoted alias entry slipped past
+    // the guard and spliced the ANCHOR's value — silent corruption of a
+    // different key. Must be refused.
+    let src = "anchor_key: &a foo\n\"target_key\": *a\n";
+    let mut doc = parse_document(src).unwrap();
+    let before = doc.to_string();
+    assert!(
+        doc.set("target_key", "bar").is_err(),
+        "set through a double-quoted alias key must be refused"
+    );
+    assert_eq!(
+        doc.to_string(),
+        before,
+        "document must be unchanged (no anchor corruption)"
+    );
+}
+
+#[test]
+fn set_double_quoted_key_with_plain_value_still_works() {
+    // No regression: an ordinary double-quoted key whose value is NOT an
+    // alias is still writable — the guard only fires on alias values.
+    let mut doc = parse_document("\"my key\": old\nplain: keep\n").unwrap();
+    doc.set("my key", "new").unwrap();
+    assert!(
+        doc.to_string().contains("\"my key\": new"),
+        "got {:?}",
+        doc.to_string()
+    );
+    assert!(doc.to_string().contains("plain: keep"));
+}

--- a/crates/noyalib/tests/cst_anchors.rs
+++ b/crates/noyalib/tests/cst_anchors.rs
@@ -349,3 +349,48 @@ other: 1
     assert!(doc.to_string().contains("&flags"));
     assert!(doc.to_string().contains("other: 2"));
 }
+
+// ── Regression: set/set_value must not write through an alias ────────
+
+#[test]
+fn set_through_alias_is_refused_not_written_to_the_anchor() {
+    // v0.0.14 review regression. `span_at` resolves an alias reference
+    // *through* to its anchor's value span (issue #149) — the correct
+    // target for a read. `set` / `set_value` reused that span for writes,
+    // so `set("ref", …)` spliced over the ANCHOR's value (`foo` on the
+    // `base:` line), silently corrupting a *different* key and leaving the
+    // alias untouched. They must refuse the edit instead.
+    let mut doc = parse_document("base: &a foo\nref: *a\n").unwrap();
+    let before = doc.to_string();
+
+    let err = doc.set("ref", "bar");
+    assert!(
+        err.is_err(),
+        "set through an alias must be refused, not silently mis-applied to the anchor"
+    );
+    assert_eq!(
+        doc.to_string(),
+        before,
+        "a refused set must leave the document byte-for-byte unchanged (no anchor corruption)"
+    );
+
+    // set_value shares the hazard and the guard.
+    let err = doc.set_value("ref", &noyalib::Value::String("bar".into()));
+    assert!(err.is_err());
+    assert_eq!(doc.to_string(), before);
+
+    // A plain (non-aliased) sibling value is still writable — the guard is
+    // scoped to alias targets, it does not block ordinary edits.
+    let mut doc2 = parse_document("base: &a foo\nplain: keep\n").unwrap();
+    doc2.set("plain", "changed").unwrap();
+    assert!(doc2.to_string().contains("plain: changed"));
+}
+
+#[test]
+fn set_through_aliased_sequence_item_is_refused() {
+    // The same hazard exists for an alias used as a sequence item.
+    let mut doc = parse_document("anchor: &a foo\nlist:\n  - *a\n").unwrap();
+    let before = doc.to_string();
+    assert!(doc.set("list.0", "bar").is_err());
+    assert_eq!(doc.to_string(), before);
+}

--- a/crates/noyalib/tests/cst_anchors.rs
+++ b/crates/noyalib/tests/cst_anchors.rs
@@ -431,3 +431,59 @@ fn set_double_quoted_key_with_plain_value_still_works() {
     );
     assert!(doc.to_string().contains("plain: keep"));
 }
+
+// ── Alias-write guard: resolution-layer coverage (ultrareview #2) ──────
+// The guard now keys off resolve_span's through-alias flag (the same
+// resolution span_at uses), closing four holes the green-tree detector
+// missed: flow collections, nested descent, mixed duplicate keys, and a
+// false-positive refusal.
+
+#[test]
+fn set_through_alias_in_flow_sequence_is_refused() {
+    // HOLE1: flow collections keep flat tokens (no SequenceItem nodes), so
+    // the old green-walk missed them and set spliced the anchor.
+    let mut doc = parse_document("a: &x foo\nb: [*x, 2]\n").unwrap();
+    let before = doc.to_string();
+    assert!(doc.set("b[0]", "bar").is_err());
+    assert_eq!(doc.to_string(), before, "anchor must be untouched");
+}
+
+#[test]
+fn set_nested_through_alias_is_refused() {
+    // HOLE2: `ref.foo` descends through the alias into the anchor's mapping.
+    let mut doc = parse_document("anchor: &a\n  foo: 1\n  bar: 2\nref: *a\n").unwrap();
+    let before = doc.to_string();
+    assert!(doc.set("ref.foo", "10").is_err());
+    assert_eq!(
+        doc.to_string(),
+        before,
+        "anchor's nested value must be untouched"
+    );
+}
+
+#[test]
+fn set_duplicate_key_last_is_alias_is_refused() {
+    // HOLE3: `key: value1` then `"key": *a` — DuplicateKeyPolicy::Last makes
+    // the resolved value the alias entry, even though a decodable plain entry
+    // also matched the key.
+    let mut doc = parse_document("anchor_key: &a foo\nkey: value1\n\"key\": *a\n").unwrap();
+    let before = doc.to_string();
+    assert!(doc.set("key", "bar").is_err());
+    assert_eq!(doc.to_string(), before, "anchor must be untouched");
+}
+
+#[test]
+fn set_quoted_key_with_plain_value_beside_alias_sibling_still_works() {
+    // HOLE4: a plain-valued double-quoted key must remain writable even when
+    // an unrelated sibling is an alias (the old boolean-flag guard wrongly
+    // refused this).
+    let mut doc =
+        parse_document("anchor: &a foo\n\"my key\": old\n\"other quoted\": *a\n").unwrap();
+    doc.set("my key", "new").unwrap();
+    assert!(
+        doc.to_string().contains("\"my key\": new"),
+        "got {:?}",
+        doc.to_string()
+    );
+    assert!(doc.to_string().contains("&a foo"), "anchor unchanged");
+}

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -653,6 +653,40 @@ fn coverage_doc_span_at_empty_path_returns_root_collection() {
     assert!(span.is_some() || span.is_none());
 }
 
+// ── Implicit-null nodes have no span of their own ───────────────────
+
+#[test]
+fn coverage_doc_span_at_implicit_null_is_none() {
+    // An absent block-mapping value is the implicit null; its bytes are
+    // the `:` indicator, which is not the value, so span_at reports None.
+    let doc = parse_document("c:\nother: 1\n").unwrap();
+    assert_eq!(doc.span_at("c"), None);
+
+    // Same at end of input.
+    let doc = parse_document("a: 1\nc:\n").unwrap();
+    assert_eq!(doc.span_at("c"), None);
+
+    // Empty sequence item (the `-` indicator) is likewise byte-less.
+    let doc = parse_document("- \n- x\n").unwrap();
+    assert_eq!(doc.span_at("[0]"), None);
+}
+
+#[test]
+fn coverage_doc_span_at_explicit_null_and_empty_quote_keep_span() {
+    // Explicit nulls and quoted empties DO have source bytes.
+    let doc = parse_document("c: ~\nother: 1\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "~");
+
+    let doc = parse_document("c: null\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "null");
+
+    let doc = parse_document("c: ''\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "''");
+}
+
 // ── parse_stream propagates errors from document_boundaries (L985) ──
 
 #[test]

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -802,6 +802,44 @@ fn coverage_doc_span_at_mapping_value_is_a_sequence() {
     assert!(txt.contains("- one"));
 }
 
+// ── Keep-chomped block scalars retain their kept trailing blanks ────
+
+#[test]
+fn coverage_doc_span_at_keep_chomped_block_scalar_keeps_trailing_blanks() {
+    // `|+` chomping keeps trailing line breaks as *content*. The value
+    // span must include them; trimming (as clip/strip spans do) would
+    // yield a slice that re-parses to a shorter, different value.
+    let src = "key: |+\n  kept\n\n\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("key").unwrap();
+    assert_eq!(&doc.source()[s..e], "|+\n  kept\n\n\n");
+    // The slice re-parses to exactly the scalar's value.
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    assert_eq!(reparsed, Value::String("kept\n\n\n".to_string()));
+}
+
+#[test]
+fn coverage_doc_span_at_folded_keep_chomped_keeps_trailing_blanks() {
+    // Same for the folded (`>+`) keep-chomped form.
+    let src = "key: >+\n  kept\n\n\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("key").unwrap();
+    assert_eq!(&doc.source()[s..e], ">+\n  kept\n\n\n");
+}
+
+#[test]
+fn coverage_doc_span_at_clip_and_strip_block_scalars_still_trim() {
+    // Clip (`|`) and strip (`|-`) block scalars do NOT own trailing
+    // blank lines, so their value span is trimmed as before.
+    let clip = parse_document("key: |\n  kept\n\n\n").unwrap();
+    let (s, e) = clip.span_at("key").unwrap();
+    assert_eq!(&clip.source()[s..e], "|\n  kept");
+
+    let strip = parse_document("key: |-\n  kept\n\n\n").unwrap();
+    let (s, e) = strip.span_at("key").unwrap();
+    assert_eq!(&strip.source()[s..e], "|-\n  kept");
+}
+
 // ── resolve_span sequence index out-of-bounds typed-cache fallback ──
 
 #[test]

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -840,6 +840,51 @@ fn coverage_doc_span_at_clip_and_strip_block_scalars_still_trim() {
     assert_eq!(&strip.source()[s..e], "|-\n  kept");
 }
 
+// ── Block-collection value spans include their first line's indent ──
+
+#[test]
+fn coverage_doc_span_at_block_mapping_value_is_uniformly_indented() {
+    // The value span must include the first line's indentation so the
+    // slice is uniformly indented and re-parses to the selected value.
+    let src = "config:\n  debug: true\n  level: info\nafter: 1\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("config").unwrap();
+    assert_eq!(&doc.source()[s..e], "  debug: true\n  level: info");
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    assert_eq!(reparsed, doc.as_value().get("config").cloned().unwrap());
+}
+
+#[test]
+fn coverage_doc_span_at_nested_block_sequence_does_not_renest() {
+    // Regression: a dedented first line ('- alpha\n    - beta') silently
+    // re-parses as the single scalar ["alpha - beta"]. The uniformly
+    // indented slice re-parses to the real two-element sequence.
+    let src = "spec:\n  items:\n    - alpha\n    - beta\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("spec.items").unwrap();
+    assert_eq!(&doc.source()[s..e], "    - alpha\n    - beta");
+    let reparsed: Value = noyalib::from_str(&doc.source()[s..e]).unwrap();
+    // Two elements, not one folded scalar.
+    assert_eq!(reparsed.as_sequence().map(|s| s.len()), Some(2));
+    let expected = doc
+        .as_value()
+        .get("spec")
+        .and_then(|s| s.get("items"))
+        .cloned()
+        .unwrap();
+    assert_eq!(reparsed, expected);
+}
+
+#[test]
+fn coverage_doc_span_at_same_line_nested_sequence_not_extended() {
+    // The inner sequence of `- - a` shares its line with the outer `-`,
+    // so its span must NOT be widened over the `- ` prefix.
+    let src = "outer:\n  - - a\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("outer[0]").unwrap();
+    assert_eq!(&doc.source()[s..e], "- a");
+}
+
 // ── resolve_span sequence index out-of-bounds typed-cache fallback ──
 
 #[test]

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -966,3 +966,22 @@ fn coverage_doc_insert_entry_into_empty_mapping_errors() {
         "{msg}"
     );
 }
+
+#[test]
+fn coverage_doc_span_at_anchored_tagged_keep_chomped_keeps_trailing_blanks() {
+    // ultrareview BUG001: an anchor (`&name`) / tag (`!Tag`, `!!str`) property
+    // widens the value span start over `&` / `!`, so the keep-chomp guard must
+    // skip the prefix before inspecting the block indicator. Otherwise the kept
+    // trailing blank lines are trimmed and the slice re-parses to a shorter
+    // value.
+    for (src, want) in [
+        ("key: &anc |+\n  kept\n\n\n", "&anc |+\n  kept\n\n\n"),
+        ("key: !!str |+\n  kept\n\n\n", "!!str |+\n  kept\n\n\n"),
+        ("key: !Tag |+\n  kept\n\n\n", "!Tag |+\n  kept\n\n\n"),
+        ("key: &anc >+\n  kept\n\n\n", "&anc >+\n  kept\n\n\n"),
+    ] {
+        let doc = parse_document(src).unwrap();
+        let (s, e) = doc.span_at("key").unwrap();
+        assert_eq!(&doc.source()[s..e], want, "span for {src:?}");
+    }
+}

--- a/crates/noyalib/tests/cst_tag_span.rs
+++ b/crates/noyalib/tests/cst_tag_span.rs
@@ -41,3 +41,38 @@ fn entry_get_returns_full_tagged_value() {
     let entry = doc.entry("name");
     assert_eq!(entry.get(), Some("!Custom 'app-1'"));
 }
+
+// Regression: an alias *reference* must resolve through to its anchor
+// definition's self-contained value span, not slice as the dangling
+// `*name` lexeme (which does not re-parse standalone).
+
+#[test]
+fn span_at_alias_reference_resolves_through_to_anchor_collection() {
+    use noyalib::cst::parse_document;
+    let src = "a: &anc [1, 2]\nb: *anc\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("b").unwrap();
+    // The anchor definition's flow-sequence value, not `*anc`.
+    assert_eq!(&src[s..e], "[1, 2]");
+    // Anchor definition itself is unchanged.
+    let (s, e) = doc.span_at("a").unwrap();
+    assert_eq!(&src[s..e], "&anc [1, 2]");
+}
+
+#[test]
+fn span_at_alias_reference_resolves_through_to_anchor_scalar() {
+    use noyalib::cst::parse_document;
+    let src = "a: &x 1\nb: *x\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("b").unwrap();
+    assert_eq!(&src[s..e], "1");
+}
+
+#[test]
+fn span_at_alias_reference_as_sequence_item_resolves_through() {
+    use noyalib::cst::parse_document;
+    let src = "defs: &d [1, 2]\nuse:\n  - *d\n";
+    let doc = parse_document(src).unwrap();
+    let (s, e) = doc.span_at("use[0]").unwrap();
+    assert_eq!(&src[s..e], "[1, 2]");
+}

--- a/crates/noyalib/tests/dup_key_spans.rs
+++ b/crates/noyalib/tests/dup_key_spans.rs
@@ -172,3 +172,55 @@ fn spanned_fields_stay_aligned_after_duplicate_key() {
         "Spanned span after a duplicate key must not be shifted"
     );
 }
+
+// ── Distinct-typed key collisions are refused, not silently collapsed ──
+//
+// The mapping key model is `Mapping<String, Value>`. Two DISTINCT YAML
+// keys that stringify the same — the integer `1` and the string `"1"`,
+// `true` and `"true"`, the null `~` and `"null"` — would otherwise
+// overwrite each other, silently losing an entry. That is data loss, so
+// the loader raises `Error::KeyCollision` instead. A genuine duplicate
+// (the same typed key twice) keeps its `DuplicateKeyPolicy` behaviour.
+
+#[test]
+fn distinct_typed_keys_collide_loudly() {
+    for src in [
+        "1: a\n\"1\": b\n",          // int vs string
+        "true: yes\n\"true\": no\n", // bool vs string
+        "~: a\n\"null\": b\n",       // null vs string
+    ] {
+        let err = parse_document(src).expect_err("distinct-typed collision must error");
+        assert!(
+            matches!(err, noyalib::Error::KeyCollision(_)),
+            "expected KeyCollision for {src:?}, got {err:?}"
+        );
+        assert!(format!("{err}").contains("collide"), "{err}");
+    }
+}
+
+#[test]
+fn genuine_duplicate_keys_are_not_a_collision() {
+    // The same typed key twice is an authored duplicate: default
+    // last-wins keeps one entry, no error.
+    let doc = parse_document("1: a\n1: b\n").unwrap();
+    let v = doc.as_value();
+    let m = v.as_mapping().unwrap();
+    assert_eq!(m.len(), 1);
+    assert_eq!(m.get("1"), Some(&noyalib::Value::String("b".into())));
+}
+
+#[test]
+fn non_colliding_scalar_keys_load() {
+    // A lone numeric or bool key stringifies without colliding.
+    assert!(parse_document("8080: service\n").is_ok());
+    assert!(parse_document("true: on\n").is_ok());
+    assert!(parse_document("a: 1\nb: 2\n").is_ok());
+}
+
+#[test]
+fn merge_keys_do_not_trip_the_collision_check() {
+    // `<<` merge values are buffered separately and never run through
+    // the ordinary-insert collision check.
+    let src = "defaults: &d\n  timeout: 30\nservice:\n  <<: *d\n  name: web\n";
+    assert!(parse_document(src).is_ok());
+}

--- a/crates/noyalib/tests/error_kind.rs
+++ b/crates/noyalib/tests/error_kind.rs
@@ -1,0 +1,123 @@
+//! `Error::kind()` classifier smoke tests.
+//!
+//! Pins the mapping from an [`Error`] variant to its coarse
+//! [`ErrorKind`]. Downstream consumers routing errors by kind
+//! (structured logging, HTTP status mapping, retry policies)
+//! rely on this being stable — new variants must land under an
+//! existing kind whenever possible.
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+use noyalib::{
+    BudgetBreach, DuplicateKeyPolicy, Error, ErrorKind, ParserConfig, Value, from_str,
+    from_str_with_config,
+};
+
+#[test]
+fn syntax_error_kinds_as_syntax() {
+    let err = from_str::<Value>("a: [unclosed").unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Syntax);
+}
+
+#[test]
+fn key_collision_kinds_as_key_collision() {
+    let err = from_str::<Value>("1: a\n\"1\": b\n").unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::KeyCollision);
+}
+
+#[test]
+fn duplicate_key_error_policy_kinds_as_duplicate_key() {
+    let mut cfg = ParserConfig::default();
+    cfg.duplicate_key_policy = DuplicateKeyPolicy::Error;
+    let err = from_str_with_config::<Value>("k: 1\nk: 2\n", &cfg).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::DuplicateKey);
+}
+
+#[test]
+fn budget_errors_kind_as_budget() {
+    // Uses a `BudgetBreach` variant so the mapping is unambiguous.
+    // (Historical caveat: `max_sequence_length` / `max_mapping_keys`
+    // still surface as `Error::Serialize("… limit exceeded")` rather
+    // than `Error::Budget(…)`, so those two land in
+    // [`ErrorKind::Data`] — worth unifying in a follow-up.)
+    let mut cfg = ParserConfig::default();
+    cfg.max_merge_keys = 1;
+    let src = "\
+a: &a
+  x: 1
+b: &b
+  y: 2
+c:
+  <<: *a
+  <<: *b
+";
+    let err = from_str_with_config::<Value>(src, &cfg).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Budget);
+}
+
+#[test]
+fn recursion_limit_kinds_as_budget() {
+    let e = Error::RecursionLimitExceeded { depth: 999 };
+    assert_eq!(e.kind(), ErrorKind::Budget);
+}
+
+#[test]
+fn budget_breach_kinds_as_budget() {
+    let e = Error::Budget(BudgetBreach::MaxEvents {
+        limit: 1,
+        observed: 2,
+    });
+    assert_eq!(e.kind(), ErrorKind::Budget);
+}
+
+#[test]
+fn end_of_stream_kinds_as_end_of_stream() {
+    assert_eq!(Error::EndOfStream.kind(), ErrorKind::EndOfStream);
+}
+
+#[test]
+fn missing_field_kinds_as_data() {
+    assert_eq!(Error::MissingField("x".into()).kind(), ErrorKind::Data);
+    assert_eq!(Error::UnknownField("y".into()).kind(), ErrorKind::Data);
+    assert_eq!(
+        Error::TypeMismatch {
+            expected: "int",
+            found: "str".into()
+        }
+        .kind(),
+        ErrorKind::Data
+    );
+}
+
+#[test]
+fn custom_kinds_as_other() {
+    assert_eq!(Error::Custom("oops".into()).kind(), ErrorKind::Other);
+    assert_eq!(Error::Message("m".into(), None).kind(), ErrorKind::Other);
+}
+
+#[test]
+fn merge_shape_kinds_as_policy() {
+    assert_eq!(Error::ScalarInMergeElement.kind(), ErrorKind::Policy);
+    assert_eq!(Error::SequenceInMergeElement.kind(), ErrorKind::Policy);
+    assert_eq!(Error::TaggedInMerge.kind(), ErrorKind::Policy);
+}
+
+#[test]
+fn shared_delegates_to_inner_kind() {
+    use std::sync::Arc;
+    let inner = Error::KeyCollision("1".into());
+    let shared = Error::Shared(Arc::new(inner));
+    assert_eq!(shared.kind(), ErrorKind::KeyCollision);
+}
+
+#[test]
+fn error_kind_traits_are_present() {
+    // Trait bounds are surfaced in the tests so a future change
+    // that drops one shows up here as a compile failure.
+    fn assert_traits<T: Copy + PartialEq + Eq + core::hash::Hash + core::fmt::Debug>() {}
+    assert_traits::<ErrorKind>();
+    let a = ErrorKind::Syntax;
+    let b = a;
+    assert_eq!(a, b);
+}

--- a/crates/noyalib/tests/no_span_loader_parity.rs
+++ b/crates/noyalib/tests/no_span_loader_parity.rs
@@ -172,3 +172,24 @@ fn duplicate_policy_first_still_wins_on_value_path() {
     // policy is overridden; both loaders honour it.
     assert_eq!(m.get("k"), Some(&Value::String("one".into())));
 }
+
+// ── max_documents parity on the Value fast path (ultrareview BUG006) ──
+
+#[test]
+fn value_fast_path_enforces_max_documents() {
+    // `from_str::<Value>` routes through NoSpanLoader, which lacked the
+    // `max_documents` guard the span-full loader enforces — so a caller
+    // using max_documents as a DoS mitigation got no enforcement on the
+    // fast path, and the whole stream was materialised.
+    let cfg = ParserConfig::new().max_documents(1);
+    let src = "a: 1\n---\nb: 2\n---\nc: 3\n";
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("max_documents must be enforced on the Value fast path");
+    assert!(
+        matches!(
+            err,
+            Error::Budget(BudgetBreach::MaxDocuments { limit: 1, .. })
+        ),
+        "expected MaxDocuments budget error, got {err:?}"
+    );
+}

--- a/crates/noyalib/tests/no_span_loader_parity.rs
+++ b/crates/noyalib/tests/no_span_loader_parity.rs
@@ -17,8 +17,8 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{
-    BudgetBreach, DuplicateKeyPolicy, Error, MergeKeyPolicy, ParserConfig, Value,
-    from_str, from_str_with_config,
+    BudgetBreach, DuplicateKeyPolicy, Error, MergeKeyPolicy, ParserConfig, Value, from_str,
+    from_str_with_config,
 };
 
 // ── Distinct-typed collisions on the Value fast path ──────────────

--- a/crates/noyalib/tests/no_span_loader_parity.rs
+++ b/crates/noyalib/tests/no_span_loader_parity.rs
@@ -1,0 +1,174 @@
+//! Fast-path `Value` loader parity with the span-full loader.
+//!
+//! `from_str::<Value>` routes through the span-free loader
+//! (`NoSpanLoader`) for the same reason the streaming path exists:
+//! the caller doesn't need span data, so building it is waste. That
+//! fast path used to lack the collision guard and the three DoS
+//! budgets the span-full loader enforces — a distinct-typed key
+//! (`1: a` then `"1": b`) would silently collapse, and an over-limit
+//! sequence, mapping, or `<<` chain would run to completion.
+//!
+//! This suite pins the parity: every check the span-full loader
+//! applies must also fire on the fast `Value` path.
+//!
+//! Regression tests for the review of `feat/v0.0.14`.
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+use noyalib::{
+    BudgetBreach, DuplicateKeyPolicy, Error, MergeKeyPolicy, ParserConfig, Value,
+    from_str, from_str_with_config,
+};
+
+// ── Distinct-typed collisions on the Value fast path ──────────────
+
+#[test]
+fn from_str_value_refuses_distinct_typed_key_collision() {
+    // Reproduces the pre-fix silent-collapse: `1: a` then `"1": b`
+    // both stringify to key `"1"`, so the second insert would drop
+    // the first. The fast path must refuse.
+    for src in [
+        "1: a\n\"1\": b\n",
+        "true: yes\n\"true\": no\n",
+        "~: a\n\"null\": b\n",
+    ] {
+        let err = from_str::<Value>(src)
+            .expect_err("distinct-typed collision must error on the Value fast path");
+        assert!(
+            matches!(err, Error::KeyCollision(_)),
+            "expected KeyCollision for {src:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn from_str_value_accepts_genuine_duplicate_keys() {
+    // Same typed key twice is a duplicate, not a collision: default
+    // `DuplicateKeyPolicy::Last` keeps one entry with no error.
+    let v: Value = from_str("1: a\n1: b\n").unwrap();
+    let m = v.as_mapping().unwrap();
+    assert_eq!(m.len(), 1);
+    assert_eq!(m.get("1"), Some(&Value::String("b".into())));
+}
+
+#[test]
+fn from_str_value_accepts_lone_scalar_key() {
+    // A lone numeric or bool key must stringify without tripping
+    // the collision check.
+    assert!(from_str::<Value>("8080: service\n").is_ok());
+    assert!(from_str::<Value>("true: on\n").is_ok());
+    assert!(from_str::<Value>("a: 1\nb: 2\n").is_ok());
+}
+
+// ── DoS budgets on the Value fast path ────────────────────────────
+
+fn small_limits() -> ParserConfig {
+    let mut cfg = ParserConfig::default();
+    cfg.max_sequence_length = 4;
+    cfg.max_mapping_keys = 4;
+    cfg.max_merge_keys = 2;
+    cfg
+}
+
+#[test]
+fn from_str_value_enforces_max_sequence_length() {
+    let cfg = small_limits();
+    let src = "[1, 2, 3, 4, 5]\n"; // 5 items > 4
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("sequence-length budget must fire on the Value fast path");
+    // Mirrors the span-full loader's spelling.
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("sequence length limit"),
+        "expected sequence-length budget error, got {msg:?}"
+    );
+}
+
+#[test]
+fn from_str_value_enforces_max_mapping_keys() {
+    let cfg = small_limits();
+    let src = "a: 1\nb: 2\nc: 3\nd: 4\ne: 5\n"; // 5 keys > 4
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("mapping-key budget must fire on the Value fast path");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("mapping key limit"),
+        "expected mapping-key budget error, got {msg:?}"
+    );
+}
+
+#[test]
+fn from_str_value_enforces_max_merge_keys() {
+    let cfg = small_limits();
+    // Three `<<:` merges > 2. Anchor-and-alias each so the merge
+    // event actually fires.
+    let src = "\
+a: &a
+  x: 1
+b: &b
+  y: 2
+c: &c
+  z: 3
+one:
+  <<: *a
+  <<: *b
+  <<: *c
+";
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("max-merge-keys budget must fire on the Value fast path");
+    assert!(
+        matches!(err, Error::Budget(BudgetBreach::MaxMergeKeys { .. })),
+        "expected MaxMergeKeys, got {err:?}"
+    );
+}
+
+#[test]
+fn from_str_value_merge_key_policy_error_refused_on_value_path() {
+    // `MergeKeyPolicy::Error` must reject `<<` on the Value fast
+    // path exactly like on the span-full path.
+    let mut cfg = ParserConfig::default();
+    cfg.merge_key_policy = MergeKeyPolicy::Error;
+    let src = "base: &b\n  x: 1\nservice:\n  <<: *b\n";
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("MergeKeyPolicy::Error must reject `<<`");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("merge key") || msg.contains("<<"),
+        "unexpected message: {msg:?}"
+    );
+}
+
+// ── Merge keys don't clone or count against collision ─────────────
+
+#[test]
+fn merge_keys_do_not_trip_collision_on_value_path() {
+    // `<<` merge values are buffered and never run through the
+    // collision check; the hot-path clone should be skipped, but
+    // the visible behaviour is: no error, merged fields present.
+    let src = "\
+defaults: &d
+  timeout: 30
+service:
+  <<: *d
+  name: web
+";
+    let v: Value = from_str(src).unwrap();
+    let svc = v.as_mapping().unwrap().get("service").unwrap();
+    let svc = svc.as_mapping().unwrap();
+    assert_eq!(svc.get("timeout"), Some(&Value::Number(30i64.into())));
+    assert_eq!(svc.get("name"), Some(&Value::String("web".into())));
+}
+
+#[test]
+fn duplicate_policy_first_still_wins_on_value_path() {
+    // Verify the parity fix preserves the existing
+    // `DuplicateKeyPolicy` behaviour on the fast path.
+    let mut cfg = ParserConfig::default();
+    cfg.duplicate_key_policy = DuplicateKeyPolicy::First;
+    let v: Value = from_str_with_config("k: one\nk: two\n", &cfg).unwrap();
+    let m = v.as_mapping().unwrap();
+    // Default fast path is last-wins, but per test above the
+    // policy is overridden; both loaders honour it.
+    assert_eq!(m.get("k"), Some(&Value::String("one".into())));
+}

--- a/crates/noyalib/tests/tag_registry.rs
+++ b/crates/noyalib/tests/tag_registry.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use noyalib::{ParserConfig, TagRegistry, from_str_with_config};
+use noyalib::{Error, ParserConfig, TagRegistry, Value, from_str_with_config};
 use serde::Deserialize;
 
 fn cfg(tags: &[&str]) -> ParserConfig {
@@ -89,8 +89,8 @@ fn unregistered_tag_on_scalar_falls_back_to_string() {
     // that wrapper and lets the typed target see through the
     // tag — the path the strongly-typed `Celsius` test uses.
     let cfg = ParserConfig::new();
-    let v: noyalib::Value = from_str_with_config("!Other 42", &cfg).unwrap();
-    let noyalib::Value::Tagged(t) = &v else {
+    let v: Value = from_str_with_config("!Other 42", &cfg).unwrap();
+    let Value::Tagged(t) = &v else {
         panic!("expected Tagged, got {v:?}");
     };
     assert_eq!(t.tag().as_str(), "!Other");
@@ -117,8 +117,8 @@ fn empty_registry_is_no_op() {
     // Empty registry is equivalent to no registry — same AST
     // routing + tag-preserving deserialise. The custom tag
     // surfaces as `Value::Tagged`; opt out by registering it.
-    let v: noyalib::Value = from_str_with_config("!Other 42", &cfg).unwrap();
-    let noyalib::Value::Tagged(t) = &v else {
+    let v: Value = from_str_with_config("!Other 42", &cfg).unwrap();
+    let Value::Tagged(t) = &v else {
         panic!("expected Tagged, got {v:?}");
     };
     assert_eq!(t.tag().as_str(), "!Other");
@@ -160,4 +160,61 @@ fn registry_contains_matches_registered() {
     assert!(!reg.contains("!c"));
     assert_eq!(reg.len(), 2);
     assert!(!reg.is_empty());
+}
+
+// ── Value target + registry: KeyCollision guard + streaming parity ───
+//
+// v0.0.14 review regression. `from_str::<Value>` WITH a tag registry
+// active used to route through the streaming path, which stringifies
+// keys before the distinct-typed `KeyCollision` guard can run — so `1`
+// and `"1"` silently collapsed. `Value`+registry now uses the AST loader
+// (which owns the guard) and the loader strips registered tags itself, so
+// its output matches what streaming produced.
+
+#[test]
+fn value_target_with_registry_detects_distinct_typed_key_collision() {
+    let cfg = cfg(&["!Celsius"]);
+    let res: Result<Value, _> = from_str_with_config("1: a\n\"1\": b\n", &cfg);
+    assert!(
+        matches!(res, Err(Error::KeyCollision(_))),
+        "Value+registry must detect the 1 vs \"1\" collision, got {res:?}"
+    );
+    // Parity with the no-registry Value path, which already errored.
+    let res2: Result<Value, _> = from_str_with_config("1: a\n\"1\": b\n", &ParserConfig::new());
+    assert!(matches!(res2, Err(Error::KeyCollision(_))));
+}
+
+#[test]
+fn value_target_registry_strip_is_style_correct() {
+    let cfg = cfg(&["!Celsius"]);
+    // Plain scalar under a registered tag: stripped, then schema-resolved
+    // to a number — exactly what streaming yields.
+    let v: Value = from_str_with_config("!Celsius 42", &cfg).unwrap();
+    assert_eq!(v.as_i64(), Some(42));
+    // Quoted scalar under the same tag: stripped, but the quoted STYLE is
+    // honoured so it stays a string. A post-parse Value walk could not know
+    // this (the AST tagged node discards style) — proving the strip must
+    // happen at parse time.
+    let v: Value = from_str_with_config("!Celsius \"42\"", &cfg).unwrap();
+    assert_eq!(v.as_str(), Some("42"));
+    // Without the registry the tag is preserved as Value::Tagged.
+    let v: Value = from_str_with_config("!Celsius 42", &ParserConfig::new()).unwrap();
+    assert!(
+        v.as_tagged().is_some(),
+        "unregistered tag must stay tagged, got {v:?}"
+    );
+}
+
+#[test]
+fn value_target_registry_strips_collection_tag() {
+    // A registered tag on a collection is stripped too (streaming parity),
+    // exposing the bare mapping rather than a Value::Tagged wrapper.
+    let cfg = cfg(&["!Config"]);
+    let v: Value = from_str_with_config("!Config\na: 1\nb: 2\n", &cfg).unwrap();
+    assert!(
+        v.as_tagged().is_none(),
+        "registered collection tag must be stripped, got {v:?}"
+    );
+    assert_eq!(v["a"].as_i64(), Some(1));
+    assert_eq!(v["b"].as_i64(), Some(2));
 }

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -487,7 +487,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.11", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.14", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -510,7 +510,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.11", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.14", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -534,7 +534,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.11", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.14", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "noyalib"
-version = "0.0.1"
+version = "0.0.14"
 dependencies = [
  "indexmap",
  "itoa",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -82,3 +82,10 @@ path = "fuzz_targets/fuzz_double_quoted.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_no_span_loader"
+path = "fuzz_targets/fuzz_no_span_loader.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_no_span_loader.rs
+++ b/fuzz/fuzz_targets/fuzz_no_span_loader.rs
@@ -1,0 +1,56 @@
+//! Fuzz target: cross-check `from_str::<Value>` against
+//! `cst::parse_document` for divergence.
+//!
+//! The `Value` target on `from_str` now runs the span-free
+//! `NoSpanLoader` fast path (the streaming path was silently
+//! collapsing distinct-typed key collisions and skipping three
+//! DoS budgets — see the v0.0.14 loader-parity fix). This fuzz
+//! target's whole job is to make sure that fast path stays in
+//! lock-step with the span-full CST loader on every input the
+//! fuzzer can reach: if one accepts and the other rejects, the
+//! divergence is a bug in the parity.
+//!
+//! Divergence rules:
+//!
+//! * both accept → OK.
+//! * both reject → OK.
+//! * one accepts and the other rejects → **PANIC** (regression).
+//!
+//! Panics on non-divergent runs are always bugs (both paths are
+//! supposed to be panic-free).
+
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use noyalib::Value;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let value_res = noyalib::from_str::<Value>(s);
+    let cst_res = noyalib::cst::parse_document(s);
+
+    match (value_res.is_ok(), cst_res.is_ok()) {
+        (true, true) | (false, false) => {}
+        (true, false) => {
+            // The CST loader is strict about the parity guards
+            // (KeyCollision, DoS budgets) — if it errors, the
+            // fast Value path must too.
+            panic!(
+                "divergence: from_str::<Value> succeeded but cst::parse_document rejected input"
+            );
+        }
+        (false, true) => {
+            // Reverse divergence: fast path errored where cst
+            // accepted. Also a bug — parity was two-way.
+            panic!(
+                "divergence: cst::parse_document succeeded but from_str::<Value> rejected input"
+            );
+        }
+    }
+});

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -38,6 +38,11 @@ suggest = false
 version = "1.12.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.crossbeam-epoch]]
+version = "0.9.20"
+criteria = "safe-to-deploy"
+suggest = false
+
 [[exemptions.data-encoding]]
 version = "2.11.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -48,24 +48,39 @@ criteria = "safe-to-deploy"
 suggest = false
 
 [[exemptions.granit-parser]]
-version = "0.0.6"
+version = "0.0.7"
 criteria = "safe-to-deploy"
+
+[[exemptions.jsonschema]]
+version = "0.46.10"
+criteria = "safe-to-deploy"
+suggest = false
+
+[[exemptions.jsonschema-regex]]
+version = "0.46.10"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.micromap]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.referencing]]
+version = "0.46.10"
+criteria = "safe-to-deploy"
+suggest = false
 
 [[exemptions.rust-yaml]]
 version = "1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.rustc-hash]]
-version = "2.1.2"
+version = "2.1.3"
 criteria = "safe-to-deploy"
 suggest = false
 
 [[exemptions.serde-saphyr]]
-version = "0.0.28"
+version = "0.0.29"
 criteria = "safe-to-deploy"
 
 [[exemptions.sval]]


### PR DESCRIPTION
# v0.0.14 — loader-parity cut, review-hardened

v0.0.14 hardens the default `from_str::<Value>` path and the CST edit API. It began as a loader-parity + supply-chain cut, then was hardened through **two review passes** (a workflow-backed code review and a cloud ultrareview) — every fix below landed with a regression test **proven to fail on the pre-fix tree**.

## 🛡️ Loader-parity security fix (the original cut)

`from_str::<Value>` — the default `Value`-target entry point — routed through the streaming deserializer or a span-free `NoSpanLoader`, both of which **silently collapsed distinct-typed mapping-key collisions**:

```yaml
1: a
"1": b
```

The integer key `1` and the string key `"1"` both stringify to `"1"`, so the second insert dropped the first — silent data loss. The `cst::parse_document` path caught this since v0.0.13; the default `Value` path did not. `NoSpanLoader` also lacked the DoS budgets the span-full `Loader` carries.

- `NoSpanLoader` runs the same distinct-typed `KeyCollision` check as `Loader`.
- `NoSpanLoader` enforces `max_sequence_length`, `max_mapping_keys`, `max_merge_keys`, `MergeKeyPolicy::Error`, and the `alias_bytes` billion-laughs cap.
- `NoSpanLoader` honours `DuplicateKeyPolicy::First / Last / Error`.
- The `Value` target is **always** excluded from the streaming path (see the registry fix below), so the collision guard is always reachable.
- `debug_assert_eq!(map.len(), typed_keys.len())` after every push in both loaders.
- `nan` / `inf` / `-inf` mapping keys stringify to their canonical plain spelling.

## 🔎 Post-cut review hardening

### Pre-release review (#161)

- **fix(cst)** — `set` / `set_value` **refuse to write through an alias reference**. `span_at` resolves an alias *through* to its anchor's value span (issue #149, correct for reads); reusing that span for a write spliced over a **different** key. Now refused.
- **fix(de)** — `from_str::<Value>` **with a tag registry** now routes through the KeyCollision-guarded AST loader (it previously fell to streaming, where the guard is unreachable). The loader strips registered tags **at parse time**, matching streaming byte-for-byte (style-correct scalars, collection tags included).
- **fix(loader)** — `NoSpanLoader` resets the alias budget per document (a std/no_std divergence otherwise).
- **docs** — crate-README install snippets `0.0.8` → `0.0.14`.

### Ultrareview (#168)

- **fix(cst) — BUG003** — the alias-write guard now covers **double-quoted / complex keys**. The #161 guard matched keys only in plain/single-quoted form, so `set("quoted-key", …)` on a double-quoted alias still corrupted the anchor. The guard now refuses when an undecodable-key entry's value is an alias (no regression for ordinary quoted-key writes).
- **fix(loader) — BUG006** — `max_documents` is now enforced on the `Value` fast path. Because `from_str::<Value>` always routes through `NoSpanLoader`, the DoS limit was silently non-functional there.
- **fix(cst) — BUG001** — anchored / tagged keep-chomped block-scalar spans (`key: &anc |+`) retain their kept trailing blank lines (the guard skips the anchor/tag prefix before the block-indicator check).

### CI

- **fix(simd)** — `clippy::question_mark` in the x86_64 SWAR `parse_decimal_u64` path (surfaced by rust-1.95 clippy on the CI runner).

## ⚠️ Known limitation → v0.0.15

`from_str_borrowing::<Value>` does **not** detect distinct-typed key collisions (BUG004). Its `T: Deserialize<'a>` bound is not `'static`, so it cannot perform the `Value`-target detection the owned path uses — the fix needs an API change or a marker-trait refactor. **Use `from_str::<Value>` for untrusted input.** Tracked for v0.0.15 with the typed/map-target gap; both will be closed by moving collision detection into the streaming map-visitor.

## 🧭 Public API

- `Error::kind() -> ErrorKind` — coarse error classification without matching every `#[non_exhaustive]` variant.

## 🔒 Supply-chain

- `crossbeam-epoch` 0.9.18 → 0.9.20 (closes **RUSTSEC-2026-0204**; reaches noyalib transitively via `rayon` / `criterion`).
- `supply-chain/config.toml` gains an `[[exemptions.crossbeam-epoch]]` for 0.9.20.

## 📦 Release plumbing

- `crates/noyalib/Cargo.toml` → `0.0.14`; `CHANGELOG.md` `[v0.0.14] — 2026-07-07`; `RELEASE-NOTES-v0.0.14.md`.
- README / crate-README / MIGRATION / GETTING_STARTED / USER-GUIDE version stragglers → `0.0.14` (historical entries preserved).

## ✅ Test posture

- `cargo test -p noyalib` — full integration suite + doctests, green.
- `cargo clippy --all-targets --all-features -- -D warnings` — green.
- `cargo vet --locked` / `cargo deny check` — green.
- Full branch CI (Miri, coverage ≥95%, semver, docs-strict, no-std, MSRV, fuzz-diff) — green on the release tip.

_Assisted-by: Claude Fable 5_
