### PR TITLE
fix(cst): implicit-null nodes report no span (None) instead of the indicator

### DIFF
--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1498,12 +1498,16 @@ fn resolve_span(
     segments: &[QuerySegment],
 ) -> Option<(usize, usize)> {
     if segments.is_empty() {
-        return Some(match span_tree {
-            SpanTree::Leaf(s, e) => (*s, *e),
+        return match span_tree {
+            // A zero-width leaf marks an implicit null (an absent
+            // block-mapping value or empty sequence item): the node has no
+            // source bytes of its own, so it has no span.
+            SpanTree::Leaf(s, e) if s == e => None,
+            SpanTree::Leaf(s, e) => Some((*s, *e)),
             SpanTree::Sequence { start, end, .. } | SpanTree::Mapping { start, end, .. } => {
-                (*start, *end)
+                Some((*start, *end))
             }
-        });
+        };
     }
     let (head, tail) = segments.split_first()?;
     match (head, value, span_tree) {

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -381,6 +381,18 @@ impl<'a> Loader<'a> {
                 tag,
                 span,
             } => {
+                // An empty plain scalar with no anchor or tag is the
+                // implicit null the parser synthesizes for an absent
+                // block-mapping value or empty sequence item. The span it
+                // was handed is the `:` / `-` indicator it followed, not the
+                // value's own bytes, so mark the leaf zero-width: the node
+                // has no source of its own and `span_at` should report None.
+                // Quoted empties carry a non-Plain style and `~` / `null` a
+                // non-empty value, so both keep their real spans.
+                let is_implicit_empty = value.is_empty()
+                    && matches!(style, crate::parser::ScalarStyle::Plain)
+                    && anchor.is_none()
+                    && tag.is_none();
                 let v = if let Some(t) = tag {
                     resolve_tagged_scalar(&t.0, &t.1, &value, self.config.lossless_u64_integers())?
                 } else if style != crate::parser::ScalarStyle::Plain {
@@ -408,7 +420,11 @@ impl<'a> Loader<'a> {
                     }
                 };
 
-                let st = SpanTree::Leaf(span.start, span.end);
+                let st = if is_implicit_empty {
+                    SpanTree::Leaf(span.start, span.start)
+                } else {
+                    SpanTree::Leaf(span.start, span.end)
+                };
                 if let Some(name) = anchor {
                     let _ = self.anchor_map.insert(name, (v.clone(), st.clone()));
                 }

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -653,6 +653,40 @@ fn coverage_doc_span_at_empty_path_returns_root_collection() {
     assert!(span.is_some() || span.is_none());
 }
 
+// ── Implicit-null nodes have no span of their own ───────────────────
+
+#[test]
+fn coverage_doc_span_at_implicit_null_is_none() {
+    // An absent block-mapping value is the implicit null; its bytes are
+    // the `:` indicator, which is not the value, so span_at reports None.
+    let doc = parse_document("c:\nother: 1\n").unwrap();
+    assert_eq!(doc.span_at("c"), None);
+
+    // Same at end of input.
+    let doc = parse_document("a: 1\nc:\n").unwrap();
+    assert_eq!(doc.span_at("c"), None);
+
+    // Empty sequence item (the `-` indicator) is likewise byte-less.
+    let doc = parse_document("- \n- x\n").unwrap();
+    assert_eq!(doc.span_at("[0]"), None);
+}
+
+#[test]
+fn coverage_doc_span_at_explicit_null_and_empty_quote_keep_span() {
+    // Explicit nulls and quoted empties DO have source bytes.
+    let doc = parse_document("c: ~\nother: 1\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "~");
+
+    let doc = parse_document("c: null\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "null");
+
+    let doc = parse_document("c: ''\n").unwrap();
+    let (s, e) = doc.span_at("c").unwrap();
+    assert_eq!(&doc.source()[s..e], "''");
+}
+
 // ── parse_stream propagates errors from document_boundaries (L985) ──
 
 #[test]


### PR DESCRIPTION
An absent block-mapping value (`c:`) or empty sequence item (`- `) is an
implicit null the parser synthesizes as an empty plain scalar, handed the
span of the `:` / `-` indicator it followed. span_at then returned those
indicator bytes — a slice that is neither the null value nor valid YAML.

The loader now marks such a scalar (empty value, plain style, no anchor
or tag) with a zero-width SpanTree leaf, and resolve_span reports None for
a zero-width leaf: the node has no source bytes of its own. Explicit
nulls (`~`, `null`) carry a non-empty value and quoted empties (`''`) a
non-Plain style, so both keep their real spans.

This only changes what span_at reports; source() and the byte-for-byte
round-trip are unaffected.

Adds cst_document_coverage tests: implicit null (map value, EOF key,
empty sequence item) -> None; explicit `~`/`null`/`''` keep their spans.
