### PR TITLE
fix(scanner): treat lone CR as a line break (classic-Mac CR-only endings)

### DIFF
--- a/crates/noyalib/src/parser/scanner.rs
+++ b/crates/noyalib/src/parser/scanner.rs
@@ -529,7 +529,15 @@ impl<'a> Scanner<'a> {
     #[inline]
     fn advance(&mut self) {
         if self.pos < self.input.len() {
-            if self.input[self.pos] == b'\n' {
+            // YAML 1.2.2 §5.4: a line break is LF, CR, or CRLF. A lone CR
+            // (classic-Mac, not followed by LF) resets the column exactly
+            // like LF; without this, CR-only input desyncs indentation
+            // tracking and yields spurious "inconsistent indentation".
+            // CRLF is consumed via `advance_by`, so its `\r` never reaches
+            // this branch; and even byte-by-byte a `\r\n` pair still nets
+            // col = 0, matching the previous behavior.
+            let b = self.input[self.pos];
+            if b == b'\n' || b == b'\r' {
                 self.col = 0;
             } else {
                 self.col += 1;
@@ -542,11 +550,14 @@ impl<'a> Scanner<'a> {
     fn advance_by(&mut self, n: usize) {
         let end = (self.pos + n).min(self.input.len());
         let slice = &self.input[self.pos..end];
-        // Fast path: no newlines in the slice (common for scalar content).
-        match slice.iter().rposition(|&b| b == b'\n') {
-            Some(last_nl) => {
-                // Column resets at the last newline, then counts remaining bytes.
-                self.col = slice.len() - last_nl - 1;
+        // Column resets at the last line break in the slice. A line break is
+        // LF, CR, or CRLF (YAML 1.2.2 §5.4); for CRLF the trailing `\n` is the
+        // last matched byte, so the column count after it is identical to
+        // matching `\n` alone — this only additionally handles a trailing lone
+        // CR (classic-Mac), mirroring `advance`.
+        match slice.iter().rposition(|&b| b == b'\n' || b == b'\r') {
+            Some(last_break) => {
+                self.col = slice.len() - last_break - 1;
             }
             None => {
                 self.col += slice.len();
@@ -1754,9 +1765,15 @@ impl<'a> Scanner<'a> {
                 // Roll indent for block mapping.
                 if self.flow_level == 0 {
                     self.reject_block_inline_with_doc_start("':'")?;
+                    // A line break is LF, CR, or CRLF (YAML 1.2.2 §5.4);
+                    // scan back for either so a key following a lone CR
+                    // (classic-Mac) is measured from its true line start.
+                    // Matching only `\n` over-counts such a key's column,
+                    // splitting the mapping (the same failure the BOM case
+                    // below guards against).
                     let mut line_start = self.input[..sk.index]
                         .iter()
-                        .rposition(|&b| b == b'\n')
+                        .rposition(|&b| b == b'\n' || b == b'\r')
                         .map_or(0, |nl| nl + 1);
                     // A leading BOM occupies the first three bytes of the
                     // stream but contributes no visual column. Exclude it so a

--- a/crates/noyalib/tests/coverage_scanner.rs
+++ b/crates/noyalib/tests/coverage_scanner.rs
@@ -432,3 +432,33 @@ fn spanned_sequence_deserialization() {
     let v: Spanned<Vec<i32>> = from_str(yaml).unwrap();
     assert_eq!(v.value.len(), 3);
 }
+
+// ── Classic-Mac CR-only line endings (YAML 1.2.2 §5.4) ──────────────────
+
+#[test]
+fn cr_only_line_endings_parse_as_line_breaks() {
+    // A lone CR (not part of CRLF) is a valid YAML line break. Before the
+    // scanner reset the column on a bare `\r`, this was rejected with a
+    // spurious "inconsistent indentation" error.
+    let yaml = "a: 1\rb: 2\r";
+    let v: Value = from_str(yaml).unwrap();
+    assert_eq!(v["a"], Value::from(1));
+    assert_eq!(v["b"], Value::from(2));
+}
+
+#[test]
+fn cr_only_block_sequence_parses() {
+    let yaml = "- one\r- two\r- three\r";
+    let v: Value = from_str(yaml).unwrap();
+    assert_eq!(v.as_sequence().map(|s| s.len()), Some(3));
+    assert_eq!(v[0], Value::String("one".to_string()));
+    assert_eq!(v[2], Value::String("three".to_string()));
+}
+
+#[test]
+fn cr_only_round_trips_byte_for_byte() {
+    // The CST keeps source bytes verbatim regardless of line-ending flavor.
+    let yaml = "a: 1\rb: 2\r";
+    let doc = noyalib::cst::parse_document(yaml).unwrap();
+    assert_eq!(doc.source(), yaml);
+}


### PR DESCRIPTION
YAML 1.2.2 §5.4 defines a line break as LF, CR, or CRLF. The scanner
recognized LF and CRLF but not a lone CR (classic-Mac), so CR-only input
such as `a: 1\rb: 2\r` was rejected.

Three sites tracked line breaks by matching `\n` only:
- advance(): a lone CR grew the column instead of resetting it.
- advance_by(): same, for bulk cursor steps (plain-scalar lookahead).
- the block-mapping simple-key line-start scan: it searched backward for
  `\n` only, so a key after a lone CR was measured from the wrong line
  start and its column over-counted, splitting the mapping in two and
  yielding a spurious 'stray content after document' error (the same
  failure mode the adjacent leading-BOM guard already documents).

All three now treat a lone CR as a line break. Byte offsets (pos/mark)
and token spans are untouched, so source() and the byte-for-byte
round-trip are unaffected; CRLF is consumed via advance_by's trailing
\n and is unchanged.

Adds coverage_scanner tests for CR-only mappings, sequences, and CST
round-trip.
