### PR TITLE
coverage: remove orphaned tag-preserving dead code + cover Number Ord arms

### DIFF
--- a/crates/noyalib/src/de/deserializer.rs
+++ b/crates/noyalib/src/de/deserializer.rs
@@ -32,19 +32,6 @@ pub struct Deserializer<'de> {
     /// `"ABCD"` (no base64 decode). Default `false` preserves YAML
     /// 1.2 semantics.
     pub(crate) ignore_binary_tag_for_string: bool,
-    /// When `true`, [`Value::Tagged`] is surfaced through the
-    /// magic-key [`crate::value::TagPreservingMapAccess`] so the
-    /// outer [`Value::deserialize`] visitor can reconstruct
-    /// `Value::Tagged(...)` losslessly. When `false` (default), a
-    /// tagged scalar is unwrapped to its inner value — the
-    /// transparent behaviour every typed `T::deserialize` expects.
-    ///
-    /// Set automatically by [`from_str_with_config`] /
-    /// [`from_value`] when the caller's `T` is `Value` (detected
-    /// via [`std::any::TypeId`]). Threaded through every
-    /// `descend()` site so nested tagged values inside a
-    /// `Mapping` / `Sequence` also survive.
-    pub(crate) preserve_tags: bool,
 }
 
 impl<'de> Deserializer<'de> {
@@ -63,7 +50,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: None,
             ignore_binary_tag_for_string: false,
-            preserve_tags: false,
         }
     }
 
@@ -89,7 +75,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: Some(span_ctx),
             ignore_binary_tag_for_string: false,
-            preserve_tags: false,
         }
     }
 
@@ -106,25 +91,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx,
             ignore_binary_tag_for_string,
-            preserve_tags: false,
-        }
-    }
-
-    /// Internal constructor used by [`from_str_with_config`] /
-    /// [`from_value`] when the caller's `T` is detected as
-    /// [`Value`] via [`std::any::TypeId`]. Sets `preserve_tags`
-    /// so [`Value::Tagged`] survives the data-binding return
-    /// path. See `Deserializer::preserve_tags` for the contract.
-    pub(crate) fn with_options_preserving_tags(
-        value: &'de Value,
-        span_ctx: Option<&'de span_context::SpanContext>,
-        ignore_binary_tag_for_string: bool,
-    ) -> Self {
-        Deserializer {
-            value,
-            span_ctx,
-            ignore_binary_tag_for_string,
-            preserve_tags: true,
         }
     }
 
@@ -137,7 +103,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: self.span_ctx,
             ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-            preserve_tags: self.preserve_tags,
         }
     }
 
@@ -176,24 +141,13 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Value::Sequence(_) => self.deserialize_seq(visitor),
             Value::Mapping(_) => self.deserialize_map(visitor),
             Value::Tagged(tagged) => {
-                if self.preserve_tags {
-                    // Tag-preserving path (`from_str::<Value>` /
-                    // `from_value::<Value>`): surface the tag via
-                    // a magic-key MapAccess so the outer
-                    // `Value::deserialize` visitor reconstructs
-                    // `Value::Tagged(...)` losslessly.
-                    self.wrap_err(visitor.visit_map(crate::value::TagPreservingMapAccess::new(
-                        tagged.tag().as_str(),
-                        tagged.value(),
-                    )))
-                } else {
-                    // Default path: typed targets see through the
-                    // tag transparently — `#[derive(Deserialize)]
-                    // struct Foo { x: i32 }` against `!Foo {x: 1}`
-                    // yields `Foo { x: 1 }`.
-                    let de = self.descend(tagged.value());
-                    de.deserialize_any(visitor)
-                }
+                // Typed targets see through the tag transparently —
+                // `#[derive(Deserialize)] struct Foo { x: i32 }` against
+                // `!Foo {x: 1}` yields `Foo { x: 1 }`. (Tag *preservation* for
+                // a `Value` target happens in the AST loader / `from_value`'s
+                // clone fast path, not here.)
+                let de = self.descend(tagged.value());
+                de.deserialize_any(visitor)
             }
         }
     }
