### PR TITLE
test(de,include): close reachable coverage gaps in de.rs + include.rs

### DIFF
--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -864,3 +864,89 @@ where
     }
     T::deserialize(Deserializer::new(value))
 }
+
+// The figment integration entry `from_str_typed_no_tag_preserve` is
+// `pub(crate)`, reachable only from within this crate (figment's
+// `Format::from_str` calls it). These unit tests drive it directly so
+// both of its arms are exercised: the streaming fast-path
+// (`return res`) and the AST fallback taken when the streaming layer
+// defers (e.g. on a merge key). Integration tests can't reach a
+// `pub(crate)` fn, so this is the only home for the coverage.
+#[cfg(all(test, feature = "std", feature = "figment"))]
+mod figment_entry_tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Endpoint {
+        name: String,
+        port: u16,
+    }
+
+    #[test]
+    fn no_tag_preserve_takes_streaming_fast_path() {
+        // A plain mapping is handled entirely by the streaming layer,
+        // so `from_str_streaming` returns `Some(..)` and the function
+        // returns through the fast-path arm.
+        let cfg = ParserConfig::default();
+        let got: Endpoint = from_str_typed_no_tag_preserve("name: alpha\nport: 7\n", &cfg).unwrap();
+        assert_eq!(
+            got,
+            Endpoint {
+                name: "alpha".into(),
+                port: 7
+            }
+        );
+    }
+
+    #[test]
+    fn no_tag_preserve_falls_back_to_ast_on_merge_key() {
+        // A merge key makes the streaming layer defer, so
+        // `from_str_streaming` yields `None` and the function takes the
+        // AST loader + policy-walk fallback arm. The merged result must
+        // still deserialise identically.
+        let cfg = ParserConfig::default();
+        let yaml = "\
+_defaults: &d\n  name: beta\n  port: 9\n<<: *d\n";
+        let got: Endpoint = from_str_typed_no_tag_preserve(yaml, &cfg).unwrap();
+        assert_eq!(
+            got,
+            Endpoint {
+                name: "beta".into(),
+                port: 9
+            }
+        );
+    }
+
+    #[test]
+    fn no_tag_preserve_surfaces_parse_error() {
+        // Over-long input trips the document-length guard before either
+        // path — exercises the error return the figment provider maps
+        // into a `FigmentError`.
+        let cfg = ParserConfig::default().max_document_length(4);
+        let res: Result<Endpoint> = from_str_typed_no_tag_preserve("name: alpha\n", &cfg);
+        assert!(matches!(res, Err(Error::Parse(_))), "got {res:?}");
+    }
+
+    #[test]
+    fn no_tag_preserve_runs_value_policies() {
+        // A non-empty policy set makes the streaming path ineligible
+        // (it requires `policies.is_empty()`), forcing the AST branch
+        // and exercising the post-load policy walk
+        // (`for p in &config.policies { p.check_value(..)? }`) plus its
+        // error-propagation edge.
+        #[derive(Debug)]
+        struct RejectAll;
+        impl crate::policy::Policy for RejectAll {
+            fn check_value(&self, _v: &Value) -> Result<()> {
+                Err(Error::Deserialize("rejected by policy".into()))
+            }
+        }
+        let cfg = ParserConfig::default().with_policy(RejectAll);
+        let res: Result<Endpoint> = from_str_typed_no_tag_preserve("name: alpha\nport: 7\n", &cfg);
+        assert!(
+            matches!(res, Err(Error::Deserialize(_))),
+            "policy rejection must surface: {res:?}"
+        );
+    }
+}

