### PR TITLE
fix: v0.0.14 ultrareview — quoted-key alias corruption, max_documents fast-path bypass, anchored keep-chomp spans

### DIFF
--- a/crates/noyalib/src/cst/document.rs
+++ b/crates/noyalib/src/cst/document.rs
@@ -1202,14 +1202,36 @@ fn terminal_is_alias(
             // Last matching entry wins (DuplicateKeyPolicy::Last), mirroring
             // walk_mapping so this agrees with what span_at would target.
             let mut found: Option<(&GreenNode, usize)> = None;
+            // `entry_key_text` can't decode every key spelling (double-quoted,
+            // complex, merge). For such an entry `span_at` falls back to the
+            // typed cache and, matching by the cache's decoded key, resolves an
+            // alias *through* to its anchor — the exact write hazard this guard
+            // exists to catch. We can't match the undecodable key by text here,
+            // so if any undecodable-key entry's value is an alias, treat the
+            // (undecodable) target as a possible hit and refuse conservatively.
+            let mut undecodable_alias = false;
             let mut pos = base;
             for child in node.children() {
                 let len = child.text_len();
                 if let GreenChild::Node(entry) = child {
-                    if entry.kind() == SyntaxKind::MappingEntry
-                        && entry_key_text(entry, source, pos).as_deref() == Some(k.as_str())
-                    {
-                        found = Some((entry, pos));
+                    if entry.kind() == SyntaxKind::MappingEntry {
+                        match entry_key_text(entry, source, pos) {
+                            Some(key) if key.as_ref() == k.as_str() => {
+                                found = Some((entry, pos));
+                            }
+                            Some(_) => {}
+                            None => {
+                                if value_after_sep_is_alias(
+                                    entry,
+                                    pos,
+                                    tail,
+                                    source,
+                                    SyntaxKind::ColonIndicator,
+                                ) {
+                                    undecodable_alias = true;
+                                }
+                            }
+                        }
                     }
                 }
                 pos += len;
@@ -1222,7 +1244,9 @@ fn terminal_is_alias(
                     source,
                     SyntaxKind::ColonIndicator,
                 ),
-                None => false,
+                // No decodable key matched: refuse if an undecodable-key entry
+                // is an alias (the target could be it).
+                None => undecodable_alias,
             }
         }
         (QuerySegment::Index(i), SyntaxKind::BlockSequence | SyntaxKind::FlowSequence) => {
@@ -1692,6 +1716,13 @@ fn trim_value_span(source: &str, start: usize, end: usize) -> (usize, usize) {
 /// other node kinds.
 fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool {
     let bytes = source.as_bytes();
+    // The value span's start may have been widened leftward over an anchor
+    // (`&name`) / tag (`!Tag`, `!!str`) property prefix (see `entry_value`), so
+    // the block indicator is not necessarily at `start`. Skip those property
+    // tokens before inspecting for `|` / `>`, otherwise an anchored/tagged
+    // keep-chomped scalar (`key: &anc |+`) is misclassified and its kept
+    // trailing blank lines are trimmed.
+    let start = skip_value_property_prefix(bytes, start, end);
     if start >= end || (bytes[start] != b'|' && bytes[start] != b'>') {
         return false;
     }
@@ -1705,6 +1736,26 @@ fn is_keep_chomped_block_scalar(source: &str, start: usize, end: usize) -> bool 
         }
     }
     false
+}
+
+/// Advance past leading anchor (`&name`) / tag (`!Tag`, `!!str`) property
+/// tokens and the whitespace between them, returning the index of the value
+/// content proper. Value spans are widened leftward over these properties, so
+/// callers inspecting the value's first byte must skip them first.
+fn skip_value_property_prefix(bytes: &[u8], mut start: usize, end: usize) -> usize {
+    loop {
+        while start < end && matches!(bytes[start], b' ' | b'\t') {
+            start += 1;
+        }
+        if start < end && matches!(bytes[start], b'&' | b'!') {
+            start += 1;
+            while start < end && !matches!(bytes[start], b' ' | b'\t' | b'\n' | b'\r') {
+                start += 1;
+            }
+        } else {
+            return start;
+        }
+    }
 }
 
 fn resolve_span(

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -915,6 +915,16 @@ impl<'a> NoSpanLoader<'a> {
                 // on the no-span path — a std/no_std divergence.
                 self.alias_count = 0;
                 self.alias_bytes = 0;
+                // Budget: max_documents (mirror the span-full Loader).
+                // `from_str::<Value>` always routes through this loader, so
+                // without this the fast path silently materialises the whole
+                // stream past the caller's document limit.
+                if self.docs.len() + 1 > self.config.max_documents {
+                    return Err(Error::Budget(crate::BudgetBreach::MaxDocuments {
+                        limit: self.config.max_documents,
+                        observed: self.docs.len() + 1,
+                    }));
+                }
             }
             Event::DocumentEnd => {
                 self.in_document = false;

--- a/crates/noyalib/tests/cst_anchors.rs
+++ b/crates/noyalib/tests/cst_anchors.rs
@@ -394,3 +394,40 @@ fn set_through_aliased_sequence_item_is_refused() {
     assert!(doc.set("list.0", "bar").is_err());
     assert_eq!(doc.to_string(), before);
 }
+
+// ── Regression: alias-write guard must cover undecodable (quoted) keys ──
+
+#[test]
+fn set_through_double_quoted_alias_key_is_refused() {
+    // ultrareview BUG003. The alias-write guard matched keys via
+    // `entry_key_text`, which can't decode double-quoted keys, so
+    // `set("target_key", …)` on a double-quoted alias entry slipped past
+    // the guard and spliced the ANCHOR's value — silent corruption of a
+    // different key. Must be refused.
+    let src = "anchor_key: &a foo\n\"target_key\": *a\n";
+    let mut doc = parse_document(src).unwrap();
+    let before = doc.to_string();
+    assert!(
+        doc.set("target_key", "bar").is_err(),
+        "set through a double-quoted alias key must be refused"
+    );
+    assert_eq!(
+        doc.to_string(),
+        before,
+        "document must be unchanged (no anchor corruption)"
+    );
+}
+
+#[test]
+fn set_double_quoted_key_with_plain_value_still_works() {
+    // No regression: an ordinary double-quoted key whose value is NOT an
+    // alias is still writable — the guard only fires on alias values.
+    let mut doc = parse_document("\"my key\": old\nplain: keep\n").unwrap();
+    doc.set("my key", "new").unwrap();
+    assert!(
+        doc.to_string().contains("\"my key\": new"),
+        "got {:?}",
+        doc.to_string()
+    );
+    assert!(doc.to_string().contains("plain: keep"));
+}

--- a/crates/noyalib/tests/cst_document_coverage.rs
+++ b/crates/noyalib/tests/cst_document_coverage.rs
@@ -966,3 +966,22 @@ fn coverage_doc_insert_entry_into_empty_mapping_errors() {
         "{msg}"
     );
 }
+
+#[test]
+fn coverage_doc_span_at_anchored_tagged_keep_chomped_keeps_trailing_blanks() {
+    // ultrareview BUG001: an anchor (`&name`) / tag (`!Tag`, `!!str`) property
+    // widens the value span start over `&` / `!`, so the keep-chomp guard must
+    // skip the prefix before inspecting the block indicator. Otherwise the kept
+    // trailing blank lines are trimmed and the slice re-parses to a shorter
+    // value.
+    for (src, want) in [
+        ("key: &anc |+\n  kept\n\n\n", "&anc |+\n  kept\n\n\n"),
+        ("key: !!str |+\n  kept\n\n\n", "!!str |+\n  kept\n\n\n"),
+        ("key: !Tag |+\n  kept\n\n\n", "!Tag |+\n  kept\n\n\n"),
+        ("key: &anc >+\n  kept\n\n\n", "&anc >+\n  kept\n\n\n"),
+    ] {
+        let doc = parse_document(src).unwrap();
+        let (s, e) = doc.span_at("key").unwrap();
+        assert_eq!(&doc.source()[s..e], want, "span for {src:?}");
+    }
+}

--- a/crates/noyalib/tests/no_span_loader_parity.rs
+++ b/crates/noyalib/tests/no_span_loader_parity.rs
@@ -172,3 +172,24 @@ fn duplicate_policy_first_still_wins_on_value_path() {
     // policy is overridden; both loaders honour it.
     assert_eq!(m.get("k"), Some(&Value::String("one".into())));
 }
+
+// ── max_documents parity on the Value fast path (ultrareview BUG006) ──
+
+#[test]
+fn value_fast_path_enforces_max_documents() {
+    // `from_str::<Value>` routes through NoSpanLoader, which lacked the
+    // `max_documents` guard the span-full loader enforces — so a caller
+    // using max_documents as a DoS mitigation got no enforcement on the
+    // fast path, and the whole stream was materialised.
+    let cfg = ParserConfig::new().max_documents(1);
+    let src = "a: 1\n---\nb: 2\n---\nc: 3\n";
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("max_documents must be enforced on the Value fast path");
+    assert!(
+        matches!(
+            err,
+            Error::Budget(BudgetBreach::MaxDocuments { limit: 1, .. })
+        ),
+        "expected MaxDocuments budget error, got {err:?}"
+    );
+}


### PR DESCRIPTION
Fixes the three confirmed blockers/defects from the `/ultrareview` deep pass on `feat/v0.0.14`. Each reproduced on the current tree before fixing, and each ships a regression test proven to fail on the pre-fix tree. Full `cargo test -p noyalib` green, clippy `-D warnings` + rustfmt clean, signed.

## Fixes

1. **`fix(cst)` — BUG003: alias-write guard bypassed for double-quoted keys** (`7e2f321`)
   `set("target_key", …)` on `"target_key": *a` slipped past the guard (which couldn't decode the double-quoted key) and spliced the replacement onto the **anchor's** value — silent corruption of a different key, the exact class the v0.0.14 guard was added to prevent. The guard now refuses when an undecodable-key entry's value is an alias; ordinary double-quoted keys with non-alias values still write (no regression).

2. **`fix(cst)` — BUG001: anchored/tagged keep-chomped block-scalar span** (`7e2f321`)
   `key: &anc |+` / `!!str |+` had the kept trailing blank lines trimmed because the keep-chomp check inspected `&`/`!` instead of the block indicator. Now skips the anchor/tag property prefix first.

3. **`fix(loader)` — BUG006: `max_documents` bypass on the `Value` fast path** (`c357742`)
   `from_str::<Value>` routes through `NoSpanLoader`, which lacked the `max_documents` guard the span-full loader enforces, so the DoS limit was silently non-functional on the default `Value` target. Mirrored the guard.

## Deferred to v0.0.15 (unchanged)

**BUG004** — `from_str_borrowing::<Value>` collapses distinct-typed key collisions. Confirmed real, but the fix needs either a breaking `'static` bound on the borrowing API or a marker-trait refactor of `is_value_target`; that's v0.0.15 scope, tracked alongside the other deferred KeyCollision items.

Assisted-by: Claude Fable 5