### PR TITLE
fix(coverage): restore `make coverage-gap` under cargo-llvm-cov ≥ 0.8.7

### DIFF
--- a/scripts/coverage-gap-report.sh
+++ b/scripts/coverage-gap-report.sh
@@ -31,13 +31,30 @@ IFS=$'\n\t'
 
 THRESHOLD="${1:-98}"
 
+# Optional second arg: a regex of files to ignore. Defaults to empty
+# (measure everything). `cargo-llvm-cov` >= 0.8.7 rejects an empty
+# `--ignore-filename-regex`, so — mirroring
+# .github/workflows/shared-coverage.yml — we only pass the flag when
+# the value is non-empty. Passing '' unconditionally makes the tool
+# exit non-zero ("empty string is not allowed").
+IGNORE_REGEX="${2:-}"
+
+IGNORE_ARGS=()
+if [ -n "${IGNORE_REGEX}" ]; then
+    IGNORE_ARGS+=(--ignore-filename-regex "${IGNORE_REGEX}")
+fi
+
 echo "→ Running cargo +nightly llvm-cov (this takes ~2 min)..."
 
-# Capture summary table; tee for diagnostic visibility.
+# Capture the summary table from *stdout* only; build / doctest
+# progress goes to stderr, which we tee to a diagnostic log. Merging
+# the two (an earlier `2>&1`) polluted the table with `Compiling …`
+# and `test … ok` lines, which the awk row filter below then
+# miscounted as under-threshold files.
 SUMMARY="$(NOYALIB_COVERAGE=1 cargo +nightly llvm-cov \
     --workspace --all-features --no-fail-fast \
-    --ignore-filename-regex '' \
-    --summary-only 2>&1 | tee /tmp/noyalib-coverage.log)"
+    ${IGNORE_ARGS[@]+"${IGNORE_ARGS[@]}"} \
+    --summary-only 2> >(tee /tmp/noyalib-coverage.log >&2))"
 
 echo
 echo "→ Parsing rows below ${THRESHOLD} %..."
@@ -56,7 +73,10 @@ echo "$SUMMARY" | awk -v T="${THRESHOLD}" '
     /^-{10,}/        { next }
     /^Filename/      { next }
     /^TOTAL/         { next }
-    NF >= 12 {
+    # A real summary row has the coverage cells as `NN.NN%`. Requiring
+    # the percent-suffixed cells rejects any stray build/test line that
+    # happens to survive with >= 12 fields.
+    NF >= 12 && $4 ~ /%$/ && $7 ~ /%$/ && $10 ~ /%$/ {
         # Region cover (col 4) is index 4 after splitting on whitespace.
         # llvm-cov columns:
         #   1=file, 2=regs, 3=missed, 4=region%, 5=fns, 6=missed, 7=fn%,


### PR DESCRIPTION
## What

`make coverage-gap` currently errors out before producing any report:
`scripts/coverage-gap-report.sh` passes `--ignore-filename-regex ''`
unconditionally, and **cargo-llvm-cov 0.8.7** now rejects an empty value
(`error: empty string is not allowed in --ignore-filename-regex`).

## Fix

- Only pass `--ignore-filename-regex` when a non-empty regex is supplied
  (now an optional 2nd arg) — mirroring the guard already present in
  `.github/workflows/shared-coverage.yml`. Default behaviour (measure
  everything) is unchanged and matches the CI gate's measurement basis.
- Parse the llvm-cov summary from **stdout only**; tee build/doctest
  progress (stderr) to the diagnostic log. The old `2>&1 | tee` let
  `Compiling …` / `test … ok` lines through the `NF >= 12` row filter and
  inflated the punchlist (a bogus "180 files below 98%"). Also require the
  coverage cells to be percent-suffixed as a belt-and-suspenders row guard.
- Safe empty-array expansion (`${arr[@]+"${arr[@]}"}`) so `set -u` doesn't
  trip on macOS bash 3.2.

## Verification

- `bash -n` clean; `shellcheck` clean.
- `make coverage-gap` now completes and reports **44 files below 98%**
  (clean `src/` rows, no build/test noise), consistent with the live CI
  TOTAL (96.05% fn / 94.29% line / 93.13% region on `main`).
- **CI is unaffected** — its workflow already guarded the empty case;
  this was local-tooling drift only.

Assisted-by: Claude <noreply@anthropic.com>