@@ -581,10 +535,6 @@ pub(crate) struct ValueSeqAccess<'de> {
     iter: core::slice::Iter<'de, Value>,
     span_ctx: Option<&'de span_context::SpanContext>,
     ignore_binary_tag_for_string: bool,
-    /// Mirror of the parent [`Deserializer::preserve_tags`] so
-    /// nested `Value::Tagged(...)` nodes inside a sequence
-    /// survive the data-binding return path.
-    preserve_tags: bool,
 }
 
 impl<'de> ValueSeqAccess<'de> {
@@ -593,7 +543,6 @@ impl<'de> ValueSeqAccess<'de> {
             iter: seq.iter(),
             span_ctx: de.span_ctx,
             ignore_binary_tag_for_string: de.ignore_binary_tag_for_string,
-            preserve_tags: de.preserve_tags,
         }
     }
 }
@@ -611,7 +560,6 @@ impl<'de> SeqAccess<'de> for ValueSeqAccess<'de> {
                     value,
                     span_ctx: self.span_ctx,
                     ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-                    preserve_tags: self.preserve_tags,
                 };
                 seed.deserialize(de).map(Some)
             }
@@ -625,10 +573,6 @@ pub(crate) struct ValueMapAccess<'de> {
     value: Option<&'de Value>,
     span_ctx: Option<&'de span_context::SpanContext>,
     ignore_binary_tag_for_string: bool,
-    /// Mirror of the parent [`Deserializer::preserve_tags`] so
-    /// nested `Value::Tagged(...)` nodes inside a mapping survive
-    /// the data-binding return path. See `de::Deserializer` docs.
-    preserve_tags: bool,
 }
 
 impl<'de> ValueMapAccess<'de> {
@@ -638,19 +582,16 @@ impl<'de> ValueMapAccess<'de> {
             value: None,
             span_ctx: de.span_ctx,
             ignore_binary_tag_for_string: de.ignore_binary_tag_for_string,
-            preserve_tags: de.preserve_tags,
         }
     }
 
     /// Build the child [`Deserializer`] used to read each map
-    /// value — propagates every per-call toggle including
-    /// `preserve_tags`.
+    /// value — propagates every per-call toggle.
     fn child_de(&self, value: &'de Value) -> Deserializer<'de> {
         Deserializer {
             value,
             span_ctx: self.span_ctx,
             ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-            preserve_tags: self.preserve_tags,
         }
     }
 }

--- a/crates/noyalib/src/value.rs
+++ b/crates/noyalib/src/value.rs
@@ -19,7 +19,6 @@ pub type Sequence = Vec<Value>;
 
 mod tag;
 pub use tag::{MaybeTag, Tag, TaggedValue, check_for_tag, nobang};
-pub(crate) use tag::{TAGGED_VALUE_FIELD_TAG, TAGGED_VALUE_FIELD_VALUE, TagPreservingMapAccess};
 
 /// Represents any valid YAML value.
 #[derive(Debug, Clone, Default)]

--- a/crates/noyalib/src/value/serde_impl.rs
+++ b/crates/noyalib/src/value/serde_impl.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-use super::{
-    Mapping, Number, TAGGED_VALUE_FIELD_TAG, TAGGED_VALUE_FIELD_VALUE, Tag, TaggedValue, Value,
-};
+use super::{Mapping, Number, TaggedValue, Value};
 use crate::prelude::*;
 use indexmap::map::Iter;
 use serde::{Deserialize, Serialize};
