### PR TITLE
fix(loader): refuse distinct-typed mapping key collisions loudly

### DIFF
--- a/crates/noyalib/src/error.rs
+++ b/crates/noyalib/src/error.rs
@@ -423,6 +423,23 @@ pub enum Error {
     /// ```
     DuplicateKey(String),
 
+    /// Two distinct-typed keys collapsed to the same string key.
+    ///
+    /// The mapping key model is `Mapping<String, Value>`, so keys are
+    /// stringified. Distinct YAML keys that share a spelling — e.g. the
+    /// integer `1` and the string `"1"`, or `true` and `"true"` — would
+    /// silently overwrite each other, losing an entry. This is raised
+    /// instead, carrying the collapsed string key. Unlike
+    /// [`Self::DuplicateKey`], it fires regardless of `DuplicateKeyPolicy`
+    /// because it is data loss, not an authored duplicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let _e = noyalib::Error::KeyCollision("1".into());
+    /// ```
+    KeyCollision(String),
+
     /// Repetition limit exceeded (security limit against billion-laughs).
     ///
     /// # Examples
@@ -711,6 +728,11 @@ impl fmt::Display for Error {
                 write!(f, "recursion depth limit exceeded: {depth}")
             }
             Error::DuplicateKey(name) => write!(f, "duplicate key: {name}"),
+            Error::KeyCollision(name) => write!(
+                f,
+                "distinct mapping keys collide after string conversion: {name} \
+                 (e.g. `1` and `\"1\"`, or `true` and `\"true\"`)"
+            ),
             Error::RepetitionLimitExceeded => f.write_str("alias expansion limit exceeded"),
             Error::Budget(breach) => write!(f, "{breach}"),
             Error::UnknownAnchor(name) => write!(f, "unknown anchor: {name}"),
@@ -1392,6 +1414,7 @@ impl miette::Diagnostic for Error {
             Error::Budget(_) => "noyalib::budget",
             Error::UnknownAnchor(_) | Error::UnknownAnchorAt { .. } => "noyalib::unknown_anchor",
             Error::DuplicateKey(_) => "noyalib::duplicate_key",
+            Error::KeyCollision(_) => "noyalib::key_collision",
             Error::EndOfStream => "noyalib::eof",
             Error::MoreThanOneDocument => "noyalib::multi_document",
             Error::Io(_) => "noyalib::io",
@@ -1424,6 +1447,9 @@ impl miette::Diagnostic for Error {
             Error::DuplicateKey(_) => {
                 Some("use DuplicateKeyPolicy::Last or ::Error to control behaviour".into())
             }
+            Error::KeyCollision(_) => Some(
+                "give the colliding keys distinct spellings, or quote them consistently".into(),
+            ),
             Error::MoreThanOneDocument => {
                 Some("use noyalib::load_all() to parse multi-document streams".into())
             }

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -208,6 +208,11 @@ enum Frame {
     MappingKey {
         map: Mapping,
         span_entries: Vec<((usize, usize), SpanTree)>,
+        /// The original typed key of each inserted entry, in insertion
+        /// order (parallel to `map`). Retained to tell a genuine YAML
+        /// duplicate (`1`/`1`) apart from a distinct-typed collision
+        /// (`1`/`"1"`) once both collapse to the same string key.
+        typed_keys: Vec<Value>,
         start: usize,
         anchor: Option<String>,
         merge_values: Vec<Value>,
@@ -219,7 +224,10 @@ enum Frame {
     MappingValue {
         map: Mapping,
         span_entries: Vec<((usize, usize), SpanTree)>,
+        typed_keys: Vec<Value>,
         key: String,
+        /// The typed key that produced `key`, kept for the collision check.
+        key_value: Value,
         key_span: (usize, usize),
         start: usize,
         anchor: Option<String>,
@@ -468,6 +476,7 @@ impl<'a> Loader<'a> {
                 self.stack.push(Frame::MappingKey {
                     map: Mapping::new(),
                     span_entries: Vec::new(),
+                    typed_keys: Vec::new(),
                     start: span.start,
                     anchor,
                     merge_values: Vec::new(),
@@ -479,6 +488,7 @@ impl<'a> Loader<'a> {
                 if let Some(Frame::MappingKey {
                     mut map,
                     span_entries,
+                    typed_keys: _,
                     start,
                     anchor,
                     merge_values,
@@ -530,11 +540,17 @@ impl<'a> Loader<'a> {
             Frame::MappingKey {
                 map,
                 span_entries,
+                typed_keys,
                 start,
                 anchor,
                 merge_values,
                 tag,
             } => {
+                // Retain the typed key before it is coerced to a string, so
+                // the insert site can tell a genuine duplicate apart from a
+                // distinct-typed collision. The clone is off the hot path
+                // (keys only) and only used for the equality check.
+                let key_value = value.clone();
                 // Coerce scalar keys to strings; complex keys (sequences,
                 // mappings) are stringified via their YAML serialization
                 // so the final `Mapping<String, Value>` can hold them.
@@ -555,6 +571,7 @@ impl<'a> Loader<'a> {
                 };
                 let old_map = core::mem::take(map);
                 let old_span_entries = core::mem::take(span_entries);
+                let old_typed_keys = core::mem::take(typed_keys);
                 let old_start = *start;
                 let old_anchor = anchor.take();
                 let old_merge_values = core::mem::take(merge_values);
@@ -563,7 +580,9 @@ impl<'a> Loader<'a> {
                 *self.stack.last_mut().unwrap() = Frame::MappingValue {
                     map: old_map,
                     span_entries: old_span_entries,
+                    typed_keys: old_typed_keys,
                     key: key_str,
+                    key_value,
                     key_span,
                     start: old_start,
                     anchor: old_anchor,
@@ -574,7 +593,9 @@ impl<'a> Loader<'a> {
             Frame::MappingValue {
                 map,
                 span_entries,
+                typed_keys,
                 key,
+                key_value,
                 key_span,
                 start,
                 anchor,
@@ -609,11 +630,26 @@ impl<'a> Loader<'a> {
                     // slot is discarded. Each branch is the last use of
                     // `key`, so the move is sound.
                     let key = core::mem::take(key);
+                    let key_value = core::mem::take(key_value);
+                    // Distinct-typed collision: the string key already exists
+                    // but was produced by a *different* typed key (e.g. `1`
+                    // then `"1"`, or `true` then `"true"`). Collapsing them
+                    // would silently drop an entry, so refuse regardless of
+                    // DuplicateKeyPolicy. A genuine duplicate (same typed key)
+                    // falls through to the policy below.
+                    if let Some(idx) = map.get_index_of(&key) {
+                        // Nested (not a `let`-chain) to keep the crate's
+                        // 1.85 MSRV: `let`-chains stabilized in 1.88.
+                        if typed_keys[idx] != key_value {
+                            return Err(Error::KeyCollision(key));
+                        }
+                    }
                     match self.config.duplicate_key_policy {
                         DuplicateKeyPolicy::First => {
                             if !map.contains_key(&key) {
                                 let _ = map.insert(key, value);
                                 span_entries.push((*key_span, span));
+                                typed_keys.push(key_value);
                             }
                         }
                         DuplicateKeyPolicy::Last => {
@@ -627,9 +663,12 @@ impl<'a> Loader<'a> {
                             if let Some(idx) = map.get_index_of(&key) {
                                 let _ = map.insert(key, value);
                                 span_entries[idx] = (*key_span, span);
+                                // `typed_keys[idx]` is unchanged: a genuine
+                                // duplicate carries the same typed key.
                             } else {
                                 let _ = map.insert(key, value);
                                 span_entries.push((*key_span, span));
+                                typed_keys.push(key_value);
                             }
                         }
                         DuplicateKeyPolicy::Error => {
@@ -638,12 +677,14 @@ impl<'a> Loader<'a> {
                             }
                             let _ = map.insert(key, value);
                             span_entries.push((*key_span, span));
+                            typed_keys.push(key_value);
                         }
                     }
                 }
 
                 let old_map = core::mem::take(map);
                 let old_span_entries = core::mem::take(span_entries);
+                let old_typed_keys = core::mem::take(typed_keys);
                 let old_start = *start;
                 let old_anchor = anchor.take();
                 let old_merge_values = core::mem::take(merge_values);
@@ -652,6 +693,7 @@ impl<'a> Loader<'a> {
                 *self.stack.last_mut().unwrap() = Frame::MappingKey {
                     map: old_map,
                     span_entries: old_span_entries,
+                    typed_keys: old_typed_keys,
                     start: old_start,
                     anchor: old_anchor,
                     merge_values: old_merge_values,

--- a/crates/noyalib/tests/dup_key_spans.rs
+++ b/crates/noyalib/tests/dup_key_spans.rs
@@ -172,3 +172,55 @@ fn spanned_fields_stay_aligned_after_duplicate_key() {
         "Spanned span after a duplicate key must not be shifted"
     );
 }
+
+// ── Distinct-typed key collisions are refused, not silently collapsed ──
+//
+// The mapping key model is `Mapping<String, Value>`. Two DISTINCT YAML
+// keys that stringify the same — the integer `1` and the string `"1"`,
+// `true` and `"true"`, the null `~` and `"null"` — would otherwise
+// overwrite each other, silently losing an entry. That is data loss, so
+// the loader raises `Error::KeyCollision` instead. A genuine duplicate
+// (the same typed key twice) keeps its `DuplicateKeyPolicy` behaviour.
+
+#[test]
+fn distinct_typed_keys_collide_loudly() {
+    for src in [
+        "1: a\n\"1\": b\n",          // int vs string
+        "true: yes\n\"true\": no\n", // bool vs string
+        "~: a\n\"null\": b\n",       // null vs string
+    ] {
+        let err = parse_document(src).expect_err("distinct-typed collision must error");
+        assert!(
+            matches!(err, noyalib::Error::KeyCollision(_)),
+            "expected KeyCollision for {src:?}, got {err:?}"
+        );
+        assert!(format!("{err}").contains("collide"), "{err}");
+    }
+}
+
+#[test]
+fn genuine_duplicate_keys_are_not_a_collision() {
+    // The same typed key twice is an authored duplicate: default
+    // last-wins keeps one entry, no error.
+    let doc = parse_document("1: a\n1: b\n").unwrap();
+    let v = doc.as_value();
+    let m = v.as_mapping().unwrap();
+    assert_eq!(m.len(), 1);
+    assert_eq!(m.get("1"), Some(&noyalib::Value::String("b".into())));
+}
+
+#[test]
+fn non_colliding_scalar_keys_load() {
+    // A lone numeric or bool key stringifies without colliding.
+    assert!(parse_document("8080: service\n").is_ok());
+    assert!(parse_document("true: on\n").is_ok());
+    assert!(parse_document("a: 1\nb: 2\n").is_ok());
+}
+
+#[test]
+fn merge_keys_do_not_trip_the_collision_check() {
+    // `<<` merge values are buffered separately and never run through
+    // the ordinary-insert collision check.
+    let src = "defaults: &d\n  timeout: 30\nservice:\n  <<: *d\n  name: web\n";
+    assert!(parse_document(src).is_ok());
+}


### PR DESCRIPTION
The mapping key model is Mapping<String, Value>, so keys are stringified
via value_to_key_string. Distinct YAML keys that share a spelling — the
integer 1 and the string "1", true and "true", the null ~ and "null" —
collapsed to the same string key and silently overwrote each other,
losing an entry from as_value(). That is data loss inside the typed view.

The spanned loader now retains each entry's original typed key (a Vec
parallel to the mapping, off the hot path — keys only) and, when an
incoming string key already exists but was produced by a *different*
typed key, raises the new Error::KeyCollision regardless of
DuplicateKeyPolicy. A genuine authored duplicate (same typed key, e.g.
1/1 or ~/null which are both null) still follows First/Last/Error as
before. Merge (<<) values are buffered separately and never run through
the check.

Scope: this patches the spanned load_one path (parse_document /
parse_stream / as_value). The no-span load_all_no_spans path and the
serde Value deserializer collapse the same keys through independent code
and warrant the same diagnostic as a follow-up.

Adds Error::KeyCollision (Display / code / help) and dup_key_spans tests:
int/str, bool/str, null/str collisions error; genuine duplicates,
non-colliding, and merge keys still load.
