### PR TITLE
fix: v0.0.14 pre-release review — CST alias-span, Value+registry KeyCollision, NoSpanLoader alias parity

### DIFF
--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.8"
+noyalib = "0.0.14"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.8", default-features = false }
+noyalib = { version = "0.0.14", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -474,6 +474,13 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: foo\nversion: 0.0.2\n");
     /// ```
     pub fn set(&mut self, path: &str, fragment: &str) -> Result<()> {
+        let segments = parse_query_path(path);
+        if value_is_alias_reference(&self.green, &segments, &self.source) {
+            return Err(Error::Parse(format!(
+                "cannot set `{path}`: its value is an alias reference (`*name`); \
+                 edit the anchor definition or replace the alias explicitly"
+            )));
+        }
         let (s, e) = self
             .span_at(path)
             .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
@@ -516,6 +523,13 @@ impl Document {
     /// assert_eq!(doc.to_string(), "name: noyalib\nversion: 0.0.2\n");
     /// ```
     pub fn set_value(&mut self, path: &str, value: &Value) -> Result<()> {
+        let segments = parse_query_path(path);
+        if value_is_alias_reference(&self.green, &segments, &self.source) {
+            return Err(Error::Parse(format!(
+                "cannot set `{path}`: its value is an alias reference (`*name`); \
+                 edit the anchor definition or replace the alias explicitly"
+            )));
+        }
         let (s, e) = self
             .span_at(path)
             .ok_or_else(|| Error::Parse(format!("path not found: {path}")))?;
@@ -1156,6 +1170,127 @@ fn resolve_path_in_green(
     // point.
     let (collection, base) = first_collection_child(root, 0)?;
     walk_path(collection, segments, base, source)
+}
+
+/// Does the value at `segments` resolve *directly* to an alias
+/// reference (`*name`)?
+///
+/// `span_at` deliberately resolves an alias *through* to its anchor's
+/// definition span (issue #149) — the right target for a read, but the
+/// wrong one for a write: splicing there rewrites the anchor's value and
+/// corrupts a *different* key. `set` / `set_value` call this and refuse
+/// the edit rather than mutate the wrong bytes. Read-only span
+/// resolution is untouched.
+fn value_is_alias_reference(root: &GreenNode, segments: &[QuerySegment], source: &str) -> bool {
+    match first_collection_child(root, 0) {
+        Some((collection, base)) => terminal_is_alias(collection, segments, base, source),
+        None => false,
+    }
+}
+
+fn terminal_is_alias(
+    node: &GreenNode,
+    segments: &[QuerySegment],
+    base: usize,
+    source: &str,
+) -> bool {
+    let Some((head, tail)) = segments.split_first() else {
+        return false;
+    };
+    match (head, node.kind()) {
+        (QuerySegment::Key(k), SyntaxKind::BlockMapping | SyntaxKind::FlowMapping) => {
+            // Last matching entry wins (DuplicateKeyPolicy::Last), mirroring
+            // walk_mapping so this agrees with what span_at would target.
+            let mut found: Option<(&GreenNode, usize)> = None;
+            let mut pos = base;
+            for child in node.children() {
+                let len = child.text_len();
+                if let GreenChild::Node(entry) = child {
+                    if entry.kind() == SyntaxKind::MappingEntry
+                        && entry_key_text(entry, source, pos).as_deref() == Some(k.as_str())
+                    {
+                        found = Some((entry, pos));
+                    }
+                }
+                pos += len;
+            }
+            match found {
+                Some((entry, entry_pos)) => value_after_sep_is_alias(
+                    entry,
+                    entry_pos,
+                    tail,
+                    source,
+                    SyntaxKind::ColonIndicator,
+                ),
+                None => false,
+            }
+        }
+        (QuerySegment::Index(i), SyntaxKind::BlockSequence | SyntaxKind::FlowSequence) => {
+            let mut pos = base;
+            let mut idx = 0usize;
+            for child in node.children() {
+                let len = child.text_len();
+                if let GreenChild::Node(item) = child {
+                    if item.kind() == SyntaxKind::SequenceItem {
+                        if idx == *i {
+                            return value_after_sep_is_alias(
+                                item,
+                                pos,
+                                tail,
+                                source,
+                                SyntaxKind::DashIndicator,
+                            );
+                        }
+                        idx += 1;
+                    }
+                }
+                pos += len;
+            }
+            false
+        }
+        // Wildcards / kind mismatch: span_at would bail to the cache; the
+        // conservative answer for a write is "not a known alias target".
+        _ => false,
+    }
+}
+
+/// Within a `MappingEntry` / `SequenceItem`, decide whether the value —
+/// the first non-trivia, non-property token after `sep` — is an alias.
+/// For a deeper path, recurse into a nested collection instead.
+fn value_after_sep_is_alias(
+    container: &GreenNode,
+    base: usize,
+    tail: &[QuerySegment],
+    source: &str,
+    sep: SyntaxKind,
+) -> bool {
+    let mut pos = base;
+    let mut after_sep = false;
+    for child in container.children() {
+        let len = child.text_len();
+        match child {
+            GreenChild::Token { kind, .. } => {
+                if !after_sep {
+                    if *kind == sep {
+                        after_sep = true;
+                    }
+                } else if *kind == SyntaxKind::AliasMark {
+                    // Only a *terminal* alias is a mutation hazard; a path that
+                    // tries to descend into an alias resolves nowhere anyway.
+                    return tail.is_empty();
+                } else if !is_trivia_kind(*kind) && !is_value_property_kind(*kind) {
+                    return false; // a real scalar leaf — safe to mutate
+                }
+            }
+            GreenChild::Node(inner) => {
+                if after_sep {
+                    return terminal_is_alias(inner, tail, pos, source);
+                }
+            }
+        }
+        pos += len;
+    }
+    false
 }
 
 fn first_collection_child(node: &GreenNode, base: usize) -> Option<(&GreenNode, usize)> {

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -402,17 +402,17 @@ where
     // takes effect. Active `properties` interpolation also disables
     // the streaming path so the post-parse substitution walk runs.
     //
-    // The `Value` target is *excluded* from the streaming path
-    // (unless a tag registry is active — the registry strips
-    // registered tags off scalars, and that only happens on the
-    // streaming path today). Rationale: serde asks the streaming
-    // deserializer for `String` keys, which stringifies typed
-    // scalars *before* `ValueVisitor::visit_map` can tell `1` and
-    // `"1"` apart — the distinct-typed `KeyCollision` guard is
-    // unreachable there. The `Value`-target fast path a few lines
-    // down runs the span-free loader which owns the collision
-    // check and the DoS budgets.
-    let value_target_bypass = is_value_target::<T>() && config.tag_registry.is_none();
+    // The `Value` target is *always* excluded from the streaming path.
+    // Rationale: serde asks the streaming deserializer for `String`
+    // keys, which stringifies typed scalars *before*
+    // `ValueVisitor::visit_map` can tell `1` and `"1"` apart — the
+    // distinct-typed `KeyCollision` guard is unreachable there. The
+    // `Value`-target fast path a few lines down runs the span-free
+    // loader, which owns the collision check and the DoS budgets — and
+    // strips registry-registered tags itself (loader `resolve_untagged_scalar`),
+    // so an active tag registry no longer forces `Value` back onto the
+    // streaming path where the collision guard cannot run.
+    let value_target_bypass = is_value_target::<T>();
     let stream_eligible = config.merge_key_policy == MergeKeyPolicy::Auto
         && !config.ignore_binary_tag_for_string
         && config.policies.is_empty()

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -49,6 +49,10 @@ pub struct ParseConfig {
     #[cfg(feature = "lossless-u64")]
     pub lossless_u64_integers: bool,
     pub policies: Vec<Arc<dyn crate::policy::Policy>>,
+    /// Tags registered for strip-through. When set, the loader resolves a
+    /// registered tag's scalar as if untagged (matching the streaming path)
+    /// instead of producing a [`Value::Tagged`].
+    pub tag_registry: Option<Arc<crate::TagRegistry>>,
 }
 
 impl Default for ParseConfig {
@@ -76,6 +80,7 @@ impl Default for ParseConfig {
             #[cfg(feature = "lossless-u64")]
             lossless_u64_integers: false,
             policies: Vec::new(),
+            tag_registry: None,
         }
     }
 }
@@ -126,6 +131,7 @@ impl From<&crate::de::ParserConfig> for ParseConfig {
             #[cfg(feature = "lossless-u64")]
             lossless_u64_integers: c.lossless_u64_integers,
             policies: c.policies.clone(),
+            tag_registry: c.tag_registry.clone(),
         }
     }
 }
@@ -420,32 +426,25 @@ impl<'a> Loader<'a> {
                     && matches!(style, crate::parser::ScalarStyle::Plain)
                     && anchor.is_none()
                     && tag.is_none();
-                let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
-                } else if style != crate::parser::ScalarStyle::Plain {
-                    // Quoted/literal/folded scalars always resolve as
-                    // strings — YAML schema resolution only applies to
-                    // plain scalars.
-                    Value::String(value.into_owned())
-                } else {
-                    match crate::streaming::resolve_plain_ext(
-                        &value,
-                        self.config.strict_booleans,
-                        self.config.legacy_booleans,
-                        self.config.no_schema,
-                        self.config.legacy_octal_numbers,
-                        self.config.legacy_sexagesimal,
-                        self.config.lossless_u64_integers(),
-                    ) {
-                        crate::streaming::Scalar::Null => Value::Null,
-                        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
-                        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
-                        #[cfg(feature = "lossless-u64")]
-                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
-                        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
-                        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
-                    }
-                };
+                let v =
+                    if let Some(t) = tag {
+                        if self.config.tag_registry.as_ref().is_some_and(|r| {
+                            crate::streaming::tag_is_registry_stripped(&t.0, &t.1, r)
+                        }) {
+                            // Registered tag: strip through and resolve as if
+                            // untagged, exactly as the streaming path does.
+                            resolve_untagged_scalar(value, style, self.config)
+                        } else {
+                            resolve_tagged_scalar(
+                                &t.0,
+                                &t.1,
+                                &value,
+                                self.config.lossless_u64_integers(),
+                            )?
+                        }
+                    } else {
+                        resolve_untagged_scalar(value, style, self.config)
+                    };
 
                 let st = if is_implicit_empty {
                     SpanTree::Leaf(span.start, span.start)
@@ -487,7 +486,7 @@ impl<'a> Loader<'a> {
                 }) = self.stack.pop()
                 {
                     let inner = Value::Sequence(items);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     let st = SpanTree::Sequence {
                         start,
                         end: span.end,
@@ -542,7 +541,7 @@ impl<'a> Loader<'a> {
                     }
 
                     let inner = Value::Mapping(map);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     let st = SpanTree::Mapping {
                         start,
                         end: span.end,
@@ -957,29 +956,25 @@ impl<'a> NoSpanLoader<'a> {
                 tag,
                 span,
             } => {
-                let v = if let Some(t) = tag {
-                    resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
-                } else if style != crate::parser::ScalarStyle::Plain {
-                    Value::String(value.into_owned())
-                } else {
-                    match crate::streaming::resolve_plain_ext(
-                        &value,
-                        self.config.strict_booleans,
-                        self.config.legacy_booleans,
-                        self.config.no_schema,
-                        self.config.legacy_octal_numbers,
-                        self.config.legacy_sexagesimal,
-                        self.config.lossless_u64_integers(),
-                    ) {
-                        crate::streaming::Scalar::Null => Value::Null,
-                        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
-                        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
-                        #[cfg(feature = "lossless-u64")]
-                        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
-                        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
-                        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
-                    }
-                };
+                let v =
+                    if let Some(t) = tag {
+                        if self.config.tag_registry.as_ref().is_some_and(|r| {
+                            crate::streaming::tag_is_registry_stripped(&t.0, &t.1, r)
+                        }) {
+                            // Registered tag: strip through and resolve as if
+                            // untagged, exactly as the streaming path does.
+                            resolve_untagged_scalar(value, style, self.config)
+                        } else {
+                            resolve_tagged_scalar(
+                                &t.0,
+                                &t.1,
+                                &value,
+                                self.config.lossless_u64_integers(),
+                            )?
+                        }
+                    } else {
+                        resolve_untagged_scalar(value, style, self.config)
+                    };
                 if let Some(name) = anchor {
                     let _ = self.anchor_def_spans.insert(name.clone(), span.start);
                     let _ = self.anchor_map.insert(name, v.clone());
@@ -1004,7 +999,7 @@ impl<'a> NoSpanLoader<'a> {
                 self.depth = self.depth.saturating_sub(1);
                 if let Some(NoSpanFrame::Sequence { items, anchor, tag }) = self.stack.pop() {
                     let inner = Value::Sequence(items);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     if let Some(name) = anchor {
                         let _ = self.anchor_map.insert(name, v.clone());
                     }
@@ -1041,7 +1036,7 @@ impl<'a> NoSpanLoader<'a> {
                         apply_merge(&mut map, mv)?;
                     }
                     let inner = Value::Mapping(map);
-                    let v = wrap_with_tag(inner, tag.as_ref());
+                    let v = wrap_with_tag(inner, tag.as_ref(), self.config.tag_registry.as_deref());
                     if let Some(name) = anchor {
                         let _ = self.anchor_map.insert(name, v.clone());
                     }
@@ -1287,10 +1282,19 @@ fn value_to_key_string(value: Value) -> Option<String> {
 /// stripped — they are no-ops on a sequence/mapping anyway and
 /// `!!seq` / `!!map` would otherwise leak into the deserialise
 /// return path as redundant metadata.
-fn wrap_with_tag(inner: Value, tag: Option<&(String, String)>) -> Value {
+fn wrap_with_tag(
+    inner: Value,
+    tag: Option<&(String, String)>,
+    registry: Option<&crate::TagRegistry>,
+) -> Value {
     let Some((handle, suffix)) = tag else {
         return inner;
     };
+    // A tag registered for strip-through drops the tag and exposes the bare
+    // collection, matching what the streaming path yields.
+    if registry.is_some_and(|r| crate::streaming::tag_is_registry_stripped(handle, suffix, r)) {
+        return inner;
+    }
     // `!!seq` / `!!map` (and the explicit URI form) are
     // pure-metadata core tags on collections; the `Sequence` or
     // `Mapping` variant of `Value` already conveys "seq" /
@@ -1322,6 +1326,40 @@ fn concat_str(a: &str, b: &str) -> String {
 /// Resolve a tagged scalar into a typed `Value`. Handles the YAML 1.2
 /// core schema tags (`!!int`, `!!float`, `!!bool`, `!!null`, `!!str`)
 /// and any custom tag falls through to the `Tagged` wrapper.
+/// Resolve a scalar as if it carried no tag: quoted / literal / folded →
+/// `String`; plain → YAML 1.2 schema resolution (via the shared
+/// `resolve_plain_ext`, so the two loaders and the streaming path agree).
+/// This is also the strip-through result for a tag registered in the active
+/// [`TagRegistry`], keeping AST and streaming byte-for-byte equivalent.
+fn resolve_untagged_scalar(
+    value: Cow<'_, str>,
+    style: crate::parser::ScalarStyle,
+    config: &ParseConfig,
+) -> Value {
+    if style != crate::parser::ScalarStyle::Plain {
+        // Quoted/literal/folded scalars always resolve as strings — YAML
+        // schema resolution only applies to plain scalars.
+        return Value::String(value.into_owned());
+    }
+    match crate::streaming::resolve_plain_ext(
+        &value,
+        config.strict_booleans,
+        config.legacy_booleans,
+        config.no_schema,
+        config.legacy_octal_numbers,
+        config.legacy_sexagesimal,
+        config.lossless_u64_integers(),
+    ) {
+        crate::streaming::Scalar::Null => Value::Null,
+        crate::streaming::Scalar::Bool(b) => Value::Bool(b),
+        crate::streaming::Scalar::Int(i) => Value::Number(Number::Integer(i)),
+        #[cfg(feature = "lossless-u64")]
+        crate::streaming::Scalar::Uint(u) => Value::Number(Number::Unsigned(u)),
+        crate::streaming::Scalar::Float(f) => Value::Number(Number::Float(f)),
+        crate::streaming::Scalar::Str(s) => Value::String(s.into_owned()),
+    }
+}
+
 fn resolve_tagged_scalar(
     handle: &str,
     suffix: &str,

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -908,6 +908,13 @@ impl<'a> NoSpanLoader<'a> {
                 self.in_document = true;
                 self.anchor_map.clear();
                 self.anchor_def_spans.clear();
+                // Reset the per-document alias budget, matching the span-full
+                // Loader (see DocumentStart above). Without this, alias counts
+                // accumulate across a multi-document stream, so a stream whose
+                // documents are each within budget can be spuriously rejected
+                // on the no-span path — a std/no_std divergence.
+                self.alias_count = 0;
+                self.alias_bytes = 0;
             }
             Event::DocumentEnd => {
                 self.in_document = false;
@@ -1525,4 +1532,48 @@ fn run_event_policies(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression (v0.0.14 review): NoSpanLoader must zero the alias budget
+    // at each DocumentStart, like the span-full Loader. A multi-document
+    // stream whose documents are each within budget must not be rejected
+    // because the per-document counts accumulate across the stream (a
+    // std/no_std divergence, since the no-span loader is the no_std default).
+    #[test]
+    fn no_span_loader_resets_alias_budget_per_document() {
+        let src = "\
+p: &x 1
+q: *x
+r: *x
+---
+p: &y 2
+q: *y
+r: *y
+---
+p: &z 3
+q: *z
+r: *z
+";
+        // Each document uses exactly 2 aliases (== the limit); three
+        // documents sum to 6. Pre-fix the no-span loader accumulated and
+        // tripped RepetitionLimitExceeded partway through the second doc.
+        let config = ParseConfig {
+            max_alias_expansions: 2,
+            ..ParseConfig::default()
+        };
+        let docs = load_all_no_spans(src, &config)
+            .expect("each document is within the per-document alias budget");
+        assert_eq!(docs.len(), 3);
+
+        // Cross-path parity: the span-full loader already resets per
+        // document, so it accepts the identical stream under the identical
+        // budget. Both paths must agree.
+        let via_span_full =
+            crate::parser::parse(src, &config).expect("span-full loader accepts the same stream");
+        assert_eq!(via_span_full.len(), 3);
+    }
 }

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -556,23 +556,9 @@ impl<'a> StreamingDeserializer<'a> {
     /// resolution) that the AST resolver must see. Registering one of
     /// those tags is a no-op.
     fn tag_in_registry(&self, tag: &(String, String)) -> bool {
-        if matches!(
-            (tag.0.as_str(), tag.1.as_str()),
-            ("!!", "int")
-                | ("!!", "float")
-                | ("!!", "str")
-                | ("!!", "bool")
-                | ("!!", "null")
-                | ("!!", "seq")
-                | ("!!", "map")
-        ) {
-            return false;
-        }
-        let Some(registry) = self.tag_registry.as_ref() else {
-            return false;
-        };
-        let full = format!("{}{}", tag.0, tag.1);
-        registry.contains(&full)
+        self.tag_registry
+            .as_ref()
+            .is_some_and(|r| tag_is_registry_stripped(&tag.0, &tag.1, r))
     }
 
     /// Put a tag back onto the currently-cached event. Used to restore
@@ -1597,6 +1583,33 @@ fn is_fallback_error(e: &Error) -> bool {
         Error::Custom(msg) => msg == FALLBACK_SENTINEL,
         _ => false,
     }
+}
+
+/// Is the tag `{handle}{suffix}` registered for strip-through in `registry`?
+///
+/// Core YAML 1.2 tags (`!!int`, `!!float`, `!!str`, `!!bool`, `!!null`,
+/// `!!seq`, `!!map`) are never stripped — their tag carries semantic
+/// resolution the loader/streamer must see, so registering one is a no-op.
+/// Shared by the streaming deserializer and the AST loader so both agree on
+/// exactly what a registry strips (three-loader parity).
+pub(crate) fn tag_is_registry_stripped(
+    handle: &str,
+    suffix: &str,
+    registry: &crate::TagRegistry,
+) -> bool {
+    if matches!(
+        (handle, suffix),
+        ("!!", "int")
+            | ("!!", "float")
+            | ("!!", "str")
+            | ("!!", "bool")
+            | ("!!", "null")
+            | ("!!", "seq")
+            | ("!!", "map")
+    ) {
+        return false;
+    }
+    registry.contains(&format!("{handle}{suffix}"))
 }
 
 /// Resolve a plain scalar according to YAML 1.2's implicit-typing

--- a/crates/noyalib/tests/cst_anchors.rs
+++ b/crates/noyalib/tests/cst_anchors.rs
@@ -349,3 +349,48 @@ other: 1
     assert!(doc.to_string().contains("&flags"));
     assert!(doc.to_string().contains("other: 2"));
 }
+
+// ── Regression: set/set_value must not write through an alias ────────
+
+#[test]
+fn set_through_alias_is_refused_not_written_to_the_anchor() {
+    // v0.0.14 review regression. `span_at` resolves an alias reference
+    // *through* to its anchor's value span (issue #149) — the correct
+    // target for a read. `set` / `set_value` reused that span for writes,
+    // so `set("ref", …)` spliced over the ANCHOR's value (`foo` on the
+    // `base:` line), silently corrupting a *different* key and leaving the
+    // alias untouched. They must refuse the edit instead.
+    let mut doc = parse_document("base: &a foo\nref: *a\n").unwrap();
+    let before = doc.to_string();
+
+    let err = doc.set("ref", "bar");
+    assert!(
+        err.is_err(),
+        "set through an alias must be refused, not silently mis-applied to the anchor"
+    );
+    assert_eq!(
+        doc.to_string(),
+        before,
+        "a refused set must leave the document byte-for-byte unchanged (no anchor corruption)"
+    );
+
+    // set_value shares the hazard and the guard.
+    let err = doc.set_value("ref", &noyalib::Value::String("bar".into()));
+    assert!(err.is_err());
+    assert_eq!(doc.to_string(), before);
+
+    // A plain (non-aliased) sibling value is still writable — the guard is
+    // scoped to alias targets, it does not block ordinary edits.
+    let mut doc2 = parse_document("base: &a foo\nplain: keep\n").unwrap();
+    doc2.set("plain", "changed").unwrap();
+    assert!(doc2.to_string().contains("plain: changed"));
+}
+
+#[test]
+fn set_through_aliased_sequence_item_is_refused() {
+    // The same hazard exists for an alias used as a sequence item.
+    let mut doc = parse_document("anchor: &a foo\nlist:\n  - *a\n").unwrap();
+    let before = doc.to_string();
+    assert!(doc.set("list.0", "bar").is_err());
+    assert_eq!(doc.to_string(), before);
+}

--- a/crates/noyalib/tests/tag_registry.rs
+++ b/crates/noyalib/tests/tag_registry.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-use noyalib::{ParserConfig, TagRegistry, from_str_with_config};
+use noyalib::{Error, ParserConfig, TagRegistry, Value, from_str_with_config};
 use serde::Deserialize;
 
 fn cfg(tags: &[&str]) -> ParserConfig {
@@ -89,8 +89,8 @@ fn unregistered_tag_on_scalar_falls_back_to_string() {
     // that wrapper and lets the typed target see through the
     // tag — the path the strongly-typed `Celsius` test uses.
     let cfg = ParserConfig::new();
-    let v: noyalib::Value = from_str_with_config("!Other 42", &cfg).unwrap();
-    let noyalib::Value::Tagged(t) = &v else {
+    let v: Value = from_str_with_config("!Other 42", &cfg).unwrap();
+    let Value::Tagged(t) = &v else {
         panic!("expected Tagged, got {v:?}");
     };
     assert_eq!(t.tag().as_str(), "!Other");
@@ -117,8 +117,8 @@ fn empty_registry_is_no_op() {
     // Empty registry is equivalent to no registry — same AST
     // routing + tag-preserving deserialise. The custom tag
     // surfaces as `Value::Tagged`; opt out by registering it.
-    let v: noyalib::Value = from_str_with_config("!Other 42", &cfg).unwrap();
-    let noyalib::Value::Tagged(t) = &v else {
+    let v: Value = from_str_with_config("!Other 42", &cfg).unwrap();
+    let Value::Tagged(t) = &v else {
         panic!("expected Tagged, got {v:?}");
     };
     assert_eq!(t.tag().as_str(), "!Other");
@@ -160,4 +160,61 @@ fn registry_contains_matches_registered() {
     assert!(!reg.contains("!c"));
     assert_eq!(reg.len(), 2);
     assert!(!reg.is_empty());
+}
+
+// ── Value target + registry: KeyCollision guard + streaming parity ───
+//
+// v0.0.14 review regression. `from_str::<Value>` WITH a tag registry
+// active used to route through the streaming path, which stringifies
+// keys before the distinct-typed `KeyCollision` guard can run — so `1`
+// and `"1"` silently collapsed. `Value`+registry now uses the AST loader
+// (which owns the guard) and the loader strips registered tags itself, so
+// its output matches what streaming produced.
+
+#[test]
+fn value_target_with_registry_detects_distinct_typed_key_collision() {
+    let cfg = cfg(&["!Celsius"]);
+    let res: Result<Value, _> = from_str_with_config("1: a\n\"1\": b\n", &cfg);
+    assert!(
+        matches!(res, Err(Error::KeyCollision(_))),
+        "Value+registry must detect the 1 vs \"1\" collision, got {res:?}"
+    );
+    // Parity with the no-registry Value path, which already errored.
+    let res2: Result<Value, _> = from_str_with_config("1: a\n\"1\": b\n", &ParserConfig::new());
+    assert!(matches!(res2, Err(Error::KeyCollision(_))));
+}
+
+#[test]
+fn value_target_registry_strip_is_style_correct() {
+    let cfg = cfg(&["!Celsius"]);
+    // Plain scalar under a registered tag: stripped, then schema-resolved
+    // to a number — exactly what streaming yields.
+    let v: Value = from_str_with_config("!Celsius 42", &cfg).unwrap();
+    assert_eq!(v.as_i64(), Some(42));
+    // Quoted scalar under the same tag: stripped, but the quoted STYLE is
+    // honoured so it stays a string. A post-parse Value walk could not know
+    // this (the AST tagged node discards style) — proving the strip must
+    // happen at parse time.
+    let v: Value = from_str_with_config("!Celsius \"42\"", &cfg).unwrap();
+    assert_eq!(v.as_str(), Some("42"));
+    // Without the registry the tag is preserved as Value::Tagged.
+    let v: Value = from_str_with_config("!Celsius 42", &ParserConfig::new()).unwrap();
+    assert!(
+        v.as_tagged().is_some(),
+        "unregistered tag must stay tagged, got {v:?}"
+    );
+}
+
+#[test]
+fn value_target_registry_strips_collection_tag() {
+    // A registered tag on a collection is stripped too (streaming parity),
+    // exposing the bare mapping rather than a Value::Tagged wrapper.
+    let cfg = cfg(&["!Config"]);
+    let v: Value = from_str_with_config("!Config\na: 1\nb: 2\n", &cfg).unwrap();
+    assert!(
+        v.as_tagged().is_none(),
+        "registered collection tag must be stripped, got {v:?}"
+    );
+    assert_eq!(v["a"].as_i64(), Some(1));
+    assert_eq!(v["b"].as_i64(), Some(2));
 }


### PR DESCRIPTION
Fixes surfaced by the high-effort pre-release review of `feat/v0.0.14`. Each fix ships a regression test **proven to fail on the pre-fix tree**; full `cargo test -p noyalib` green, clippy `-D warnings` + rustfmt clean, all commits signed.

## Fixes

1. **`fix(cst)` — set/set_value refuse to write through an alias** (`e16f096`)
   `span_at` resolves an alias reference *through* to its anchor's value span (issue #149) — correct for a read. `set`/`set_value` reused that span for writes, so `set("ref", …)` on `base: &a foo\nref: *a` spliced over the anchor's `foo`, silently corrupting a **different** key. They now refuse. Read path (issue #149) untouched.

2. **`fix(de)` — Value+registry routed through the KeyCollision-guarded AST path** (`f57d0d1`)
   `from_str::<Value>` with a tag registry routed through streaming, which stringifies keys before the distinct-typed `KeyCollision` guard can run, so `1` and `"1"` silently collapsed. All `Value` targets now use the AST loader (which owns the guard + DoS budgets); the loader strips registered tags **at parse time** (style-correct — a post-parse walk couldn't match streaming since the `Tagged` node discards scalar style), via a predicate shared with streaming, covering collection tags too so nothing regressed.

3. **`docs(readme)` — crate README install snippets `0.0.8` → `0.0.14`** (`54697a6`)
   The crates.io/docs.rs README still pinned the old version; caught by the version-refs audit.

4. **`fix(loader)` — NoSpanLoader resets the alias budget per document** (`2f8d0c8`)
   NoSpanLoader never zeroed `alias_count`/`alias_bytes` at `DocumentStart`, so a multi-document stream accumulated counts and could trip `RepetitionLimitExceeded` — a std/no_std divergence (NoSpanLoader is the no_std multi-doc default). Now mirrors the span-full loader; cross-path unit test pins the parity.

## Deferred to v0.0.15 (agreed)

`from_str_borrowing::<Value>` KeyCollision gap (blocked by its non-`'static` bound), the typed/map-target gap (already documented in `architecture-contract` §5.2), `max_merge_keys`-on-streaming, and the Budget-vs-Data error-kind wart (§5.1).

Assisted-by: Claude Fable 5