@@ -81,43 +79,7 @@ impl<'de> Deserialize<'de> for Value {
             where
                 A: MapAccess<'de>,
             {
-                // Tag-preserving fast path: noyalib's own
-                // [`crate::de::Deserializer::deserialize_any`]
-                // routes `Value::Tagged(...)` through a
-                // [`TagPreservingMapAccess`] when its
-                // `preserve_tags` flag is on (set automatically
-                // for `from_str::<Value>` / `from_value::<Value>`
-                // — see [`crate::de::is_value_target`]). The first
-                // key of that map is the [`TAGGED_VALUE_FIELD_TAG`]
-                // sentinel; detect it and reconstruct
-                // `Value::Tagged` so the tag survives the
-                // data-binding return path.
-                //
-                // Other Deserializers (serde_json, FlatMap, …)
-                // never see this magic shape, so this branch is
-                // strictly additive.
                 let first_key: Option<String> = map.next_key()?;
-                if let Some(k) = first_key.as_deref() {
-                    if k == TAGGED_VALUE_FIELD_TAG {
-                        let tag_str: String = map.next_value()?;
-                        let second_key: String = map.next_key()?.ok_or_else(|| {
-                            <A::Error as serde::de::Error>::custom(
-                                "tag-preserving map missing $__noyalib_value entry",
-                            )
-                        })?;
-                        if second_key != TAGGED_VALUE_FIELD_VALUE {
-                            return Err(<A::Error as serde::de::Error>::custom(format!(
-                                "tag-preserving map: expected `{}`, got `{}`",
-                                TAGGED_VALUE_FIELD_VALUE, second_key
-                            )));
-                        }
-                        let inner: Value = map.next_value()?;
-                        return Ok(Value::Tagged(Box::new(TaggedValue::new(
-                            Tag::new(tag_str),
-                            inner,
-                        ))));
-                    }
-                }
                 // Regular mapping path — collect every (k, v) pair
                 // including the (k, v) we already consumed.
                 // Pre-size when the MapAccess provides a usable

--- a/crates/noyalib/src/value/tag.rs
+++ b/crates/noyalib/src/value/tag.rs
@@ -62,16 +62,6 @@ pub fn check_for_tag<T: fmt::Display>(value: &T) -> MaybeTag<String> {
     }
 }
 
-/// Magic key in the [`TagPreservingMapAccess`] map shape that
-/// signals "the next entry is the tag string". Recognised by
-/// `Value::deserialize`'s visitor on the tag-preserving path
-/// driven by [`crate::de::Deserializer::preserve_tags`].
-pub(crate) const TAGGED_VALUE_FIELD_TAG: &str = "$__noyalib_tag";
-
-/// Magic key in the [`TagPreservingMapAccess`] map shape that
-/// signals "the next entry is the inner [`Value`]".
-pub(crate) const TAGGED_VALUE_FIELD_VALUE: &str = "$__noyalib_value";
-
 /// A YAML tag.
 ///
 /// Tags are used in YAML to denote the type of a value.
@@ -430,108 +420,6 @@ impl<'de> serde::de::MapAccess<'de> for TaggedValueMapAccess<'de> {
         match self.value.take() {
             Some(value) => seed.deserialize(value),
             None => Err(serde::de::Error::custom("value is missing")),
-        }
-    }
-}
-
-/// MapAccess emitted on the [`TAGGED_VALUE_TYPE_NAME`] code path.
-///
-/// Surfaces a tagged scalar as a two-entry map with magic keys
-/// (`$__noyalib_tag` → tag string; `$__noyalib_value` → inner
-/// `Value`) so [`Value`]'s own visitor can pattern-match the
-/// shape and reconstruct `Value::Tagged(...)` on the
-/// data-binding return path. Distinct from the existing
-/// [`TaggedValueMapAccess`] (which uses the *real* tag as the
-/// map key for typed-enum deserialise) to avoid colliding with
-/// user data that legitimately has a key of the same name.
-pub(crate) struct TagPreservingMapAccess<'de> {
-    state: TagPreservingState<'de>,
-}
-
-#[derive(Clone, Copy)]
-enum TagPreservingState<'de> {
-    EmitTagKey { tag: &'de str, value: &'de Value },
-    EmitTagValue { tag: &'de str, value: &'de Value },
-    EmitValueKey { value: &'de Value },
-    EmitValueValue { value: &'de Value },
-    Done,
-}
-
-impl<'de> TagPreservingMapAccess<'de> {
-    pub(crate) fn new(tag: &'de str, value: &'de Value) -> Self {
-        Self {
-            state: TagPreservingState::EmitTagKey { tag, value },
-        }
-    }
-}
-
-impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
-    type Error = crate::Error;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
-    where
-        K: serde::de::DeserializeSeed<'de>,
-    {
-        match self.state {
-            TagPreservingState::EmitTagKey { tag, value } => {
-                self.state = TagPreservingState::EmitTagValue { tag, value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
-                        TAGGED_VALUE_FIELD_TAG,
-                    ),
-                )
-                .map(Some)
-            }
-            TagPreservingState::EmitValueKey { value } => {
-                self.state = TagPreservingState::EmitValueValue { value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
-                        TAGGED_VALUE_FIELD_VALUE,
-                    ),
-                )
-                .map(Some)
-            }
-            TagPreservingState::Done => Ok(None),
-            // Calling next_key without consuming the previous value
-            // is a serde misuse — surface as a custom error rather
-            // than panicking.
-            TagPreservingState::EmitTagValue { .. } | TagPreservingState::EmitValueValue { .. } => {
-                Err(serde::de::Error::custom(
-                    "TagPreservingMapAccess: next_key called before next_value",
-                ))
-            }
-        }
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
-    where
-        V: serde::de::DeserializeSeed<'de>,
-    {
-        match self.state {
-            TagPreservingState::EmitTagValue { tag, value } => {
-                self.state = TagPreservingState::EmitValueKey { value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(tag),
-                )
-            }
-            TagPreservingState::EmitValueValue { value } => {
-                self.state = TagPreservingState::Done;
-                // Route through the preserve-tags-aware Deserializer
-                // so any nested `Value::Tagged` inside `value` also
-                // survives the round-trip — without this wrapping,
-                // a tagged scalar inside a tagged collection would
-                // collapse to the single-key `Mapping{"!tag": …}`
-                // shape that the standard `&'de Value` Deserializer
-                // produces for `Value::Tagged` (BUG: noyalib v0.0.1
-                // C4HZ regression — global tags inside a tagged
-                // sequence).
-                seed.deserialize(crate::de::Deserializer::with_options_preserving_tags(
-                    value, None, false,
-                ))
-            }
-            _ => Err(serde::de::Error::custom(
-                "TagPreservingMapAccess: next_value called out of order",
-            )),
         }
     }
 }