--- a/crates/noyalib/tests/coverage_de_include.rs
+++ b/crates/noyalib/tests/coverage_de_include.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Coverage for `de.rs`'s `!include` recursion error edges and
+//! `include.rs`'s filesystem read-error path.
+//!
+//! These close gaps the existing `include_directive.rs` suite leaves
+//! open because its assertions only check `is_err()` without pinning
+//! the *variant* — e.g. `max_include_depth_caps_recursion` reuses the
+//! spec `"infinite"`, so it trips the **cycle** guard and never reaches
+//! the **depth** guard (`de.rs` line 607). Each test here asserts the
+//! specific failure so the intended region is actually exercised.
+
+#![cfg(feature = "include")]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use noyalib::include::{IncludeRequest, IncludeResolver, InputSource};
+use noyalib::{Error, ErrorKind, ParserConfig, Result, Value, from_str_with_config};
+
+/// A depth-blowup resolver that hands back a **distinct** spec on
+/// every call, so the per-walk `visited` cycle guard never fires and
+/// resolution can only be stopped by the depth cap. This is what makes
+/// the recursion reach `de.rs`'s `RecursionLimitExceeded` branch (607)
+/// rather than the cycle branch (620) the existing test hits.
+fn ever_deeper_resolver() -> IncludeResolver {
+    let counter = Arc::new(AtomicUsize::new(0));
+    IncludeResolver::new(move |_req: IncludeRequest<'_>| -> Result<InputSource> {
+        let n = counter.fetch_add(1, Ordering::Relaxed);
+        // Each level references a freshly-named child spec.
+        Ok(InputSource::new(
+            "gen",
+            format!("deeper: !include level_{}\n", n + 1),
+        ))
+    })
+}
+
+#[test]
+fn depth_cap_yields_recursion_limit_not_cycle() {
+    let cfg = ParserConfig::new()
+        .include_resolver(ever_deeper_resolver())
+        .max_include_depth(4);
+    let res: Result<Value> = from_str_with_config("root: !include level_0\n", &cfg);
+    let err = res.unwrap_err();
+    // The distinguishing assertion: this must be the *depth* guard,
+    // not the cycle guard. Cycle errors are `Error::Custom`
+    // (ErrorKind::Other); the depth guard is `RecursionLimitExceeded`
+    // (ErrorKind::Budget).
+    assert!(
+        matches!(err, Error::RecursionLimitExceeded { .. }),
+        "expected RecursionLimitExceeded, got {err:?}"
+    );
+    assert_eq!(err.kind(), ErrorKind::Budget);
+}
+
+#[test]
+fn error_propagates_through_non_include_tagged_wrapper() {
+    // A `!custom`-tagged node whose *inner* value contains an
+    // `!include` that fails. The walker takes the non-`!include`
+    // Tagged branch (`de.rs` line 672), recurses into the wrapped
+    // mapping, and the failing include's error must propagate back up
+    // through the `?` at line 682.
+    let resolver = IncludeResolver::new(|req: IncludeRequest<'_>| -> Result<InputSource> {
+        Err(Error::Custom(format!("boom for `{}`", req.spec)))
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let yaml = "wrapped: !custom\n  inner: !include child.yaml\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("boom for `child.yaml`"),
+        "inner include error must surface through the tagged wrapper: {err}"
+    );
+}
+
+#[test]
+fn error_propagates_through_sequence_element() {
+    // The OK sequence path is covered elsewhere; this pins the
+    // Err-propagation edge of the sequence arm (`de.rs` line 696):
+    // a sequence element that is a failing `!include`.
+    let resolver = IncludeResolver::new(|req: IncludeRequest<'_>| -> Result<InputSource> {
+        Err(Error::Custom(format!("seq boom for `{}`", req.spec)))
+    });
+    let cfg = ParserConfig::new().include_resolver(resolver);
+    let yaml = "items:\n  - ok\n  - !include broken.yaml\n";
+    let res: Result<Value> = from_str_with_config(yaml, &cfg);
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("seq boom for `broken.yaml`"),
+        "failing include inside a sequence must propagate: {err}"
+    );
+}
+
+/// The read-error path in `include.rs` (`SafeFileResolver`): a path
+/// that canonicalises successfully but cannot be read as a file —
+/// i.e. it is a **directory**. Exercises lines 289-294 (`fs::read_to_string`
+/// error closure), which the "missing file" tests never reach because
+/// canonicalisation fails first for a non-existent path.
+#[cfg(feature = "include_fs")]
+#[test]
+fn including_a_directory_surfaces_read_error() {
+    use noyalib::include::SafeFileResolver;
+
+    let root = std::env::temp_dir().join("noyalib-cov-de-include-dir");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    // `sub` is a directory *inside* root — canonicalises fine, but is
+    // not a readable file.
+    std::fs::create_dir_all(root.join("sub")).unwrap();
+
+    let cfg = ParserConfig::new().include_resolver(SafeFileResolver::new(&root).into_resolver());
+    let res: Result<Value> = from_str_with_config("x: !include sub\n", &cfg);
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("cannot read"),
+        "reading a directory must yield the resolver read-error: {err}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/noyalib/tests/tag_registry.rs
+++ b/crates/noyalib/tests/tag_registry.rs
@@ -218,3 +218,28 @@ fn value_target_registry_strips_collection_tag() {
     assert_eq!(v["a"].as_i64(), Some(1));
     assert_eq!(v["b"].as_i64(), Some(2));
 }
+
+// ── Borrowing entry honours the registry ─────────────────────────────
+
+#[test]
+fn borrowing_entry_attaches_tag_registry() {
+    // Every other registry test drives the *owning*
+    // `from_str_with_config`. This exercises the *borrowing* entry
+    // (`from_str_borrowing_with_config`), whose registry-attach branch
+    // (`de.rs` line 153) is otherwise never taken. A registered
+    // `!Celsius` must be stripped so the inner scalar deserialises into
+    // the newtype exactly as on the owning path.
+    let cfg = cfg(&["!Celsius"]);
+    let c: Celsius = noyalib::from_str_borrowing_with_config("!Celsius 42.5", &cfg).unwrap();
+    assert_eq!(c, Celsius(42.5));
+}
+
+#[test]
+fn borrowing_entry_without_registry_keeps_tag_opaque() {
+    // Control for the test above: with no registry installed the
+    // borrowing entry must *not* strip the tag, so the newtype visitor
+    // rejects the wrapped `{tag, value}` shape.
+    let res: Result<Celsius, Error> =
+        noyalib::from_str_borrowing_with_config("!Celsius 42.5", &ParserConfig::new());
+    assert!(res.is_err(), "unregistered tag must not strip: {res:?}");
+}


### PR DESCRIPTION
Coverage-campaign slice 1 — **worst-file-first**, effective-100% target
(cover every *reachable* region; document defensive/cfg exclusions).
Scoped to files **not** owned by the in-flight #172.

## Results (workspace `--all-features`)

| file | region | line | fn |
|---|---|---|---|
| `de.rs` | 81.28% → **90.59%** | 88.11% → **94.75%** | **100%** |
| `include.rs` | 89.22% → **94.12%** | 82.95% → **90.91%** | 92.86% |
| **TOTAL** | 93.13% → **93.29%** | 94.29% → **94.44%** | 96.05% → **96.12%** |

## What it closes

- **`de.rs` `!include` recursion edges (607/682/696).** The existing
  `include_directive.rs` only asserted `is_err()` without pinning the
  variant — its depth test reuses the spec `"infinite"`, so it trips the
  **cycle** guard (620) and never reaches the **depth** guard (607). The
  new `coverage_de_include.rs` uses a distinct-spec resolver and asserts
  `RecursionLimitExceeded` / `ErrorKind::Budget`, plus the Err-propagation
  edges through a non-`!include` tagged wrapper and a sequence element.
- **`de.rs` `from_str_typed_no_tag_preserve` (199–217).** The `pub(crate)`
  figment entry had its whole body uncovered (figment's provider doesn't
  reach it via a hitting path). A crate-internal unit module drives both
  arms directly: streaming fast-path, merge-key AST fallback, the policy
  walk, and the parse-error return.
- **`de.rs:153`** — tag-registry attach on the *borrowing* entry (every
  prior registry test used the owning entry).
- **`include.rs:289–294`** — `SafeFileResolver` read-error path, via
  including a directory (canonicalises, but is not a readable file).

## Effective-100% exclusions (documented, not tested)

- `include.rs:276–280` — the `symlink_metadata` error closure, reachable
  only if lstat fails *after* canonicalisation succeeded (a TOCTOU race).
- `include.rs:286` — `format!` macro-expansion region artifact.
- `de.rs` retains a long tail of partial-branch regions that later slices
  target toward the 98% region goal.

## Verification

- `cargo fmt --check` clean; `cargo clippy --all-features --tests` clean.
- New tests pass; `include_directive` / `figment_provider` / `tag_registry`
  unaffected. Coverage deltas above measured pre/post on this branch.

Assisted-by: Claude <noreply@anthropic.com>