--- a/crates/noyalib/tests/cov_number_ord.rs
+++ b/crates/noyalib/tests/cov_number_ord.rs
@@ -36,7 +36,7 @@ fn number_ord_integer_vs_unsigned() {
 #[test]
 fn number_ord_unsigned_vs_float_and_nan() {
     let umax = Value::from(u64::MAX);
-    let flt = Value::from(3.14_f64);
+    let flt = Value::from(2.5_f64);
     let nan = Value::from(f64::NAN);
 
     // Unsigned vs Float and the symmetric Float vs Unsigned.
@@ -50,7 +50,7 @@ fn number_ord_unsigned_vs_float_and_nan() {
 #[test]
 fn number_ord_integer_vs_float() {
     let neg = Value::from(-5_i64);
-    let flt = Value::from(3.14_f64);
+    let flt = Value::from(2.5_f64);
     assert_eq!(neg.cmp(&flt), Ordering::Less);
     assert_eq!(flt.cmp(&neg), Ordering::Greater);
 }
@@ -58,10 +58,10 @@ fn number_ord_integer_vs_float() {
 #[test]
 fn number_ord_sort_mixed_types() {
     // A sort exercises many cross-type comparisons at once.
-    let mut xs = vec![
+    let mut xs = [
         Value::from(u64::MAX),
         Value::from(-5_i64),
-        Value::from(3.14_f64),
+        Value::from(2.5_f64),
         Value::from(5_i64),
         Value::from(0_i64),
     ];

--- a/crates/noyalib/tests/cov_number_ord.rs
+++ b/crates/noyalib/tests/cov_number_ord.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Coverage: `Number::cmp` cross-type arms (Integer / Unsigned / Float),
+//! reachable because `Value::cmp` delegates to `Number::cmp` for two numeric
+//! values. The `Unsigned` arms are `#[cfg(feature = "lossless-u64")]`.
+//!
+//! NB: values are built with `Value::from(u64/i64/f64)` — `from_str` with the
+//! default config never yields `Number::Unsigned` (lossless-u64 is a config
+//! toggle, not just a feature), so it would not reach the `Unsigned` arms.
+
+#![cfg(feature = "lossless-u64")]
+#![allow(clippy::unwrap_used)]
+
+use std::cmp::Ordering;
+
+use noyalib::Value;
+
+#[test]
+fn number_ord_integer_vs_unsigned() {
+    let umax = Value::from(u64::MAX); // Number::Unsigned
+    let neg = Value::from(-5_i64); // Number::Integer(-5)
+    let pos = Value::from(5_i64); // Number::Integer(5)
+
+    // Integer vs Unsigned: a negative integer is always Less.
+    assert_eq!(neg.cmp(&umax), Ordering::Less);
+    // A non-negative integer widens to u64 and compares.
+    assert_eq!(pos.cmp(&umax), Ordering::Less);
+    // Unsigned vs Integer (the symmetric arm).
+    assert_eq!(umax.cmp(&neg), Ordering::Greater);
+    assert_eq!(umax.cmp(&pos), Ordering::Greater);
+    // Unsigned vs Unsigned.
+    assert_eq!(umax.cmp(&Value::from(u64::MAX)), Ordering::Equal);
+}
+
+#[test]
+fn number_ord_unsigned_vs_float_and_nan() {
+    let umax = Value::from(u64::MAX);
+    let flt = Value::from(3.14_f64);
+    let nan = Value::from(f64::NAN);
+
+    // Unsigned vs Float and the symmetric Float vs Unsigned.
+    assert_eq!(umax.cmp(&flt), Ordering::Greater);
+    assert_eq!(flt.cmp(&umax), Ordering::Less);
+    // NaN arms must not panic and must yield a total order.
+    let _ = umax.cmp(&nan);
+    let _ = nan.cmp(&umax);
+}
+
+#[test]
+fn number_ord_integer_vs_float() {
+    let neg = Value::from(-5_i64);
+    let flt = Value::from(3.14_f64);
+    assert_eq!(neg.cmp(&flt), Ordering::Less);
+    assert_eq!(flt.cmp(&neg), Ordering::Greater);
+}
+
+#[test]
+fn number_ord_sort_mixed_types() {
+    // A sort exercises many cross-type comparisons at once.
+    let mut xs = vec![
+        Value::from(u64::MAX),
+        Value::from(-5_i64),
+        Value::from(3.14_f64),
+        Value::from(5_i64),
+        Value::from(0_i64),
+    ];
+    xs.sort();
+    assert_eq!(xs.first(), Some(&Value::from(-5_i64)));
+    assert_eq!(xs.last(), Some(&Value::from(u64::MAX)));
+}


### PR DESCRIPTION
Coverage campaign, first verified batch into `feat/v0.0.15`. **TOTAL lines 93.11% → 94.74%** (all-features), the honest way.

**Chunk 1 — remove orphaned tag-preserving deserializer path (dead code).** The `preserve_tags` / `TagPreservingMapAccess` path had no external entry (v0.0.14 orphaned it when `from_str::<Value>` → AST loader and `from_value::<Value>` → clone). Removed ~110 dead lines across `de/deserializer.rs`, `value/tag.rs`, `serde_impl.rs`. `value/tag.rs` 78→99%. Tag round-trip verified intact via the live paths.

**Chunk 2 — cover `Number::cmp` cross-type Ord arms.** Integer↔Unsigned↔Float (negatives, NaN), built with `Value::from(u64/i64/f64)` (verified to produce the right variants; `from_str` default config never yields `Unsigned`). The `432-444`/`492-504` arms are confirmed covered.

Each chunk was verified against the coverage tool before landing (target lines confirmed dropped).

Remaining campaign (deep `streaming.rs`/`scanner.rs`/etc. paths) continues separately — see below.

Assisted-by: Claude Fable 5