### PR TITLE
refactor: derive serde fully qualified

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -39,9 +39,8 @@ Full per-channel install matrix lives in
 
 ```rust
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Config {
     name: String,
     port: u16,

--- a/README.md
+++ b/README.md
@@ -194,9 +194,8 @@ for rationale and migration notes.
 
 ```rust
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Config {
     name: String,
     port: u16,
@@ -589,9 +588,8 @@ fix-up engine that rewrites these to match the schema:
 
 ```rust
 use noyalib::{coerce_to_schema, from_str, schema_for, validate_against_schema, JsonSchema};
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 struct ServerConfig {
     /// Port the server binds on.
     port: u16,
@@ -668,9 +666,7 @@ gap when a config-key typo (e.g. `replicass: 3`) deserialises into
 a struct whose `replicas` field stays at its `Default`:
 
 ```rust
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Config {
     port: u16,
     host: String,
@@ -1096,12 +1092,10 @@ let yaml = to_string_multi(&[config1, config2])?;
 <summary><b>Enum serialization</b></summary>
 
 ```rust
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 enum Action { StartServer, StopServer }
 
-#[derive(Serialize, Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct Task {
     #[serde(with = "noyalib::with::singleton_map")]
     action: Action,

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -77,9 +77,8 @@ typo-detection helpers are absent. Re-enable individually with
 
 ```rust
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Config {
     host: String,
     port: u16,
@@ -233,9 +232,7 @@ let s: Server = from_str("host: api\nport: 8080\n")?;
 ### Strict deserialise (reject unknown keys)
 
 ```rust
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Cfg { port: u16, host: String }
 
 let yaml = "port: 8080\nhost: api\nporrt: 9090\n";   // typo

--- a/crates/noyalib/benches/architecture.rs
+++ b/crates/noyalib/benches/architecture.rs
@@ -14,7 +14,6 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use serde::Deserialize;
 use std::hint::black_box;
 
 // ── Test Payloads ────────────────────────────────────────────────────
@@ -113,14 +112,14 @@ fn billion_laughs(depth: usize) -> String {
 
 // ── Typed structs for streaming vs AST comparison ────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct K8sMetadata {
     name: String,
     namespace: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct K8sDeployment {
     #[serde(rename = "apiVersion")]
@@ -129,7 +128,7 @@ struct K8sDeployment {
     metadata: K8sMetadata,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct ZeroCopyConfig {
     host: String,
@@ -180,7 +179,7 @@ fn bench_streaming_vs_ast(c: &mut Criterion) {
 
 // ── Benchmark: Span Tracking Overhead ────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct SpannedConfig {
     host: noyalib::Spanned<String>,

--- a/crates/noyalib/benches/benchmarks.rs
+++ b/crates/noyalib/benches/benchmarks.rs
@@ -81,7 +81,6 @@ use noyalib::{
     validate_yaml_failsafe_schema,
     validate_yaml_json_schema,
 };
-use serde::{Deserialize, Serialize};
 use std::hint::black_box;
 
 // ============================================================================
@@ -203,14 +202,14 @@ fn generate_wide_sequence(count: usize) -> String {
 // Helper Types for Serde Benchmarks
 // ============================================================================
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct SimpleConfig {
     name: String,
     version: u64,
     enabled: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct SpannedConfig {
     #[allow(dead_code)]
     port: Spanned<u16>,
@@ -218,26 +217,26 @@ struct SpannedConfig {
     name: Spanned<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Action {
     Get(String),
     Set { key: String, value: String },
     Delete,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct SingletonAction {
     #[serde(with = "noyalib::with::singleton_map")]
     action: Action,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct RecursiveAction {
     #[serde(with = "noyalib::with::singleton_map_recursive")]
     action: Action,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct OptionalAction {
     #[serde(with = "noyalib::with::singleton_map_optional")]
     action: Option<Action>,

--- a/crates/noyalib/benches/comparison.rs
+++ b/crates/noyalib/benches/comparison.rs
@@ -8,7 +8,7 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::hint::black_box;
 
 // ── Test Data ────────────────────────────────────────────────────────
@@ -47,34 +47,34 @@ const LARGE_LIST: &str = include_str!("fixtures/large_list.yaml");
 const K8S_DEPLOYMENT: &str = include_str!("fixtures/k8s_deployment.yaml");
 const GITHUB_ACTIONS: &str = include_str!("fixtures/github_actions.yaml");
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Simple {
     name: String,
     version: u32,
     enabled: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Nested {
     server: Server,
     database: Database,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Server {
     host: String,
     port: u16,
     ssl: Ssl,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Ssl {
     enabled: bool,
     cert: String,
     key: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Database {
     host: String,
     port: u16,

--- a/crates/noyalib/benches/large_doc_soak.rs
+++ b/crates/noyalib/benches/large_doc_soak.rs
@@ -55,13 +55,13 @@ fn synthetic_yaml(target_bytes: usize) -> String {
     s
 }
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 #[allow(dead_code)]
 struct Doc {
     services: Vec<Record>,
 }
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 #[allow(dead_code)]
 struct Record {
     name: String,

--- a/crates/noyalib/benches/parallel.rs
+++ b/crates/noyalib/benches/parallel.rs
@@ -15,10 +15,9 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use serde::Deserialize;
 use std::hint::black_box;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Record {
     id: u32,

--- a/crates/noyalib/benches/streaming_vs_value.rs
+++ b/crates/noyalib/benches/streaming_vs_value.rs
@@ -28,7 +28,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::hint::black_box;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Doc {
     name: String,
@@ -36,7 +36,7 @@ struct Doc {
     items: Vec<Item>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Item {
     id: u32,

--- a/crates/noyalib/benches/validation_overhead.rs
+++ b/crates/noyalib/benches/validation_overhead.rs
@@ -9,10 +9,9 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use noyalib::{Spanned, from_str};
-use serde::Deserialize;
 use std::hint::black_box;
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 #[allow(dead_code)]
 struct ErrorHeavy {
     items: Vec<Spanned<u8>>,

--- a/crates/noyalib/examples/alias.rs
+++ b/crates/noyalib/examples/alias.rs
@@ -11,7 +11,6 @@ mod support;
 use std::collections::BTreeMap;
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 fn main() {
     support::header("noyalib -- alias");
@@ -61,7 +60,7 @@ server2:
     });
 
     // Typed deserialization
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct ServerConfig {
         host: String,

--- a/crates/noyalib/examples/anchor_shared.rs
+++ b/crates/noyalib/examples/anchor_shared.rs
@@ -13,7 +13,6 @@
 mod support;
 
 use noyalib::{ArcAnchor, RcAnchor, to_string, to_string_tracking_shared};
-use serde::Serialize;
 
 fn main() {
     support::header("noyalib -- anchor_shared (automatic Rc/Arc anchor emission)");
@@ -54,12 +53,12 @@ fn main() {
 
     // ── Struct with shared mapping leaf ──────────────────────────────
     support::task_with_output("Struct field sharing a mapping inner", || {
-        #[derive(Clone, Serialize)]
+        #[derive(Clone, serde::Serialize)]
         struct Endpoint {
             host: String,
             port: u16,
         }
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Topology {
             primary: RcAnchor<Endpoint>,
             replica: RcAnchor<Endpoint>,

--- a/crates/noyalib/examples/bridge.rs
+++ b/crates/noyalib/examples/bridge.rs
@@ -70,9 +70,7 @@ fn main() {
 
     // ── Shared struct between both formats ───────────────────────────
     support::task_with_output("Shared struct: serialize to both formats", || {
-        use serde::{Deserialize, Serialize};
-
-        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
         struct Config {
             name: String,
             port: u16,

--- a/crates/noyalib/examples/comments.rs
+++ b/crates/noyalib/examples/comments.rs
@@ -18,7 +18,6 @@ mod support;
 
 use noyalib::fmt::Commented;
 use noyalib::{Value, from_str, to_string};
-use serde::Serialize;
 
 fn main() {
     support::header("noyalib -- comments");
@@ -50,7 +49,7 @@ pool_size: 10    # max connections
 
     // ── Commented<T>: attach comments during serialization ───────────
     support::task_with_output("Commented<T>: attach inline comments", || {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Config {
             host: Commented<String>,
             port: Commented<u16>,
@@ -73,7 +72,7 @@ pool_size: 10    # max connections
         let v: Value = from_str(yaml).unwrap();
 
         // Wrap values with Commented<T> for serialization
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Annotated {
             host: Commented<String>,
             port: Commented<i64>,

--- a/crates/noyalib/examples/deep.rs
+++ b/crates/noyalib/examples/deep.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Address {
     street: String,
     city: String,
@@ -19,13 +18,13 @@ struct Address {
     zip: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Contact {
     email: String,
     phone: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Employee {
     id: u32,
     name: String,
@@ -36,7 +35,7 @@ struct Employee {
     active: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Company {
     name: String,
     founded: u32,

--- a/crates/noyalib/examples/diagnostic_path.rs
+++ b/crates/noyalib/examples/diagnostic_path.rs
@@ -21,16 +21,15 @@
 mod support;
 
 use noyalib::{Deserializer, Value, from_str};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct App {
     name: String,
     server: Server,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Server {
     host: String,
@@ -40,14 +39,14 @@ struct Server {
     replicas: Vec<Replica>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Database {
     url: String,
     pool_size: u16,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Replica {
     region: String,

--- a/crates/noyalib/examples/errors.rs
+++ b/crates/noyalib/examples/errors.rs
@@ -9,7 +9,6 @@
 mod support;
 
 use noyalib::{Error, Location, Value, from_str};
-use serde::Deserialize;
 
 fn main() {
     support::header("noyalib -- errors");
@@ -31,7 +30,7 @@ fn main() {
 
     // ── Type mismatch ────────────────────────────────────────────────
     support::task_with_output("Catch type mismatch (expected failure)", || {
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         #[allow(dead_code)]
         struct Typed {
             name: i32,
@@ -44,7 +43,7 @@ fn main() {
 
     // ── Missing field ────────────────────────────────────────────────
     support::task_with_output("Catch missing field (expected failure)", || {
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         #[allow(dead_code)]
         struct Required {
             name: String,

--- a/crates/noyalib/examples/figment.rs
+++ b/crates/noyalib/examples/figment.rs
@@ -20,9 +20,8 @@ mod support;
 use figment::Figment;
 use figment::providers::{Env, Format, Serialized};
 use noyalib::figment::Yaml;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct AppConfig {
     name: String,
     port: u16,
@@ -101,7 +100,7 @@ fn main() {
         // the example still demonstrates Env wiring in real
         // pipelines; the synthetic overlay below stands in for the
         // OS env that those pipelines would carry.
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct EnvOverlay {
             port: u16,
             workers: u16,

--- a/crates/noyalib/examples/flatten.rs
+++ b/crates/noyalib/examples/flatten.rs
@@ -9,17 +9,16 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── Flatten: merge nested struct fields into parent ──────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Metadata {
     created_by: String,
     version: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Document {
     title: String,
     #[serde(flatten)]
@@ -28,14 +27,14 @@ struct Document {
 
 // ── Untagged enum: infer variant from structure ──────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum Endpoint {
     Simple(String),
     Detailed { url: String, timeout: u32 },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Service {
     name: String,
     endpoints: Vec<Endpoint>,
@@ -43,7 +42,7 @@ struct Service {
 
 // ── Internally tagged enum ───────────────────────────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(tag = "type")]
 enum Resource {
     #[serde(rename = "database")]

--- a/crates/noyalib/examples/flattened.rs
+++ b/crates/noyalib/examples/flattened.rs
@@ -21,16 +21,15 @@
 mod support;
 
 use noyalib::{Flattened, Value, from_str};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct ServerConfig {
     host: String,
     port: u16,
     tls: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Envelope {
     name: String,
     // Capture both the typed `ServerConfig` view AND the raw

--- a/crates/noyalib/examples/global.rs
+++ b/crates/noyalib/examples/global.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{SerializerConfig, Value, to_string, to_string_with_config};
-use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 struct ServerConfig {
     host: String,
     port: u16,

--- a/crates/noyalib/examples/hello.rs
+++ b/crates/noyalib/examples/hello.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Person {
     name: String,
     age: u32,

--- a/crates/noyalib/examples/lossless_u64.rs
+++ b/crates/noyalib/examples/lossless_u64.rs
@@ -12,9 +12,8 @@ use noyalib::{
     Number, ParserConfig, SerializerConfig, Value, from_str_with_config,
     to_string_value_with_config,
 };
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Record {
     id: u64,
 }

--- a/crates/noyalib/examples/mask.rs
+++ b/crates/noyalib/examples/mask.rs
@@ -12,11 +12,10 @@
 mod support;
 
 use noyalib::{Value, from_str, to_string};
-use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// A value that serializes normally but redacts in Display/Debug.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 struct Secret<T>(T);
 
@@ -32,7 +31,7 @@ impl<T> fmt::Display for Secret<T> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct DatabaseConfig {
     host: String,
     port: u16,

--- a/crates/noyalib/examples/modify.rs
+++ b/crates/noyalib/examples/modify.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{Mapping, MappingAny, Value, from_str, from_value, to_value};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Server {
     host: String,
     port: u16,

--- a/crates/noyalib/examples/parallel.rs
+++ b/crates/noyalib/examples/parallel.rs
@@ -17,10 +17,9 @@
 //! ```
 
 use noyalib::Value;
-use serde::Deserialize;
 use std::time::Instant;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Event {
     id: u32,

--- a/crates/noyalib/examples/preserve.rs
+++ b/crates/noyalib/examples/preserve.rs
@@ -14,14 +14,13 @@ mod support;
 
 use noyalib::fmt::{Commented, FlowMap, FlowSeq, LitString, SpaceAfter};
 use noyalib::{Value, from_str, to_string};
-use serde::Serialize;
 
 fn main() {
     support::header("noyalib -- preserve");
 
     // ── Current: Commented<T> for write-only comments ────────────────
     support::task_with_output("Commented<T>: attach comments during serialization", || {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Config {
             host: Commented<String>,
             port: Commented<u16>,
@@ -40,7 +39,7 @@ fn main() {
 
     // ── Current: SpaceAfter<T> for section spacing ───────────────────
     support::task_with_output("SpaceAfter<T>: blank lines between sections", || {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Doc {
             header: SpaceAfter<String>,
             body: String,
@@ -57,7 +56,7 @@ fn main() {
 
     // ── Current: FlowSeq/FlowMap for inline style preservation ───────
     support::task_with_output("FlowSeq/FlowMap: preserve inline style intent", || {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct Manifest {
             tags: FlowSeq<Vec<String>>,
             metadata: FlowMap<std::collections::BTreeMap<String, String>>,

--- a/crates/noyalib/examples/read_iterator.rs
+++ b/crates/noyalib/examples/read_iterator.rs
@@ -16,10 +16,9 @@
 mod support;
 
 use noyalib::read;
-use serde::Deserialize;
 use std::io::Cursor;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Doc {
     id: u32,
     name: String,

--- a/crates/noyalib/examples/recursive.rs
+++ b/crates/noyalib/examples/recursive.rs
@@ -12,11 +12,10 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── File system tree ─────────────────────────────────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum FsEntry {
     File {
@@ -31,7 +30,7 @@ enum FsEntry {
 
 // ── Org chart ────────────────────────────────────────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Person {
     name: String,
     title: String,
@@ -41,7 +40,7 @@ struct Person {
 
 // ── Generic tree (Box<T> recursion) ──────────────────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct TreeNode {
     label: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/noyalib/examples/rename.rs
+++ b/crates/noyalib/examples/rename.rs
@@ -9,7 +9,6 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── Snake case ──────────────────────────────────────────────────────────
 
@@ -34,7 +33,7 @@ mod snake_case_keys {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum HttpMethod {
     GetRequest,
     PostData,
@@ -42,7 +41,7 @@ enum HttpMethod {
     DeleteItem,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct ApiEndpoint {
     path: String,
     #[serde(with = "snake_case_keys")]
@@ -72,7 +71,7 @@ mod kebab_case_keys {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum LogLevel {
     TraceVerbose,
     DebugInfo,
@@ -81,7 +80,7 @@ enum LogLevel {
     ErrorCritical,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct LogConfig {
     name: String,
     #[serde(with = "kebab_case_keys")]
@@ -111,7 +110,7 @@ mod lowercase_keys {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
 enum Environment {
     DEVELOPMENT,
@@ -119,7 +118,7 @@ enum Environment {
     PRODUCTION,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct DeployConfig {
     app_name: String,
     #[serde(with = "lowercase_keys")]
@@ -128,18 +127,18 @@ struct DeployConfig {
 
 // ── Comparison: default vs singleton_map vs singleton_map_with ────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Status {
     Active,
     Inactive,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct DefaultStyle {
     status: Status,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct SingletonStyle {
     #[serde(with = "noyalib::with::singleton_map")]
     status: Status,

--- a/crates/noyalib/examples/replay.rs
+++ b/crates/noyalib/examples/replay.rs
@@ -14,7 +14,6 @@ mod support;
 use std::collections::BTreeMap;
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 fn main() {
     support::header("noyalib -- replay (anchor event replay)");
@@ -22,7 +21,7 @@ fn main() {
     // ── Simple scalar anchors and aliases ────────────────────────────
     support::task_with_output("Scalar anchor and alias (string)", || {
         let yaml = "name: &who Alice\ngreeting: *who\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             name: String,
             greeting: String,
@@ -55,12 +54,12 @@ defaults: &cfg
   port: 8080
 staging: *cfg
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Endpoint {
             host: String,
             port: u16,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             defaults: Endpoint,
             staging: Endpoint,
@@ -87,7 +86,7 @@ copies:
   - *second
   - *first
 "#;
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             items: Vec<String>,
             copies: Vec<String>,
@@ -103,12 +102,12 @@ copies:
     // ── Multiple aliases to the same anchor ──────────────────────────
     support::task_with_output("Multiple aliases to the same anchor", || {
         let yaml = "origin: &pt\n  x: 0\n  y: 0\na: *pt\nb: *pt\nc: *pt\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Point {
             x: i32,
             y: i32,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             origin: Point,
             a: Point,
@@ -132,13 +131,13 @@ database: &db
 read_replica: *db
 analytics_replica: *db
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct DbConfig {
             host: String,
             port: u16,
             name: String,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Topology {
             database: DbConfig,
             read_replica: DbConfig,

--- a/crates/noyalib/examples/robotics_polymorphism.rs
+++ b/crates/noyalib/examples/robotics_polymorphism.rs
@@ -27,9 +27,8 @@
 mod support;
 
 use noyalib::robotics::{Degrees, Radians, StrictFloat};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 #[allow(dead_code)]
 enum Step {
@@ -53,7 +52,7 @@ enum Step {
     },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct Mission {
     fleet: String,

--- a/crates/noyalib/examples/schema_validation.rs
+++ b/crates/noyalib/examples/schema_validation.rs
@@ -26,9 +26,8 @@
 mod support;
 
 use noyalib::{JsonSchema, Value, coerce_to_schema, from_str, schema_for, validate_against_schema};
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct ServerConfig {
     /// Port the server binds on.

--- a/crates/noyalib/examples/scientific.rs
+++ b/crates/noyalib/examples/scientific.rs
@@ -28,7 +28,6 @@ fn main() {
 #[cfg(feature = "robotics")]
 fn run_robotics_examples() {
     use noyalib::robotics::{Degrees, Radians, StrictFloat};
-    use serde::Deserialize;
 
     // ── StrictFloat: valid values ────────────────────────────────────
     support::task_with_output("StrictFloat: valid values", || {
@@ -101,7 +100,7 @@ joint4: 0.0
 joint5: 270.0
 joint6: 135.0
 "#;
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct RobotArm {
             joint1: Radians,
             joint2: Radians,
@@ -145,7 +144,7 @@ offset_x: 0.001
 offset_y: -0.002
 scale: 1.00015
 "#;
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Calibration {
             offset_x: StrictFloat,
             offset_y: StrictFloat,

--- a/crates/noyalib/examples/source.rs
+++ b/crates/noyalib/examples/source.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{Spanned, from_str};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Config {
     host: Spanned<String>,
     port: Spanned<u16>,

--- a/crates/noyalib/examples/std.rs
+++ b/crates/noyalib/examples/std.rs
@@ -11,7 +11,6 @@ mod support;
 use std::collections::HashMap;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 fn main() {
     support::header("noyalib -- std");
@@ -42,7 +41,7 @@ fn main() {
     });
 
     support::task_with_output("Serialize and roundtrip nested collections", || {
-        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
         struct Config {
             name: String,
             tags: Vec<String>,

--- a/crates/noyalib/examples/stream.rs
+++ b/crates/noyalib/examples/stream.rs
@@ -9,7 +9,6 @@
 mod support;
 
 use noyalib::{Value, load_all, load_all_as, try_load_all};
-use serde::Deserialize;
 
 /// Format a Value as a compact one-liner (no debug dump).
 fn compact(v: &Value) -> String {
@@ -67,7 +66,7 @@ fn main() {
 
     // ── load_all_as: typed structs ───────────────────────────────────
     support::task_with_output("load_all_as: typed deserialization", || {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Config {
             name: String,
             value: i32,

--- a/crates/noyalib/examples/style.rs
+++ b/crates/noyalib/examples/style.rs
@@ -12,9 +12,8 @@ use std::collections::BTreeMap;
 
 use noyalib::fmt::{Commented, FlowMap, FlowSeq, LitString, SpaceAfter};
 use noyalib::to_string;
-use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct Config {
     tags: FlowSeq<Vec<String>>,
     metadata: FlowMap<BTreeMap<String, String>>,

--- a/crates/noyalib/examples/tags.rs
+++ b/crates/noyalib/examples/tags.rs
@@ -9,9 +9,8 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Status {
     Pending,
     Active,
@@ -19,14 +18,14 @@ enum Status {
     Error(String),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Task {
     name: String,
     #[serde(with = "noyalib::with::singleton_map")]
     status: Status,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct OptionalTask {
     name: String,
     #[serde(
@@ -37,13 +36,13 @@ struct OptionalTask {
     status: Option<Status>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Action {
     Simple,
     WithData { value: i32 },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Workflow {
     name: String,
     #[serde(with = "noyalib::with::singleton_map_recursive")]

--- a/crates/noyalib/examples/tokio_async_reader.rs
+++ b/crates/noyalib/examples/tokio_async_reader.rs
@@ -12,11 +12,11 @@
 async fn main() {
     use bytes::BytesMut;
     use noyalib::tokio_async::{YamlDecoder, from_async_reader_multi};
-    use serde::Deserialize;
+
     use tokio::io::BufReader;
     use tokio_util::codec::Decoder;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Pkg {
         name: String,
         version: String,

--- a/crates/noyalib/examples/untagged.rs
+++ b/crates/noyalib/examples/untagged.rs
@@ -12,11 +12,10 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── K8s-style: infer resource type from fields ──────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum Resource {
     Service {
@@ -36,7 +35,7 @@ enum Resource {
 
 // ── CI/CD-style: step can be a string or a map ──────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum Step {
     Simple(String),
@@ -49,7 +48,7 @@ enum Step {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Pipeline {
     name: String,
     steps: Vec<Step>,
@@ -57,7 +56,7 @@ struct Pipeline {
 
 // ── Config value: string, number, or list ───────────────────────────
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum ConfigValue {
     Text(String),

--- a/crates/noyalib/examples/validated_miette.rs
+++ b/crates/noyalib/examples/validated_miette.rs
@@ -12,9 +12,8 @@ mod support;
 use garde::Validate;
 use noyalib::Spanned;
 use noyalib::validated_miette::garde_errors_to_miette;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 struct ServerCfg {
     #[garde(length(min = 1, max = 255))]
     host: String,

--- a/crates/noyalib/examples/validation.rs
+++ b/crates/noyalib/examples/validation.rs
@@ -29,12 +29,11 @@ fn main() {
 #[cfg(feature = "miette")]
 fn run_miette_examples() {
     use noyalib::Spanned;
-    use serde::Deserialize;
 
     // ── Parse YAML with Spanned<T> fields ────────────────────────────
     support::task_with_output("Parse YAML with Spanned<T> fields", || {
         let yaml = "name: myapp\nport: 8080\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Config {
             name: Spanned<String>,
             port: Spanned<u16>,
@@ -59,7 +58,7 @@ fn run_miette_examples() {
     // ── Validate fields and generate diagnostics ─────────────────────
     support::task_with_output("Validate: port must be >= 1024", || {
         let yaml = "port: 80\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Cfg {
             port: Spanned<u16>,
         }
@@ -84,7 +83,7 @@ fn run_miette_examples() {
     // ── Validate: name must not be empty ─────────────────────────────
     support::task_with_output("Validate: name must not be empty", || {
         let yaml = "name: \"\"\nport: 8080\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Cfg {
             name: Spanned<String>,
             #[allow(dead_code)]
@@ -103,7 +102,7 @@ fn run_miette_examples() {
     // ── Multiple validation errors collected ─────────────────────────
     support::task_with_output("Collect multiple validation errors", || {
         let yaml = "host: \"\"\nport: 80\nmax_connections: -5\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct ServerCfg {
             host: Spanned<String>,
             port: Spanned<u16>,
@@ -145,7 +144,7 @@ fn run_miette_examples() {
     // ── Show rendered diagnostic output ──────────────────────────────
     support::task_with_output("Rendered diagnostic with source highlighting", || {
         let yaml = "database:\n  host: db.local\n  port: 80\n  name: prod\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct DbCfg {
             #[allow(dead_code)]
             host: String,
@@ -153,7 +152,7 @@ fn run_miette_examples() {
             #[allow(dead_code)]
             name: String,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Root {
             database: DbCfg,
         }
@@ -180,7 +179,7 @@ fn run_miette_examples() {
         use miette::Diagnostic;
 
         let yaml = "value: 42\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             value: Spanned<i32>,
         }

--- a/crates/noyalib/examples/validation_garde.rs
+++ b/crates/noyalib/examples/validation_garde.rs
@@ -19,9 +19,8 @@ mod support;
 
 use garde::Validate;
 use noyalib::Validated;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 #[allow(dead_code)]
 struct ServerConfig {
     #[garde(length(min = 1, max = 253))]
@@ -37,7 +36,7 @@ struct ServerConfig {
     service_name: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 #[allow(dead_code)]
 struct DeployConfig {
     #[garde(length(min = 1, max = 32))]

--- a/crates/noyalib/examples/validation_validator.rs
+++ b/crates/noyalib/examples/validation_validator.rs
@@ -16,10 +16,9 @@
 mod support;
 
 use noyalib::ValidatedValidator;
-use serde::Deserialize;
 use validator::Validate;
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 #[allow(dead_code)]
 struct UserAccount {
     #[validate(email)]
@@ -35,7 +34,7 @@ struct UserAccount {
     website: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 #[allow(dead_code)]
 struct ApiKey {
     #[validate(length(equal = 40))]

--- a/crates/noyalib/examples/variants.rs
+++ b/crates/noyalib/examples/variants.rs
@@ -9,23 +9,22 @@
 mod support;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Shape {
     Rectangle { width: u32, height: u32 },
     Circle { radius: f64 },
     Triangle { base: u32, height: u32 },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Status {
     Active,
     Inactive,
     Pending,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Message {
     Text(String),
     Number(i32),

--- a/crates/noyalib/examples/wasm/Cargo.toml
+++ b/crates/noyalib/examples/wasm/Cargo.toml
@@ -18,9 +18,8 @@ serde-wasm-bindgen = "0.6"
 wasm-opt = false
 
 [package.metadata.cargo-machete]
-# `serde` here is consumed by the inline `#[derive(Serialize,
-# Deserialize)]` macros in the example source; cargo-machete's
-# AST scan misses the proc-macro reference.
+# `serde` here is consumed by the inline serde derive macros in the example source
+# cargo-machete's AST scan misses the proc-macro reference.
 ignored = ["serde"]
 
 [profile.release]

--- a/crates/noyalib/examples/zero_copy_borrow.rs
+++ b/crates/noyalib/examples/zero_copy_borrow.rs
@@ -18,16 +18,15 @@ mod support;
 
 use noyalib::borrowed::TransformReason;
 use noyalib::from_str_borrowing;
-use serde::Deserialize;
 use std::borrow::Cow;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Config<'a> {
     name: &'a str,
     role: &'a str,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct CowConfig<'a> {
     #[serde(borrow)]
     plain: Cow<'a, str>,

--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -403,9 +403,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         name: String,
         port: u16,

--- a/crates/noyalib/src/de.rs
+++ b/crates/noyalib/src/de.rs
@@ -101,9 +101,8 @@ where
 ///
 /// ```
 /// use noyalib::from_str_borrowing;
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Person<'a> {
 ///     name: &'a str,
 ///     role: &'a str,
@@ -236,9 +235,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }
@@ -300,9 +297,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }
@@ -336,9 +331,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     port: u16,
 /// }

--- a/crates/noyalib/src/diagnostic.rs
+++ b/crates/noyalib/src/diagnostic.rs
@@ -8,9 +8,8 @@
 //!
 //! ```
 //! use noyalib::{from_str, Spanned, diagnostic::spanned_error};
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize)]
+//! #[derive(serde::Deserialize)]
 //! struct Cfg { port: Spanned<u16> }
 //! let yaml = "port: 80\n";
 //! let cfg: Cfg = from_str(yaml).unwrap();
@@ -72,9 +71,8 @@ impl miette::Diagnostic for SpannedDiagnostic {
 ///
 /// ```
 /// use noyalib::{from_str, Spanned, diagnostic::spanned_error};
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Cfg { port: Spanned<u16> }
 /// let yaml = "port: 80\n";
 /// let cfg: Cfg = from_str(yaml).unwrap();
@@ -108,8 +106,7 @@ pub fn spanned_error<T, M: fmt::Display>(
 ///
 /// ```rust,no_run
 /// # use noyalib::{from_str, Spanned, diagnostic::spanned_error_with_context};
-/// # use serde::Deserialize;
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Cfg {
 ///     anchor: Spanned<String>,
 ///     alias: Spanned<String>,

--- a/crates/noyalib/src/document.rs
+++ b/crates/noyalib/src/document.rs
@@ -205,9 +205,8 @@ pub fn try_load_all(input: &str) -> Result<DocumentIterator> {
 ///
 /// ```rust
 /// use noyalib::document::load_all_as;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, PartialEq)]
+/// #[derive(Debug, serde::Deserialize, PartialEq)]
 /// struct Doc {
 ///     name: String,
 /// }
@@ -366,9 +365,8 @@ impl<T> ExactSizeIterator for DocumentReadIterator<T> where
 ///
 /// ```
 /// use std::io::Cursor;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, PartialEq)]
+/// #[derive(Debug, serde::Deserialize, PartialEq)]
 /// struct Doc { id: u32 }
 ///
 /// let yaml = "id: 1\n---\nid: 2\n---\nid: 3\n";

--- a/crates/noyalib/src/figment.rs
+++ b/crates/noyalib/src/figment.rs
@@ -20,9 +20,8 @@
 //! use figment::providers::Format;
 //! use figment::Figment;
 //! use noyalib::figment::Yaml;
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize)]
+//! #[derive(serde::Deserialize)]
 //! struct Config {
 //!     name: String,
 //!     port: u16,

--- a/crates/noyalib/src/flattened.rs
+++ b/crates/noyalib/src/flattened.rs
@@ -41,14 +41,13 @@ use crate::value::Value;
 ///
 /// ```
 /// use noyalib::{from_str, Flattened, Value};
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Inner {
 ///     port: u16,
 /// }
 ///
-/// #[derive(Debug, Deserialize)]
+/// #[derive(Debug, serde::Deserialize)]
 /// struct Config {
 ///     name: String,
 ///     // Capture both the typed view and the raw mapping so the

--- a/crates/noyalib/src/fmt.rs
+++ b/crates/noyalib/src/fmt.rs
@@ -9,9 +9,8 @@
 //!
 //! ```rust
 //! use noyalib::fmt::{FlowSeq, LitString};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize)]
+//! #[derive(serde::Serialize, serde::Deserialize)]
 //! struct Config {
 //!     tags: FlowSeq<Vec<String>>,
 //!     script: LitString,
@@ -43,8 +42,7 @@ pub(crate) const MAGIC_ANCHOR_REF: &str = "__noya_anchor_ref";
 ///
 /// ```
 /// use noyalib::{to_string, FlowSeq};
-/// use serde::Serialize;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { v: FlowSeq<Vec<i32>> }
 /// let yaml = to_string(&Doc { v: FlowSeq(vec![1, 2]) }).unwrap();
 /// assert!(yaml.contains("["));
@@ -110,9 +108,8 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for FlowSeq<T> {
 ///
 /// ```
 /// use noyalib::{to_string, FlowMap};
-/// use serde::Serialize;
 /// use std::collections::BTreeMap;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { m: FlowMap<BTreeMap<String, i32>> }
 /// let mut m = BTreeMap::new();
 /// let _ = m.insert("a".into(), 1);
@@ -462,8 +459,7 @@ impl<'de> Deserialize<'de> for FoldString {
 ///
 /// ```
 /// use noyalib::{to_string, Commented};
-/// use serde::Serialize;
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Doc { v: Commented<i32> }
 /// let yaml = to_string(&Doc { v: Commented::new(42, "meaning") }).unwrap();
 /// assert!(yaml.contains("# meaning"));

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -31,9 +31,8 @@
 //!
 //! ```rust
 //! use noyalib::{from_str, to_string};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Config {
 //!     name: String,
 //!     port: u16,

--- a/crates/noyalib/src/parallel.rs
+++ b/crates/noyalib/src/parallel.rs
@@ -192,7 +192,6 @@ pub fn split(input: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
 
     #[test]
     fn split_separates_three_records() {
@@ -250,7 +249,7 @@ mod tests {
 
     #[test]
     fn parse_round_trips_typed_records() {
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Record {
             id: u32,
         }
@@ -273,7 +272,7 @@ mod tests {
 
     #[test]
     fn parse_propagates_first_error() {
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         #[allow(dead_code)]
         struct Record {
             id: u32,
@@ -294,7 +293,7 @@ mod tests {
             yaml.push_str(&format!("---\nid: {i}\nname: record-{i}\n"));
         }
 
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Record {
             id: u32,
             name: String,

--- a/crates/noyalib/src/robotics.rs
+++ b/crates/noyalib/src/robotics.rs
@@ -18,7 +18,7 @@
 
 use core::fmt;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// A float that rejects values outside f64's precise representation range.
 ///
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 /// let result: Result<StrictFloat, _> = noyalib::from_str(".inf");
 /// assert!(result.is_err());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(transparent)]
 pub struct StrictFloat(f64);
 
@@ -119,7 +119,7 @@ impl StrictFloat {
 /// let r: Radians = noyalib::from_str("180.0").unwrap();
 /// assert!((r.0 - std::f64::consts::PI).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
 #[serde(transparent)]
 pub struct Radians(pub f64);
 
@@ -146,7 +146,7 @@ impl<'de> Deserialize<'de> for Radians {
 /// let d: Degrees = noyalib::from_str("90.0").unwrap();
 /// assert!((d.0 - 90.0).abs() < 1e-10);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Degrees(pub f64);
 

--- a/crates/noyalib/src/schema_codegen.rs
+++ b/crates/noyalib/src/schema_codegen.rs
@@ -24,9 +24,8 @@
 //!
 //! ```
 //! use noyalib::{schema_for, schema_for_yaml, JsonSchema};
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, JsonSchema)]
+//! #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 //! struct ServerConfig {
 //!     /// Port the server binds on.
 //!     port: u16,
@@ -168,9 +167,8 @@ pub fn schema_for_yaml<T: JsonSchema>() -> Result<String> {
 ///
 /// ```
 /// use noyalib::{schema_for, JsonSchema, Value};
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Serialize, Deserialize, JsonSchema)]
+/// #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 /// struct Envelope {
 ///     id: String,
 ///     payload: Value,
@@ -223,9 +221,8 @@ impl JsonSchema for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Cfg {
         port: u16,
@@ -264,7 +261,7 @@ mod tests {
         assert_eq!(port["maximum"].as_i64(), Some(65_535));
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct WithDoc {
         /// Bound TCP port.
@@ -278,7 +275,7 @@ mod tests {
         assert_eq!(desc, Some("Bound TCP port."));
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct WithDefault {
         port: u16,
@@ -301,7 +298,7 @@ mod tests {
         );
     }
 
-    #[derive(Serialize, Deserialize, JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Renamed {
         #[serde(rename = "bind_port")]

--- a/crates/noyalib/src/schema_validate.rs
+++ b/crates/noyalib/src/schema_validate.rs
@@ -418,9 +418,8 @@ properties:
     fn schema_for_codegen_round_trip_validates_self() {
         // Phase 3.1 + 3.2 together — derive JsonSchema, emit, then
         // validate sample data against the emitted schema.
-        use serde::{Deserialize, Serialize};
 
-        #[derive(Serialize, Deserialize, crate::JsonSchema)]
+        #[derive(serde::Serialize, serde::Deserialize, crate::JsonSchema)]
         #[allow(dead_code)]
         struct Cfg {
             port: u16,

--- a/crates/noyalib/src/ser.rs
+++ b/crates/noyalib/src/ser.rs
@@ -259,9 +259,7 @@ impl SerializerConfig {
 /// # Examples
 ///
 /// ```rust
-/// use serde::Serialize;
-///
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Config {
 ///     name: String,
 ///     port: u16,
@@ -298,9 +296,8 @@ where
 ///
 /// ```rust
 /// use noyalib::SerializerConfig;
-/// use serde::Serialize;
 ///
-/// #[derive(Serialize)]
+/// #[derive(serde::Serialize)]
 /// struct Config {
 ///     name: String,
 ///     port: u16,

--- a/crates/noyalib/src/spanned.rs
+++ b/crates/noyalib/src/spanned.rs
@@ -47,9 +47,8 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 ///
 /// ```rust
 /// use noyalib::Spanned;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Serialize, Deserialize, Debug)]
+/// #[derive(serde::Serialize, serde::Deserialize, Debug)]
 /// struct Config {
 ///     port: Spanned<u16>,
 /// }
@@ -71,7 +70,7 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 ///
 /// ```rust,ignore
 /// // Works.
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Config {
 ///     name: String,
 ///     #[serde(flatten)]
@@ -79,7 +78,7 @@ pub(crate) const SPANNED_FIELDS: &[&str] = &[
 /// }
 ///
 /// // Errors with a clear message at deserialize time.
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct AlsoConfig {
 ///     name: String,
 ///     #[serde(flatten)]

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -61,7 +61,7 @@ pub(crate) enum Scalar<'a> {
 /// use noyalib::StreamingDeserializer;
 /// use serde::Deserialize;
 ///
-/// #[derive(Deserialize)]
+/// #[derive(serde::Deserialize)]
 /// struct Doc { k: i32 }
 ///
 /// let mut de = StreamingDeserializer::new("k: 42\n");
@@ -149,7 +149,7 @@ impl<'a> StreamingDeserializer<'a> {
     /// use serde::Deserialize;
     /// use std::sync::Arc;
     ///
-    /// #[derive(Deserialize)]
+    /// #[derive(serde::Deserialize)]
     /// struct Temp(f64);
     ///
     /// let reg = Arc::new(TagRegistry::new().with("!Celsius"));

--- a/crates/noyalib/src/tag_registry.rs
+++ b/crates/noyalib/src/tag_registry.rs
@@ -19,10 +19,9 @@
 //!
 //! ```
 //! use noyalib::{from_str_with_config, ParserConfig, TagRegistry};
-//! use serde::Deserialize;
 //! use std::sync::Arc;
 //!
-//! #[derive(Debug, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Deserialize, PartialEq)]
 //! struct Celsius(f64);
 //!
 //! let registry = Arc::new(TagRegistry::new().with("!Celsius"));

--- a/crates/noyalib/src/tokio_async.rs
+++ b/crates/noyalib/src/tokio_async.rs
@@ -357,10 +357,10 @@ fn find_doc_boundary(bytes: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
     use bytes::BytesMut;
-    use serde::Deserialize;
+
     use tokio::io::BufReader;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Pkg {
         name: String,
         version: String,

--- a/crates/noyalib/src/validated.rs
+++ b/crates/noyalib/src/validated.rs
@@ -12,9 +12,8 @@
 //! ```rust
 //! use noyalib::Validated;
 //! use garde::Validate;
-//! use serde::Deserialize;
 //!
-//! #[derive(Deserialize, Validate)]
+//! #[derive(serde::Deserialize, Validate)]
 //! struct Server {
 //!     #[garde(length(min = 1, max = 255))]
 //!     host: String,
@@ -40,9 +39,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// ```
 /// use noyalib::Validated;
 /// use garde::Validate;
-/// use serde::Deserialize;
 ///
-/// #[derive(Deserialize, Validate)]
+/// #[derive(serde::Deserialize, Validate)]
 /// struct Port {
 ///     #[garde(range(min = 1024))]
 ///     n: u16,
@@ -62,10 +60,9 @@ pub struct Validated<T>(pub T);
 ///
 /// ```
 /// use noyalib::ValidatedValidator;
-/// use serde::Deserialize;
 /// use validator::Validate;
 ///
-/// #[derive(Deserialize, Validate)]
+/// #[derive(serde::Deserialize, Validate)]
 /// struct Port {
 ///     #[validate(range(min = 1024))]
 ///     n: u16,

--- a/crates/noyalib/src/validated_miette.rs
+++ b/crates/noyalib/src/validated_miette.rs
@@ -120,9 +120,8 @@ impl miette::Diagnostic for ValidationDiagnostic {
 /// use noyalib::Spanned;
 /// use noyalib::validated_miette::garde_errors_to_miette;
 /// use garde::Validate;
-/// use serde::Deserialize;
 ///
-/// #[derive(Debug, Deserialize, Validate)]
+/// #[derive(Debug, serde::Deserialize, Validate)]
 /// struct Cfg {
 ///     #[garde(range(min = 1024))]
 ///     port: u16,
@@ -160,10 +159,9 @@ pub fn garde_errors_to_miette<T>(
 /// ```ignore
 /// use noyalib::Spanned;
 /// use noyalib::validated_miette::validator_errors_to_miette;
-/// use serde::Deserialize;
 /// use validator::Validate;
 ///
-/// #[derive(Debug, Deserialize, Validate)]
+/// #[derive(Debug, serde::Deserialize, Validate)]
 /// struct Cfg {
 ///     #[validate(range(min = 1024))]
 ///     port: u16,

--- a/crates/noyalib/src/with/mod.rs
+++ b/crates/noyalib/src/with/mod.rs
@@ -12,15 +12,14 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Action {
 //!     Start { delay: u32 },
 //!     Stop,
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(with = "singleton_map")]

--- a/crates/noyalib/src/with/singleton_map.rs
+++ b/crates/noyalib/src/with/singleton_map.rs
@@ -8,16 +8,15 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Status {
 //!     Active,
 //!     Pending { reason: String },
 //!     Error { code: i32, message: String },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(with = "singleton_map")]
@@ -54,15 +53,14 @@ use serde::{Deserializer, Serialize, Serializer};
 ///
 /// ```rust
 /// use noyalib::with::singleton_map;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Action {
 ///     Start,
 ///     Stop { graceful: bool },
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Command {
 ///     #[serde(with = "singleton_map")]
 ///     action: Action,
@@ -109,12 +107,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Status { Active }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map")]
 ///     s: Status,
@@ -136,16 +133,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum TestEnum {
         Unit,
         Newtype(i32),
         Struct { value: String },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(with = "crate::with::singleton_map")]
@@ -186,7 +182,7 @@ mod tests {
     #[test]
     fn test_singleton_map_fallback_sequence() {
         // Test the fallback path when value is a Sequence
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct SeqContainer {
             #[serde(with = "crate::with::singleton_map")]
             items: Vec<i32>,
@@ -205,7 +201,7 @@ mod tests {
     #[test]
     fn test_singleton_map_fallback_integer() {
         // Test the fallback path when value is a Number
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct NumContainer {
             #[serde(with = "crate::with::singleton_map")]
             value: i32,

--- a/crates/noyalib/src/with/singleton_map_optional.rs
+++ b/crates/noyalib/src/with/singleton_map_optional.rs
@@ -8,15 +8,14 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_optional;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Status {
 //!     Active,
 //!     Pending { reason: String },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Task {
 //!     name: String,
 //!     #[serde(
@@ -54,15 +53,14 @@ use serde::{Deserializer, Serialize, Serializer};
 ///
 /// ```rust
 /// use noyalib::with::singleton_map_optional;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Action {
 ///     Start,
 ///     Stop,
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Command {
 ///     #[serde(
 ///         with = "singleton_map_optional",
@@ -118,12 +116,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map_optional;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Status { Active }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map_optional", default)]
 ///     s: Option<Status>,
@@ -152,15 +149,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum TestEnum {
         Unit,
         Struct { value: String },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(
@@ -220,7 +216,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_fallback() {
         // Test the fallback path when value is a Sequence
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct SeqContainer {
             #[serde(with = "crate::with::singleton_map_optional")]
             items: Option<Vec<i32>>,
@@ -237,7 +233,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_serialize_none() {
         // Test serializing None without skip_serializing_if
-        #[derive(Debug, Serialize)]
+        #[derive(Debug, serde::Serialize)]
         struct NoneContainer {
             name: String,
             #[serde(with = "crate::with::singleton_map_optional")]
@@ -257,7 +253,7 @@ mod tests {
     #[test]
     fn test_singleton_map_optional_deserialize_none() {
         // Test deserializing null as None
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct NoneContainer {
             name: String,
             #[serde(with = "crate::with::singleton_map_optional", default)]

--- a/crates/noyalib/src/with/singleton_map_recursive.rs
+++ b/crates/noyalib/src/with/singleton_map_recursive.rs
@@ -7,21 +7,20 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_recursive;
-//! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Inner {
 //!     A,
 //!     B { value: i32 },
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum Outer {
 //!     Single(Inner),
 //!     Multiple(Vec<Inner>),
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct Config {
 //!     #[serde(with = "singleton_map_recursive")]
 //!     items: Vec<Outer>,
@@ -67,15 +66,14 @@ fn transform_to_singleton_map(value: crate::Value) -> crate::Value {
 ///
 /// ```rust
 /// use noyalib::with::singleton_map_recursive;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// enum Status {
 ///     Active,
 ///     Pending,
 /// }
 ///
-/// #[derive(Debug, Serialize, Deserialize)]
+/// #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// struct Task {
 ///     #[serde(with = "singleton_map_recursive")]
 ///     statuses: Vec<Status>,
@@ -105,12 +103,11 @@ where
 ///
 /// ```
 /// use noyalib::with::singleton_map_recursive;
-/// use serde::{Deserialize, Serialize};
 ///
-/// #[derive(Deserialize, Serialize, PartialEq, Debug)]
+/// #[derive(serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 /// enum Inner { A }
 ///
-/// #[derive(Deserialize, Debug)]
+/// #[derive(serde::Deserialize, Debug)]
 /// struct Doc {
 ///     #[serde(with = "singleton_map_recursive")]
 ///     items: Vec<Inner>,
@@ -134,15 +131,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Inner {
         A,
         B { value: i32 },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         name: String,
         #[serde(with = "crate::with::singleton_map_recursive")]
@@ -161,7 +157,7 @@ mod tests {
         assert_eq!(parsed, container);
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Nested {
         #[serde(with = "crate::with::singleton_map_recursive")]
         data: std::collections::BTreeMap<String, Inner>,

--- a/crates/noyalib/src/with/singleton_map_with.rs
+++ b/crates/noyalib/src/with/singleton_map_with.rs
@@ -15,7 +15,6 @@
 //!
 //! ```rust
 //! use noyalib::with::singleton_map_with;
-//! use serde::{Deserialize, Serialize};
 //!
 //! // Define custom serialize/deserialize functions
 //! mod snake_case {
@@ -73,14 +72,14 @@
 //!     }
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! enum HttpMethod {
 //!     GetRequest,
 //!     PostData,
 //!     DeleteItem,
 //! }
 //!
-//! #[derive(Debug, Serialize, Deserialize, PartialEq)]
+//! #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 //! struct ApiCall {
 //!     #[serde(with = "snake_case")]
 //!     method: HttpMethod,
@@ -453,9 +452,7 @@ mod tests {
 
     #[test]
     fn test_serialize_with_directly() {
-        use serde::Serialize;
-
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         struct TestStruct {
             name: String,
         }

--- a/crates/noyalib/tests/alias_dual_label.rs
+++ b/crates/noyalib/tests/alias_dual_label.rs
@@ -8,7 +8,6 @@
 //! derived from the closest known anchor name.
 
 use noyalib::{Error, Value, from_str};
-use serde::Deserialize;
 
 // ── Loader path (AST deserialisation to `Value`) ─────────────────────────
 
@@ -88,7 +87,7 @@ fn loader_unknown_anchor_picks_closest_among_many() {
 
 #[test]
 fn streaming_unknown_anchor_with_similar_name_carries_suggestion() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         db: String,
@@ -115,7 +114,7 @@ fn streaming_unknown_anchor_with_similar_name_carries_suggestion() {
 
 #[test]
 fn streaming_unknown_anchor_without_similar_name() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         a: String,

--- a/crates/noyalib/tests/anchor_shared_ser.rs
+++ b/crates/noyalib/tests/anchor_shared_ser.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use noyalib::{ArcAnchor, RcAnchor, to_string, to_string_tracking_shared};
-use serde::{Deserialize, Serialize};
 
 // ── Basic emission ──────────────────────────────────────────────────────
 
@@ -84,7 +83,7 @@ fn tracking_opt_in_default_unchanged() {
 
 // ── Mapping / struct inner ──────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Endpoint {
     host: String,
     port: u16,
@@ -111,7 +110,7 @@ fn mapping_inner_anchor_is_valid_yaml() {
 
 #[test]
 fn nested_struct_with_shared_leaf() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Root {
         primary: RcAnchor<Endpoint>,
         replica: RcAnchor<Endpoint>,
@@ -129,7 +128,7 @@ fn nested_struct_with_shared_leaf() {
     assert_eq!(yaml.matches("*id001").count(), 1);
 
     // Both fields round-trip equivalently.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Parsed {
         primary: Endpoint,
         replica: Endpoint,
@@ -164,7 +163,7 @@ fn arc_two_clones_emit_anchor_and_alias() {
 
 #[test]
 fn arc_struct_shared() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Root {
         a: ArcAnchor<Endpoint>,
         b: ArcAnchor<Endpoint>,

--- a/crates/noyalib/tests/ariadne_adapter.rs
+++ b/crates/noyalib/tests/ariadne_adapter.rs
@@ -34,8 +34,7 @@ fn unclosed_flow_renders_with_source_excerpt() {
 
 #[test]
 fn typed_target_error_renders() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         #[allow(dead_code)]
         port: u16,

--- a/crates/noyalib/tests/binary_serde_bytes.rs
+++ b/crates/noyalib/tests/binary_serde_bytes.rs
@@ -17,9 +17,7 @@
 
 #![allow(missing_docs)]
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Payload {
     name: String,
     #[serde(with = "serde_bytes")]
@@ -52,7 +50,7 @@ fn vec_u8_with_serde_bytes_roundtrips_via_binary() {
 fn byte_buf_roundtrips_via_binary() {
     use serde_bytes::ByteBuf;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper {
         data: ByteBuf,
     }
@@ -77,7 +75,7 @@ fn byte_buf_roundtrips_via_binary() {
 fn empty_byte_buf_roundtrips() {
     use serde_bytes::ByteBuf;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper {
         data: ByteBuf,
     }
@@ -146,7 +144,7 @@ body: !!binary \"this is not base64\"
 fn full_byte_range_roundtrips() {
     use serde_bytes::ByteBuf;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper {
         data: ByteBuf,
     }
@@ -173,7 +171,7 @@ secret: !!binary SGVsbG8sIFdvcmxkIQ==
 ";
     let cfg = ParserConfig::strict();
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct S {
         #[serde(with = "serde_bytes")]
         secret: Vec<u8>,

--- a/crates/noyalib/tests/binary_tag_for_string.rs
+++ b/crates/noyalib/tests/binary_tag_for_string.rs
@@ -9,14 +9,13 @@
 #![allow(missing_docs)]
 
 use noyalib::{ParserConfig, from_str, from_str_with_config};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Doc {
     payload: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct DocBytes {
     payload: serde_bytes::ByteBuf,
 }

--- a/crates/noyalib/tests/comments.rs
+++ b/crates/noyalib/tests/comments.rs
@@ -103,9 +103,8 @@ fn comment_crossref_with_spanned_field() {
     // The primary use case: find the comment attached to a specific
     // Spanned<T> field by byte-position proximity.
     use noyalib::Spanned;
-    use serde::Deserialize;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         port: Spanned<u16>,
     }

--- a/crates/noyalib/tests/competitive_features.rs
+++ b/crates/noyalib/tests/competitive_features.rs
@@ -3,19 +3,16 @@
 
 //! Integration tests for the 4 competitive features.
 
-use serde::Deserialize;
-
 // ── Feature 1: Anchor Event Replay in Streaming Deserializer ────────────
 
 /// Tests that anchors and aliases work through the streaming path
 /// (which used to fall back to the Value AST path).
 mod anchor_replay {
-    use super::*;
 
     #[test]
     fn scalar_anchor_alias() {
         let yaml = "a: &val hello\nb: *val\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Doc {
             a: String,
             b: String,
@@ -28,7 +25,7 @@ mod anchor_replay {
     #[test]
     fn sequence_anchor_alias() {
         let yaml = "original: &items\n  - 1\n  - 2\ncopy: *items\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Doc {
             original: Vec<i32>,
             copy: Vec<i32>,
@@ -46,12 +43,12 @@ base: &base
   port: 8080
 dev: *base
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Server {
             host: String,
             port: u16,
         }
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Doc {
             base: Server,
             dev: Server,
@@ -64,7 +61,7 @@ dev: *base
     #[test]
     fn multiple_aliases_same_anchor() {
         let yaml = "x: &v 42\ny: *v\nz: *v\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             x: i32,
             y: i32,
@@ -79,7 +76,7 @@ dev: *base
     #[test]
     fn nested_sequence_alias() {
         let yaml = "items: &list\n  - a\n  - b\nother: *list\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             items: Vec<String>,
             other: Vec<String>,
@@ -92,7 +89,7 @@ dev: *base
     #[test]
     fn bool_anchor_alias() {
         let yaml = "a: &flag true\nb: *flag\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             a: bool,
             b: bool,
@@ -105,7 +102,7 @@ dev: *base
     #[test]
     fn float_anchor_alias() {
         let yaml = "a: &pi 3.125\nb: *pi\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             a: f64,
             b: f64,
@@ -118,7 +115,7 @@ dev: *base
     #[test]
     fn optional_with_anchor() {
         let yaml = "a: &v hello\nb: *v\nc: null\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             a: Option<String>,
             b: Option<String>,
@@ -135,13 +132,13 @@ dev: *base
 
 #[cfg(feature = "miette")]
 mod diagnostic_bridge {
-    use super::*;
+
     use noyalib::Spanned;
 
     #[test]
     fn spanned_error_report() {
         let yaml = "port: 80\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Cfg {
             port: Spanned<u16>,
         }
@@ -158,7 +155,7 @@ mod diagnostic_bridge {
         use miette::Diagnostic;
 
         let yaml = "name: test\nvalue: 42\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Cfg {
             #[allow(dead_code)]
             name: String,
@@ -344,9 +341,7 @@ mod robotics_types {
 
     #[test]
     fn strict_float_in_struct() {
-        use serde::Deserialize;
-
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Measurement {
             distance: StrictFloat,
             angle: Radians,

--- a/crates/noyalib/tests/competitive_features_full.rs
+++ b/crates/noyalib/tests/competitive_features_full.rs
@@ -6,7 +6,6 @@
 //! Covers all permutations of anchor replay, AnchorRegistry,
 //! robotics numeric types, and miette diagnostic bridge.
 
-use serde::Deserialize;
 use std::collections::BTreeMap;
 
 // ════════════════════════════════════════════════════════════════════════
@@ -63,12 +62,12 @@ mod anchor_replay {
     #[test]
     fn mapping_anchor_alias() {
         let yaml = "base: &cfg\n  host: localhost\n  port: 8080\ncopy: *cfg\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Endpoint {
             host: String,
             port: u16,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             base: Endpoint,
             copy: Endpoint,
@@ -82,7 +81,7 @@ mod anchor_replay {
     #[test]
     fn sequence_anchor_alias() {
         let yaml = "orig: &items\n  - a\n  - b\n  - c\ncopy: *items\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Doc {
             orig: Vec<String>,
             copy: Vec<String>,
@@ -103,16 +102,16 @@ config:
     port: 5432
 replica: *db_cfg
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct DbCfg {
             host: String,
             port: u16,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Config {
             db: DbCfg,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             config: Config,
             replica: DbCfg,
@@ -153,13 +152,13 @@ primary: &srv
   memory: 16
 failover: *srv
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Server {
             name: String,
             cpu: u32,
             memory: u32,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             primary: Server,
             failover: Server,
@@ -173,13 +172,13 @@ failover: *srv
     #[test]
     fn anchor_typed_enum() {
         let yaml = "status: &s active\ncopy: *s\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         #[serde(rename_all = "lowercase")]
         enum Status {
             Active,
             Inactive,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             status: Status,
             copy: Status,
@@ -194,7 +193,7 @@ failover: *srv
     #[test]
     fn anchor_typed_tuple() {
         let yaml = "pair: &p\n  - 10\n  - 20\ncopy: *p\n";
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct Doc {
             pair: (i32, i32),
             copy: (i32, i32),
@@ -209,7 +208,7 @@ failover: *srv
     #[test]
     fn anchor_in_sequence_items() {
         let yaml = "items:\n  - &x 10\n  - &y 20\n  - *x\n  - *y\n  - *x\n";
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             items: Vec<i32>,
         }
@@ -239,23 +238,23 @@ l1:
         value: found
 shallow: *deep
 "#;
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct L4 {
             value: String,
         }
-        #[derive(Debug, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Deserialize, PartialEq)]
         struct L3 {
             l4: L4,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct L2 {
             l3: L3,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct L1 {
             l2: L2,
         }
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Doc {
             l1: L1,
             shallow: L3,
@@ -268,12 +267,12 @@ shallow: *deep
 
     #[test]
     fn roundtrip_serialize_deserialize() {
-        #[derive(Debug, Serialize, Deserialize, PartialEq)]
+        #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
         struct Data {
             name: String,
             count: u32,
         }
-        use serde::Serialize;
+
         let original = Data {
             name: "test".into(),
             count: 42,
@@ -618,14 +617,12 @@ mod robotics_tests {
 
     #[test]
     fn struct_with_radians_fields() {
-        use serde::Deserialize;
-
         let yaml = r#"
 joint1: 90.0
 joint2: -45.0
 joint3: 180.0
 "#;
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, serde::Deserialize)]
         struct Arm {
             joint1: Radians,
             joint2: Radians,
@@ -654,12 +651,11 @@ joint3: 180.0
 mod diagnostic_tests {
     use miette::Diagnostic;
     use noyalib::Spanned;
-    use serde::Deserialize;
 
     #[test]
     fn spanned_error_creates_report() {
         let yaml = "port: 80\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Cfg {
             port: Spanned<u16>,
         }
@@ -672,7 +668,7 @@ mod diagnostic_tests {
     #[test]
     fn diagnostic_has_correct_source_code() {
         let yaml = "value: 42\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Doc {
             value: Spanned<i32>,
         }
@@ -685,7 +681,7 @@ mod diagnostic_tests {
     #[test]
     fn diagnostic_has_correct_labels() {
         let yaml = "value: 42\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Doc {
             value: Spanned<i32>,
         }
@@ -700,7 +696,7 @@ mod diagnostic_tests {
     #[test]
     fn diagnostic_has_code() {
         let yaml = "x: 1\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Doc {
             x: Spanned<i32>,
         }
@@ -714,7 +710,7 @@ mod diagnostic_tests {
     #[test]
     fn multiple_validation_errors() {
         let yaml = "host: \"\"\nport: 80\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Cfg {
             host: Spanned<String>,
             port: Spanned<u16>,
@@ -745,7 +741,7 @@ mod diagnostic_tests {
     #[test]
     fn integration_parse_validate_diagnose() {
         let yaml = "database:\n  host: db.local\n  port: 80\n  name: prod\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct DbCfg {
             #[allow(dead_code)]
             host: String,
@@ -753,7 +749,7 @@ mod diagnostic_tests {
             #[allow(dead_code)]
             name: String,
         }
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Root {
             database: DbCfg,
         }

--- a/crates/noyalib/tests/competitor_bugs.rs
+++ b/crates/noyalib/tests/competitor_bugs.rs
@@ -223,9 +223,8 @@ fn yr2_21_inline_comments_stripped() {
 #[test]
 fn yr2_27_source_spans_via_spanned() {
     use noyalib::Spanned;
-    use serde::Deserialize;
 
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Config {
         host: Spanned<String>,
         port: Spanned<u16>,
@@ -274,9 +273,7 @@ fn yr2_22_multi_document_parsing() {
 
 #[test]
 fn yr2_22_multi_document_typed() {
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         name: String,
     }

--- a/crates/noyalib/tests/complex_serde_interop.rs
+++ b/crates/noyalib/tests/complex_serde_interop.rs
@@ -15,17 +15,16 @@
 #![allow(missing_docs)]
 
 use noyalib::{Spanned, Value, from_str};
-use serde::{Deserialize, Serialize};
 
 // ── Flatten + anchors / aliases ─────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Common {
     image: String,
     version: String,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Service {
     name: String,
     #[serde(flatten)]
@@ -51,7 +50,7 @@ services:
     <<: *defaults
     replicas: 5
 ";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         services: Vec<Service>,
         #[allow(dead_code)]
@@ -68,7 +67,7 @@ services:
 
 // ── Flatten + Spanned<T> ────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct SpannedFlatten {
     #[allow(dead_code)]
     name: Spanned<String>,
@@ -94,13 +93,13 @@ version: 1.0.0
 
 #[test]
 fn multiple_flattened_fields_compose() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Resources {
         cpu: String,
         memory: String,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Combined {
         name: String,
         #[serde(flatten)]
@@ -123,7 +122,7 @@ memory: 256Mi
 
 // ── Untagged enum: parser must backtrack across variants ────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 #[serde(untagged)]
 enum Resource {
     Pod {
@@ -154,7 +153,7 @@ fn untagged_enum_distinguishes_pod_from_service() {
 
 // ── Internally tagged ───────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 #[serde(tag = "kind")]
 enum K8sResource {
     Pod { containers: u32 },
@@ -176,7 +175,7 @@ fn internally_tagged_enum_round_trips() {
 
 // ── Adjacently tagged ───────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
 #[serde(tag = "kind", content = "spec")]
 enum AdjResource {
     Pod { containers: u32 },
@@ -197,7 +196,7 @@ fn adjacently_tagged_enum_round_trips() {
 /// must handle them all without cross-contamination.
 #[test]
 fn mixed_enum_strategies_in_one_document() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct MixedDoc {
         // Untagged inner — variant inferred from shape
         worker: Resource,
@@ -233,7 +232,7 @@ fn untagged_enum_picks_the_first_matching_variant() {
     // variants top-to-bottom and picks the first that matches
     // — the parser must not get stuck on the failed first
     // probe and abandon the second.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     #[serde(untagged)]
     enum Either {
         Left { x: i32, y: i32 },
@@ -261,7 +260,7 @@ fn flatten_with_value_residue_captures_unknown_keys() {
     // The `extras: Value` field captures any unknown keys, so
     // the parse never fails on the document carrying
     // application-specific metadata.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Envelope {
         name: String,
         version: String,
@@ -298,13 +297,13 @@ services:
     port: *port
 ";
     use std::collections::BTreeMap;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         services: BTreeMap<String, Endpoint>,
         #[allow(dead_code)]
         default_port: u16,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Endpoint {
         port: u16,
     }

--- a/crates/noyalib/tests/coverage_100.rs
+++ b/crates/noyalib/tests/coverage_100.rs
@@ -14,7 +14,7 @@
 use std::collections::HashMap;
 
 use noyalib::*;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 // ============================================================================
 // 1. value.rs — Mapping / MappingAny Visitor expecting
@@ -41,7 +41,7 @@ fn mapping_any_deserialize_from_yaml() {
 // 1. value.rs — TaggedValue Deserializer (lines 1440-1600)
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum MyEnum {
     UnitVariant,
     NewtypeVariant(i64),
@@ -378,7 +378,7 @@ fn ref_value_deserialize_any_mapping() {
 #[test]
 fn ref_value_deserialize_enum_string() {
     // deserialize_enum with Value::String (line 2799-2800)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Simple {
         Hello,
         World,
@@ -938,7 +938,7 @@ fn loader_value_to_key_types() {
 #[test]
 fn de_deserialize_identifier() {
     // deserialize_identifier (lines 648-652)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Wrapper {
         field: String,
     }
@@ -950,7 +950,7 @@ fn de_deserialize_identifier() {
 #[test]
 fn de_spanned_map_access_all_fields() {
     // SpannedMapAccess states (lines 786-814)
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         name: Spanned<String>,
         value: Spanned<i64>,
@@ -1046,7 +1046,7 @@ fn ser_literal_block() {
     // Literal block serialization (lines 707-713, 779-789)
     use noyalib::fmt::LitString;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         script: LitString,
     }
@@ -1062,7 +1062,7 @@ fn ser_folded_block() {
     // Folded block serialization (lines 714-720)
     use noyalib::fmt::FoldString;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         text: FoldString,
     }
@@ -1078,7 +1078,7 @@ fn ser_flow_sequence() {
     // Flow sequence serialization (lines 749-763)
     use noyalib::fmt::FlowSeq;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         items: FlowSeq<Vec<i32>>,
     }
@@ -1095,7 +1095,7 @@ fn ser_flow_mapping() {
     // Flow mapping serialization (lines 765-777)
     use noyalib::fmt::FlowMap;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         map: FlowMap<std::collections::BTreeMap<String, i32>>,
     }
@@ -1163,7 +1163,7 @@ fn path_seq_parent_and_depth() {
 fn fmt_commented_roundtrip() {
     use noyalib::fmt::Commented;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         key: Commented<String>,
     }
@@ -1175,7 +1175,7 @@ fn fmt_commented_roundtrip() {
     assert!(s.contains("# my comment"));
 
     // Deserialize back (comment is lost, per design)
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct DocIn {
         key: Commented<String>,
     }
@@ -1191,13 +1191,13 @@ fn fmt_commented_roundtrip() {
 fn singleton_map_recursive_tagged_value() {
     use noyalib::with::singleton_map_recursive;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Action {
         Start { delay: u32 },
         Stop,
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Task {
         #[serde(with = "singleton_map_recursive")]
         action: Action,
@@ -1221,7 +1221,7 @@ fn singleton_map_with_deserialize_transform() {
     // Exercise transform_value_keys including Tagged branch (lines 214-217)
     use noyalib::with::singleton_map_with;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum MyAction {
         START,
         STOP,
@@ -1241,7 +1241,7 @@ fn singleton_map_with_serialize_branches() {
     // Exercise serialize_with String and Mapping branches (lines 125-143)
     use noyalib::with::singleton_map_with;
 
-    #[derive(Debug, Serialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, PartialEq)]
     enum Status {
         Active,
         WithData { count: u32 },
@@ -1382,7 +1382,7 @@ fn ser_space_after() {
     // SpaceAfter serialization (lines 737-740)
     use noyalib::fmt::SpaceAfter;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         section: SpaceAfter<String>,
     }
@@ -1412,7 +1412,7 @@ fn ref_value_deserialize_tagged_any() {
 #[test]
 fn ref_value_deserialize_enum_tagged() {
     // &Value deserialize_enum for Tagged (lines 2795-2798)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Blue,
@@ -1426,7 +1426,7 @@ fn ref_value_deserialize_enum_tagged() {
 #[test]
 fn ref_value_deserialize_enum_non_tagged_non_string() {
     // &Value deserialize_enum fallthrough to deserialize_any (line 2801)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Thing {
         Value(i64),
     }
@@ -1529,7 +1529,7 @@ fn scanner_block_scalar_folded_multiple_breaks() {
 fn ref_value_deserialize_struct_normal() {
     // deserialize_struct for non-spanned struct -> falls through to deserialize_map
     // (line 2844)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Point {
         x: i64,
         y: i64,
@@ -1746,7 +1746,7 @@ fn ref_value_deserialize_enum_string_variant() {
     // Exercise deserialize_enum on string Value (line 2799-2801)
     use serde::Deserialize;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Blue,
@@ -1774,9 +1774,8 @@ fn ref_value_deserialize_seq_fallback() {
 fn ref_value_deserialize_struct_spanned_via_ref() {
     // Exercise deserialize_struct with Spanned name (lines 2837-2844)
     // The &Value deserializer checks for SPANNED_TYPE_NAME
-    use serde::Deserialize;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         port: Spanned<u16>,
     }
@@ -1790,9 +1789,8 @@ fn ref_value_deserialize_struct_spanned_via_ref() {
 #[test]
 fn ref_value_deserialize_struct_spanned_from_value() {
     // Exercise the &Value path specifically via from_value
-    use serde::Deserialize;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         port: Spanned<u16>,
     }
@@ -2377,7 +2375,7 @@ fn loader_large_int_overflow_float() {
 
 #[test]
 fn de_spanned_all_field_states() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct S {
         name: Spanned<String>,
         count: Spanned<i64>,
@@ -2398,7 +2396,7 @@ fn de_spanned_all_field_states() {
 
 #[test]
 fn spanned_bool_from_yaml() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct S {
         flag: Spanned<bool>,
     }
@@ -2582,12 +2580,12 @@ fn ser_folded_block_strip_chomping() {
 fn singleton_map_recursive_with_tagged() {
     use noyalib::with::singleton_map_recursive;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Action {
         Click { x: i32, y: i32 },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         #[serde(with = "singleton_map_recursive")]
         action: Action,
@@ -3157,7 +3155,7 @@ fn loader_merge_with_scalar_value() {
 fn de_deserialize_identifier_via_from_value_enum() {
     // from_value with an enum exercises deserialize_identifier on the Value
     // deserializer
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Direction {
         North,
         South,
@@ -3174,7 +3172,7 @@ fn de_deserialize_identifier_via_from_value_enum() {
 #[test]
 fn de_deserialize_identifier_via_from_value_struct_fields() {
     // Struct field names go through deserialize_identifier
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Point {
         x: i32,
         y: i32,
@@ -3209,7 +3207,7 @@ fn de_spanned_map_access_complete_lifecycle() {
 fn de_spanned_in_struct_from_str() {
     // Spanned within struct exercises SpannedMapAccess fully when deserializing
     // from YAML
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         host: Spanned<String>,
         port: Spanned<u16>,
@@ -3779,7 +3777,7 @@ fn spanned_unknown_field_skipped() {
 #[test]
 fn value_map_access_next_value_via_ref_value() {
     // Deserialize a mapping via &Value to exercise ValueMapAccess (line 2755)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Pair {
         key: String,
         val: i64,
@@ -3799,7 +3797,7 @@ fn value_map_access_next_value_via_ref_value() {
 fn ref_value_deserialize_enum_mapping() {
     // Mapping value as enum -> uses from_value which goes through de.rs
     // Deserializer
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Animal {
         Dog { name: String },
     }
@@ -3823,7 +3821,7 @@ fn ref_value_deserialize_enum_mapping() {
 fn ref_value_deserialize_struct_via_mapping() {
     // deserialize_struct on &Value with non-spanned name -> falls to
     // deserialize_map (line 2844)
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Rgb {
         r: u8,
         g: u8,
@@ -3858,7 +3856,7 @@ fn ref_value_deserialize_struct_spanned_via_value() {
 #[test]
 fn ref_value_deserialize_struct_spanned_nested_in_mapping() {
     // Exercise Spanned<T> in a struct deserialized from a Value mapping
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Item {
         name: Spanned<String>,
         count: Spanned<i32>,
@@ -3880,13 +3878,13 @@ fn singleton_map_recursive_transform_tagged() {
 
     // Create a value that has Tagged variant to exercise lines 47-51
     // The transform_to_singleton_map function processes Tagged values recursively
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Op {
         Add(i32),
     }
 
     // First serialize to get a Value, then use singleton_map_recursive
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Ops {
         #[serde(with = "singleton_map_recursive")]
         ops: Vec<Op>,
@@ -3980,7 +3978,7 @@ fn events_flow_sequence_explicit_key_mapping() {
 #[test]
 fn spanned_mapping_value_from_str() {
     // Spanned<Mapping> via from_str exercises all SpannedFieldState transitions
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         data: Spanned<HashMap<String, i32>>,
     }

--- a/crates/noyalib/tests/coverage_boost.rs
+++ b/crates/noyalib/tests/coverage_boost.rs
@@ -15,7 +15,6 @@ use noyalib::{
     DuplicateKeyPolicy, Error, Location, Mapping, MappingAny, Number, ParserConfig, Spanned, Value,
     from_slice, from_str, from_str_with_config, from_value, to_string,
 };
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // 1. streaming.rs — typed deserialization through the streaming path
@@ -211,7 +210,7 @@ fn streaming_char_error_on_sequence() {
 #[test]
 fn streaming_bytes() {
     // serde_bytes provides a type that calls deserialize_bytes
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ByteWrap {
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
@@ -222,7 +221,7 @@ fn streaming_bytes() {
 
 #[test]
 fn streaming_byte_buf() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ByteBufWrap {
         #[serde(with = "serde_bytes")]
         data: serde_bytes::ByteBuf,
@@ -287,7 +286,7 @@ fn streaming_unit_error_on_mapping() {
 
 #[test]
 fn streaming_unit_struct() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Marker;
     let v: Marker = from_str("~").unwrap();
     assert_eq!(v, Marker);
@@ -296,7 +295,7 @@ fn streaming_unit_struct() {
 // --- deserialize_newtype_struct ---
 #[test]
 fn streaming_newtype_struct() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Wrapper(i32);
     let v: Wrapper = from_str("42").unwrap();
     assert_eq!(v, Wrapper(42));
@@ -304,7 +303,7 @@ fn streaming_newtype_struct() {
 
 #[test]
 fn streaming_newtype_struct_string() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Name(String);
     let v: Name = from_str("hello").unwrap();
     assert_eq!(v, Name("hello".to_owned()));
@@ -319,14 +318,14 @@ fn streaming_tuple() {
 
 #[test]
 fn streaming_tuple_struct() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Point(f64, f64);
     let v: Point = from_str("[1.0, 2.5]").unwrap();
     assert_eq!(v, Point(1.0, 2.5));
 }
 
 // --- deserialize_enum ---
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
 enum Color {
     Red,
     Blue,
@@ -376,7 +375,7 @@ fn streaming_enum_error_on_sequence() {
 #[test]
 fn streaming_ignored_any() {
     // Extra fields are silently ignored via deserialize_ignored_any
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Partial {
         name: String,
     }
@@ -390,7 +389,7 @@ fn streaming_ignored_any() {
 fn streaming_seq_early_drop() {
     // A tuple takes fewer elements than the YAML sequence provides,
     // triggering the Drop draining logic
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct TwoOf {
         items: (i32, i32),
     }
@@ -403,7 +402,7 @@ fn streaming_seq_early_drop() {
 #[test]
 fn streaming_map_early_drop() {
     // Struct with fewer fields than the mapping, triggering Drop drain
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Small {
         a: i32,
@@ -416,7 +415,7 @@ fn streaming_map_early_drop() {
 // --- Fallback to Value-based path (anchors, aliases, tags) ---
 #[test]
 fn streaming_fallback_anchor_alias() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct Cfg {
         a: String,
         b: String,
@@ -700,7 +699,7 @@ fn de_char_single() {
 // bytes from value
 #[test]
 fn de_bytes_from_value() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct W {
         #[serde(with = "serde_bytes")]
         d: Vec<u8>,
@@ -713,7 +712,7 @@ fn de_bytes_from_value() {
 // unit_struct from value
 #[test]
 fn de_unit_struct() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct Empty;
     let v: Empty = from_str_with_config("~", &ParserConfig::new()).unwrap();
     assert_eq!(v, Empty);
@@ -722,7 +721,7 @@ fn de_unit_struct() {
 // tuple_struct from value
 #[test]
 fn de_tuple_struct() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct Pair(i32, i32);
     let v: Pair = from_str_with_config("[10, 20]", &ParserConfig::new()).unwrap();
     assert_eq!(v, Pair(10, 20));
@@ -731,7 +730,7 @@ fn de_tuple_struct() {
 // newtype_struct from value
 #[test]
 fn de_newtype_struct() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct W(String);
     let v: W = from_str_with_config("hello", &ParserConfig::new()).unwrap();
     assert_eq!(v, W("hello".to_owned()));
@@ -741,7 +740,7 @@ fn de_newtype_struct() {
 #[test]
 fn de_identifier() {
     // Field name deserialization uses deserialize_identifier
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Named {
         field_name: i32,
@@ -753,7 +752,7 @@ fn de_identifier() {
 // ignored_any from value
 #[test]
 fn de_ignored_any() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Pick {
         a: i32,
@@ -1300,7 +1299,7 @@ fn spanned_deserialization_from_value() {
 #[test]
 fn spanned_deserialization_from_str() {
     let yaml = "port: 8080";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Config {
         port: Spanned<u16>,
     }
@@ -1331,13 +1330,13 @@ fn spanned_deref() {
 
 #[test]
 fn singleton_map_recursive_roundtrip() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Inner {
         A,
         B { value: i32 },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         items: Vec<Inner>,
@@ -1364,7 +1363,7 @@ fn document_load_all() {
 
 #[test]
 fn document_load_all_as() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Doc {
         name: String,
@@ -1409,7 +1408,7 @@ fn streaming_quoted_number_not_resolved() {
 // Map with various value types
 #[test]
 fn streaming_map_mixed_values() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Mixed {
         name: String,
@@ -1700,7 +1699,7 @@ fn scanner_escape_sequences() {
 
 #[test]
 fn streaming_fallback_for_spanned() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Cfg {
         port: Spanned<u16>,
     }
@@ -1863,7 +1862,7 @@ fn streaming_positive_float() {
 
 #[test]
 fn streaming_skip_nested_sequence() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct S {
         a: i32,
     }
@@ -1874,7 +1873,7 @@ fn streaming_skip_nested_sequence() {
 
 #[test]
 fn streaming_skip_nested_mapping() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct S {
         a: i32,
     }
@@ -2353,7 +2352,7 @@ fn scanner_block_sequence_of_mappings() {
 
 #[test]
 fn streaming_struct_with_optional_fields() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Config {
         name: String,
@@ -2370,7 +2369,7 @@ fn streaming_struct_with_optional_fields() {
 
 #[test]
 fn streaming_struct_with_all_fields() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Config {
         name: String,
@@ -2388,13 +2387,13 @@ fn streaming_struct_with_all_fields() {
 
 #[test]
 fn streaming_nested_struct() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Inner {
         x: i32,
         y: i32,
     }
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Outer {
         name: String,
@@ -2408,7 +2407,7 @@ fn streaming_nested_struct() {
 
 #[test]
 fn streaming_vec_of_structs() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Item {
         id: u32,
@@ -2662,7 +2661,7 @@ fn multi_doc_via_load_all_with_config() {
 
 #[test]
 fn multi_doc_typed() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     struct Simple {
         x: i32,
     }
@@ -2681,7 +2680,7 @@ fn multi_doc_typed() {
 fn from_reader_streaming_path() {
     let yaml = b"name: test\ncount: 42";
     let cursor = std::io::Cursor::new(&yaml[..]);
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct S {
         name: String,
         count: u32,
@@ -2697,7 +2696,7 @@ fn from_reader_streaming_path() {
 
 #[test]
 fn spanned_in_struct_with_config() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Cfg {
         name: Spanned<String>,
         port: Spanned<u16>,
@@ -2715,7 +2714,7 @@ fn spanned_in_struct_with_config() {
 
 #[test]
 fn singleton_map_with_roundtrip() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Status {
         Active,
         Pending,
@@ -2732,7 +2731,7 @@ fn singleton_map_with_roundtrip() {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Cfg {
         #[serde(serialize_with = "ser_status", deserialize_with = "de_status")]
         status: Status,
@@ -2814,7 +2813,7 @@ fn from_slice_fallback_path() {
 
 #[test]
 fn de_bytes_error_on_non_string() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct W {
         #[serde(with = "serde_bytes")]
@@ -2850,13 +2849,13 @@ fn de_enum_non_string_key_in_mapping() {
 fn singleton_map_recursive_tagged() {
     use noyalib::with::singleton_map_recursive;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Status {
         Active,
         Inactive,
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         #[serde(with = "singleton_map_recursive")]
         status: Status,

--- a/crates/noyalib/tests/coverage_de.rs
+++ b/crates/noyalib/tests/coverage_de.rs
@@ -164,9 +164,7 @@ fn deserialize_option_some() {
 
 #[test]
 fn deserialize_ignored_any() {
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Partial {
         name: String,
     }
@@ -177,8 +175,7 @@ fn deserialize_ignored_any() {
 
 #[test]
 fn deserialize_enum_unit() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Green,
@@ -191,8 +188,7 @@ fn deserialize_enum_unit() {
 
 #[test]
 fn deserialize_enum_newtype() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Wrapper {
         Int(i64),
     }
@@ -203,8 +199,7 @@ fn deserialize_enum_newtype() {
 
 #[test]
 fn deserialize_enum_struct() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Shape {
         Circle { radius: f64 },
     }
@@ -217,8 +212,7 @@ fn deserialize_enum_struct() {
 
 #[test]
 fn deserialize_enum_tuple() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Pair {
         Point(f64, f64),
     }
@@ -229,9 +223,7 @@ fn deserialize_enum_tuple() {
 
 #[test]
 fn from_value_struct() {
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Config {
         name: String,
         port: u16,

--- a/crates/noyalib/tests/coverage_final.rs
+++ b/crates/noyalib/tests/coverage_final.rs
@@ -6,7 +6,6 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{Mapping, Value, from_str, from_value, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── Scanner: escape sequences, line folding, error paths ────────────────
 
@@ -534,7 +533,7 @@ fn loader_anchored_mapping() {
 #[test]
 fn de_deserialize_ignored_any_returns_unit() {
     // Extra fields in a struct should be ignored
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     struct Simple {
         name: String,
     }
@@ -568,7 +567,7 @@ fn de_spanned_map_access_all_fields() {
 
 #[test]
 fn de_type_mismatch_on_enum_from_non_map_non_string() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     enum MyEnum {
         A,
         B,
@@ -735,7 +734,7 @@ fn value_deserialize_via_ref() {
 
 #[test]
 fn value_deserialize_enum_from_ref() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     enum Color {
         Red,
         Blue,
@@ -785,13 +784,13 @@ fn spanned_unknown_field_skipped() {
 
 #[test]
 fn singleton_map_recursive_tagged_value_transforms() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Status {
         Active,
         Inactive,
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Container {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         status: Status,
@@ -807,13 +806,13 @@ fn singleton_map_recursive_tagged_value_transforms() {
 
 #[test]
 fn singleton_map_recursive_nested_sequence() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Item {
         A,
         B { x: i32 },
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         items: Vec<Item>,

--- a/crates/noyalib/tests/coverage_final_sweep.rs
+++ b/crates/noyalib/tests/coverage_final_sweep.rs
@@ -14,12 +14,11 @@ use noyalib::{
     from_str_with_config, to_string, to_string_with_config, to_value, to_writer_tracking_shared,
     to_writer_tracking_shared_with_config,
 };
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 // ── de.rs AST paths (Spanned<T> forces AST) ─────────────────────────────
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
 struct WithSpan {
     name: Spanned<String>,
 }
@@ -28,7 +27,7 @@ struct WithSpan {
 fn ast_deserialize_bytes_from_string() {
     // AST path handles deserialize_bytes by converting a String value
     // to byte slice.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Blob {
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
@@ -42,7 +41,7 @@ fn ast_deserialize_bytes_from_string() {
 #[test]
 fn ast_deserialize_tuple_via_spanned_force() {
     // Wrap in Spanned to force AST path, then read a tuple.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         pair: Spanned<(i32, String)>,
@@ -54,9 +53,9 @@ fn ast_deserialize_tuple_via_spanned_force() {
 
 #[test]
 fn ast_deserialize_unit_struct() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Marker;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: Spanned<String>,
@@ -69,9 +68,9 @@ fn ast_deserialize_unit_struct() {
 
 #[test]
 fn ast_deserialize_newtype_struct_non_spanned() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Wrapper(String);
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: Spanned<String>,
@@ -84,7 +83,7 @@ fn ast_deserialize_newtype_struct_non_spanned() {
 
 #[test]
 fn ast_deserialize_option_some() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: Spanned<String>,
@@ -97,7 +96,7 @@ fn ast_deserialize_option_some() {
 
 #[test]
 fn ast_deserialize_option_none() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: Spanned<String>,
@@ -136,7 +135,7 @@ fn to_writer_tracking_shared_with_config_indent_four() {
 
 #[test]
 fn ser_flow_map_emits_inline() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         inner: FlowMap<BTreeMap<String, i32>>,
     }
@@ -150,7 +149,7 @@ fn ser_flow_map_emits_inline() {
 
 #[test]
 fn ser_flow_seq_emits_inline() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         items: FlowSeq<Vec<i32>>,
     }
@@ -164,7 +163,7 @@ fn ser_flow_seq_emits_inline() {
 
 #[test]
 fn ser_lit_str_emits_literal_block() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         desc: LitString,
     }
@@ -177,7 +176,7 @@ fn ser_lit_str_emits_literal_block() {
 
 #[test]
 fn ser_fold_str_emits_folded_block() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         desc: FoldString,
     }
@@ -190,7 +189,7 @@ fn ser_fold_str_emits_folded_block() {
 
 #[test]
 fn ser_commented_emits_inline_hash() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         value: Commented<i32>,
     }
@@ -203,7 +202,7 @@ fn ser_commented_emits_inline_hash() {
 
 #[test]
 fn ser_space_after_emits_blank_line() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         section: SpaceAfter<String>,
         next: String,
@@ -247,7 +246,7 @@ fn to_string_with_config_quote_all_forces_single_quotes() {
 
 #[test]
 fn to_string_with_config_indent_width() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         nested: BTreeMap<String, i32>,
     }
@@ -362,7 +361,7 @@ fn number_compares_float_to_int() {
 #[test]
 fn streaming_newtype_struct_custom_tag_wraps() {
     // A custom tag on a newtype struct routes through StreamingTagMapAccess.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Custom {
         tag: String,
         value: String,
@@ -424,7 +423,7 @@ fn to_value_sequence_round_trip() {
 
 #[test]
 fn to_value_struct_round_trip() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         name: String,
         count: i32,
@@ -489,11 +488,11 @@ fn number_float_ordering_nan_handled() {
 #[test]
 fn spanned_reports_line_and_column_for_nested_field() {
     let yaml = "outer:\n  inner: value\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Inner {
         inner: Spanned<String>,
     }
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Outer {
         outer: Inner,
     }

--- a/crates/noyalib/tests/coverage_final_sweep2.rs
+++ b/crates/noyalib/tests/coverage_final_sweep2.rs
@@ -13,7 +13,7 @@
 )]
 
 use noyalib::{ParserConfig, RcAnchor, Spanned, Value, from_str, from_str_with_config};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 // ── streaming: anchor whose body contains an alias (maybe_record Alias arm) ─
 
@@ -38,7 +38,7 @@ copy: *b
 #[test]
 fn streaming_merge_unknown_anchor_errors() {
     let yaml = "base:\n  k: 1\nderived:\n  <<: *missing\n  v: 2\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         base: std::collections::BTreeMap<String, i64>,
         derived: std::collections::BTreeMap<String, i64>,
@@ -65,14 +65,14 @@ child:
   nested:
     inner: yes
 ";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Child {
         shared: i64,
         items: Vec<i64>,
         nested: std::collections::BTreeMap<String, String>,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         #[serde(skip)]
@@ -96,7 +96,7 @@ child:
 
 #[test]
 fn streaming_ignored_any_on_scalar() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         keep: String,
         #[serde(default, skip_deserializing)]
@@ -116,7 +116,7 @@ fn streaming_ignored_any_on_alias() {
     // An ignored field whose value is *an alias* hits the
     // `Event::Alias if balance == 0` arm inside `skip_value`.
     let yaml = "anchor: &a hello\n_skip: *a\nkeep: yes\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         anchor: String,
         keep: String,
@@ -128,7 +128,7 @@ fn streaming_ignored_any_on_alias() {
 
 // ── streaming: deserialize_newtype_struct with a custom tag ─────────
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, serde::Serialize)]
 struct NewtypeWrapper(String);
 
 impl<'de> Deserialize<'de> for NewtypeWrapper {
@@ -137,7 +137,7 @@ impl<'de> Deserialize<'de> for NewtypeWrapper {
         D: serde::Deserializer<'de>,
     {
         // Access the {tag, value} map produced by StreamingTagMapAccess.
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Inner {
             tag: String,
             value: String,
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for NewtypeWrapper {
 fn streaming_newtype_struct_with_custom_tag() {
     // Deserializing a struct that takes a NewtypeWrapper with a custom
     // tag routes through StreamingTagMapAccess.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         field: std::collections::BTreeMap<String, String>,
     }
@@ -186,7 +186,7 @@ fn ast_wrap_err_emits_deserialize_with_location() {
     // A Spanned<T> deserialize error gets wrapped with location. Force
     // the AST path via Spanned<String>, then throw a Deserialize error
     // by expecting a non-existent variant.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         #[serde(rename = "kind")]
@@ -194,7 +194,7 @@ fn ast_wrap_err_emits_deserialize_with_location() {
         #[allow(dead_code)]
         value: Choice,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     enum Choice {
         A,
         B,
@@ -212,14 +212,14 @@ fn ast_identifier_path_via_tag_key() {
     // Serde uses deserialize_identifier for #[serde(tag = "type")]
     // struct matching. Forcing AST via Spanned<_> gets us into
     // de.rs deserialize_identifier.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[serde(tag = "type")]
     #[allow(dead_code)]
     enum Shape {
         Square { side: i64 },
         Circle { radius: i64 },
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         #[allow(dead_code)]
@@ -239,7 +239,7 @@ fn ast_identifier_path_via_tag_key() {
 #[test]
 fn ast_deserialize_bytes_type_mismatch() {
     // bytes on a numeric Value should error with "bytes" expected.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         #[allow(dead_code)]
@@ -293,7 +293,7 @@ fn streaming_map_drop_on_partial_read() {
     // Deserialising an empty-field struct from a populated mapping
     // triggers StreamingMapAccess::drop to skip all keys+values.
     let yaml = "a: 1\nb: 2\nc: 3\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Empty {}
     let _: Empty = from_str(yaml).unwrap();
 }

--- a/crates/noyalib/tests/coverage_final_sweep3.rs
+++ b/crates/noyalib/tests/coverage_final_sweep3.rs
@@ -13,13 +13,12 @@
 )]
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 // ── streaming: deserialize_enum with a custom tag, newtype variant ──
 
 #[test]
 fn streaming_enum_custom_tag_newtype_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Msg {
         #[serde(rename = "!bang")]
         Bang(i64),
@@ -37,7 +36,7 @@ fn streaming_enum_custom_tag_newtype_variant() {
 
 #[test]
 fn streaming_enum_custom_tag_unit_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Msg {
         #[serde(rename = "!quiet")]
         Quiet,
@@ -86,7 +85,7 @@ fn streaming_seq_drop_with_short_read() {
     // Reading only the first element from a 5-element seq triggers
     // SeqAccess::drop to chew through remaining events, including the
     // inner mapping.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct One(i32);
     let yaml = "- 1\n- {a: 1, b: [2, 3]}\n- 3\n";
     let _: One = from_str(yaml).unwrap_or(One(1));
@@ -96,7 +95,7 @@ fn streaming_seq_drop_with_short_read() {
 
 #[test]
 fn streaming_enum_custom_tag_struct_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Event {
         #[serde(rename = "!log")]
         Log { level: String, msg: String },
@@ -113,7 +112,7 @@ fn streaming_enum_custom_tag_struct_variant() {
 
 #[test]
 fn streaming_enum_custom_tag_tuple_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Pair {
         #[serde(rename = "!pair")]
         Pair(i32, i32),
@@ -129,7 +128,7 @@ fn streaming_enum_custom_tag_tuple_variant() {
 
 #[test]
 fn streaming_enum_custom_tag_bare_exclamation() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!plain")]
         Plain(String),

--- a/crates/noyalib/tests/coverage_final_sweep4.rs
+++ b/crates/noyalib/tests/coverage_final_sweep4.rs
@@ -12,7 +12,6 @@
 )]
 
 use noyalib::{Error, Value, from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ── error.rs: Error::location for UnknownAnchorAt ────────────────────
 
@@ -31,7 +30,7 @@ fn error_location_for_unknown_anchor_at() {
 
 #[test]
 fn error_unknown_field_via_deny_unknown_fields() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[serde(deny_unknown_fields)]
     struct Strict {
         known: String,
@@ -51,7 +50,7 @@ fn error_miette_labels_for_deserialize_with_location() {
     use miette::Diagnostic;
     // Force a deserialize error with location by using a Spanned field
     // plus a type mismatch downstream.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         name: noyalib::Spanned<String>,
@@ -92,11 +91,11 @@ fn error_miette_labels_for_parse_with_location() {
 #[test]
 fn singleton_map_with_tagged_value() {
     // Force transform_value_keys to walk a Value::Tagged branch.
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Event {
         Log(String),
     }
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Doc {
         #[serde(with = "noyalib::with::singleton_map")]
         event: Event,
@@ -113,7 +112,7 @@ fn singleton_map_recursive_tagged_value_branch() {
     // Serializing a Value::Tagged via singleton_map_recursive exercises
     // the Tagged arm in `transform_to_singleton_map`.
     use noyalib::{Tag, TaggedValue};
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Wrap<'a> {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         v: &'a Value,
@@ -158,7 +157,7 @@ fn singleton_map_with_tagged_value_branch() {
     // serialize_with walks transform_value_keys which has a Tagged arm.
     use noyalib::{Tag, TaggedValue};
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Wrap<'a> {
         #[serde(with = "snake_with")]
         v: &'a Value,
@@ -177,12 +176,12 @@ fn singleton_map_with_tagged_value_branch() {
 #[test]
 fn singleton_map_recursive_deep() {
     use noyalib::with::singleton_map_recursive as smr;
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Node {
         Leaf(i32),
         Branch(Vec<Node>),
     }
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Tree {
         #[serde(with = "smr")]
         root: Node,
@@ -203,13 +202,13 @@ fn singleton_map_recursive_deep() {
 fn ast_deserialize_identifier_string_path() {
     // Spanned forces AST; serde uses deserialize_identifier to match
     // tagged-enum discriminator "type" against variants.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[serde(tag = "type")]
     enum Item {
         Apple,
         Banana,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: noyalib::Spanned<String>,
@@ -226,7 +225,7 @@ fn ast_deserialize_identifier_string_path() {
 fn ast_deserialize_bytes_type_mismatch_on_sequence() {
     // AST deserialize_bytes does not accept sequences directly; the
     // type mismatch exercise reaches the `_ => TypeMismatch` arm.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         _force: noyalib::Spanned<String>,
@@ -260,14 +259,14 @@ fn ast_spanned_enum_hits_variant_access_with_span_context() {
     // path, and deserializing the enum inside Spanned context walks
     // VariantAccess::unit_variant / newtype_variant_seed with
     // span_ctx Some.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Kind {
         One,
         Two(i64),
         Three(i64, i64),
         Four { n: i64 },
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         unit: noyalib::Spanned<Kind>,
@@ -294,7 +293,7 @@ strct:
 
 #[test]
 fn streaming_unknown_field_via_deny() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[serde(deny_unknown_fields)]
     struct Strict {
         k: i32,

--- a/crates/noyalib/tests/coverage_full.rs
+++ b/crates/noyalib/tests/coverage_full.rs
@@ -20,7 +20,6 @@ use noyalib::{
     SerializerConfig, Spanned, Tag, TaggedValue, Value, from_str, from_str_with_config, from_value,
     to_string, to_string_with_config,
 };
-use serde::{Deserialize, Serialize};
 
 // ═══════════════════════════════════════════════════════════════════════
 // scanner.rs — Quoted scalar escape sequences (lines 938–1121)
@@ -698,7 +697,7 @@ fn large_integer_as_float() {
 #[test]
 fn deserialize_identifier_delegates_to_str() {
     // de.rs:648, 652 — deserialize_identifier
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     enum Color {
         Red,
         Blue,
@@ -723,7 +722,7 @@ fn spanned_deserialize_all_fields() {
 #[test]
 fn spanned_nested_value() {
     // de.rs:786-814 — Spanned with specific value
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         name: Spanned<String>,
     }
@@ -896,7 +895,7 @@ fn tagged_value_enum_deserialization() {
 #[test]
 fn tagged_value_unit_variant() {
     // value.rs:1564-1566 — unit variant through tagged
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Flag {
         On,
         Off,
@@ -910,7 +909,7 @@ fn tagged_value_unit_variant() {
 #[test]
 fn tagged_value_tuple_variant() {
     // value.rs:1575-1580 — tuple variant through tagged
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Data {
         Pair(i32, i32),
     }
@@ -922,7 +921,7 @@ fn tagged_value_tuple_variant() {
 #[test]
 fn tagged_value_struct_variant() {
     // value.rs:1582-1591 — struct variant through tagged
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Shape {
         Circle { radius: f64 },
     }
@@ -986,7 +985,7 @@ fn value_deserialize_map() {
     m.insert("a", Value::from(1));
     m.insert("b", Value::from(2));
     let v = Value::Mapping(m);
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Obj {
         a: i64,
         b: i64,
@@ -1190,12 +1189,12 @@ fn fold_str_as_str_and_into_inner() {
 #[test]
 fn singleton_map_recursive_with_tagged() {
     // singleton_map_recursive.rs:47-51 — tagged value transformation
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Action {
         Run(String),
         Stop,
     }
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Job {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         actions: Vec<Action>,
@@ -1252,7 +1251,7 @@ fn singleton_map_with_from_kebab_case() {
 
 #[test]
 fn load_all_as_typed_deserialization() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         name: String,
     }

--- a/crates/noyalib/tests/coverage_gaps.rs
+++ b/crates/noyalib/tests/coverage_gaps.rs
@@ -14,7 +14,6 @@ use noyalib::{
     load_all_as, load_all_with_config, to_string, to_string_multi, to_string_multi_with_config,
     to_string_with_config, to_value, to_writer, to_writer_with_config, try_load_all,
 };
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // from_slice: valid + invalid + UTF-8 error
@@ -30,7 +29,7 @@ fn from_slice_valid_yaml() {
 
 #[test]
 fn from_slice_typed_struct() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Cfg {
         name: String,
         port: u16,
@@ -78,7 +77,7 @@ fn from_reader_valid() {
 
 #[test]
 fn from_reader_typed() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Item {
         name: String,
     }
@@ -220,7 +219,7 @@ fn to_writer_roundtrip() {
 
 #[test]
 fn to_writer_struct() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Item {
         name: String,
         count: i32,
@@ -295,7 +294,7 @@ fn to_string_multi_with_config_flow() {
 fn flow_seq_serialize_roundtrip() {
     use noyalib::fmt::FlowSeq;
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
     struct Doc {
         tags: FlowSeq<Vec<String>>,
     }
@@ -338,7 +337,7 @@ fn flow_seq_debug() {
 fn flow_map_serialize_roundtrip() {
     use noyalib::fmt::FlowMap;
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
     struct Doc {
         meta: FlowMap<BTreeMap<String, i32>>,
     }
@@ -370,7 +369,7 @@ fn flow_map_deref_into_inner_from_debug() {
 fn lit_string_serialize() {
     use noyalib::fmt::LitString;
 
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         script: LitString,
     }
@@ -563,7 +562,7 @@ fn try_load_all_invalid() {
 
 #[test]
 fn load_all_as_typed() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Doc {
         name: String,
     }
@@ -889,7 +888,7 @@ fn location_from_index_at_newline() {
 
 #[test]
 fn spanned_unicode_location() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         name: Spanned<String>,
     }
@@ -913,7 +912,7 @@ fn spanned_from_value_returns_zero_locations() {
 
 #[test]
 fn spanned_nested_vec() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         items: Spanned<Vec<Spanned<String>>>,
     }

--- a/crates/noyalib/tests/coverage_loader.rs
+++ b/crates/noyalib/tests/coverage_loader.rs
@@ -6,7 +6,6 @@
 
 use noyalib::document::{load_all, load_all_as, load_all_with_config, try_load_all};
 use noyalib::{ParserConfig, Value};
-use serde::Deserialize;
 
 // ============================================================================
 // load_all
@@ -157,7 +156,7 @@ fn try_load_all_invalid() {
 
 #[test]
 fn load_all_as_basic() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         name: String,
     }

--- a/crates/noyalib/tests/coverage_loader_full.rs
+++ b/crates/noyalib/tests/coverage_loader_full.rs
@@ -10,11 +10,10 @@ use noyalib::{
     document::{load_all, load_all_as, load_all_with_config, try_load_all},
     from_str, from_str_with_config,
 };
-use serde::Deserialize;
 
 // ── Spanned<T> forces the span-aware AST loader (hits most error paths) ─
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct SpannedCfg {
     #[allow(dead_code)]
     name: Spanned<String>,
@@ -44,12 +43,12 @@ fn spanned_struct_recursion_limit_via_ast() {
 #[test]
 fn ast_depth_limit_enforced_on_deeply_nested_value() {
     // from_str::<Value> with Spanned forces AST.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Nested {
         #[allow(dead_code)]
         level: Spanned<i32>,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Outer {
         #[allow(dead_code)]
         inner: Nested,
@@ -63,7 +62,7 @@ fn ast_depth_limit_enforced_on_deeply_nested_value() {
 
 #[test]
 fn ast_duplicate_policy_first_keeps_first() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         a: Spanned<String>,
@@ -76,7 +75,7 @@ fn ast_duplicate_policy_first_keeps_first() {
 
 #[test]
 fn ast_duplicate_policy_last_keeps_last() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         a: Spanned<String>,
@@ -89,7 +88,7 @@ fn ast_duplicate_policy_last_keeps_last() {
 
 #[test]
 fn ast_duplicate_policy_error_rejects() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         a: Spanned<String>,
@@ -120,7 +119,7 @@ fn alias_outside_document_via_ast() {
 #[test]
 fn ast_unknown_anchor_error() {
     // Spanned forces AST; unknown alias should surface UnknownAnchorAt.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         #[allow(dead_code)]
         v: Spanned<String>,
@@ -136,7 +135,7 @@ fn ast_unknown_anchor_error() {
 fn ast_alias_expansion_count_limit() {
     let config = ParserConfig::new().max_alias_expansions(2);
     // Spanned to force AST path.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         anchor: Spanned<String>,
@@ -159,7 +158,7 @@ fn ast_mapping_key_limit_enforced() {
         yaml.push_str(&format!("key{i}: val{i}\n"));
     }
     // Value deser uses streaming; Spanned forces AST.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         key0: Spanned<String>,
@@ -177,7 +176,7 @@ fn ast_sequence_length_limit_enforced() {
     for i in 0..10 {
         yaml.push_str(&format!("  - {i}\n"));
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         items: Vec<Spanned<i32>>,
@@ -213,7 +212,7 @@ fn try_load_all_is_alias_for_load_all() {
 
 #[test]
 fn load_all_as_typed_struct() {
-    #[derive(Deserialize, Debug)]
+    #[derive(serde::Deserialize, Debug)]
     #[allow(dead_code)]
     struct Doc {
         name: String,
@@ -246,14 +245,14 @@ fn load_all_empty_stream_returns_empty() {
 
 #[test]
 fn ast_merge_key_single_anchor() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Target {
         a: Spanned<i32>,
         b: Spanned<i32>,
         c: Spanned<i32>,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         target: Target,
@@ -356,7 +355,7 @@ fn ast_anchor_on_mapping() {
 #[test]
 fn ast_spanned_in_multi_document() {
     let yaml = "---\nname: first\n---\nname: second\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         name: Spanned<String>,
@@ -381,7 +380,7 @@ fn ast_merge_empty_anchor() {
 
 #[test]
 fn ast_scalar_anchor_alias() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         a: Spanned<String>,
@@ -399,7 +398,7 @@ fn ast_scalar_anchor_alias() {
 fn ast_deep_sequence_hits_recursion_limit() {
     // Deep sequence through AST (Spanned forces it).
     let config = ParserConfig::new().max_depth(3);
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         deep: Spanned<Vec<Vec<Vec<Vec<i32>>>>>,
@@ -419,7 +418,7 @@ fn ast_alias_bytes_limit_hits_repetition() {
     for i in 0..20 {
         yaml.push_str(&format!("ref{i}: *a\n"));
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         anchor: Spanned<String>,

--- a/crates/noyalib/tests/coverage_misc.rs
+++ b/crates/noyalib/tests/coverage_misc.rs
@@ -19,7 +19,7 @@ mod diagnostic {
     use noyalib::Spanned;
     use noyalib::diagnostic::{spanned_error, spanned_error_with_context};
 
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct TwoFields {
         a: Spanned<String>,
         b: Spanned<i32>,
@@ -77,7 +77,7 @@ mod span_context {
     #[test]
     fn spanned_field_reports_location_of_value() {
         let yaml = "port: 8080\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Cfg {
             port: Spanned<u16>,
         }
@@ -94,11 +94,11 @@ mod span_context {
     #[test]
     fn spanned_in_nested_mapping() {
         let yaml = "outer:\n  inner: hello\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Inner {
             inner: Spanned<String>,
         }
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Outer {
             outer: Inner,
         }
@@ -112,7 +112,7 @@ mod span_context {
     #[test]
     fn spanned_in_sequence() {
         let yaml = "items:\n  - first\n  - second\n";
-        #[derive(Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Doc {
             items: Vec<Spanned<String>>,
         }
@@ -281,7 +281,7 @@ mod validated_extra {
     use garde::Validate;
     use noyalib::Validated;
 
-    #[derive(Debug, Deserialize, Validate)]
+    #[derive(Debug, serde::Deserialize, Validate)]
     struct Plain {
         #[garde(skip)]
         x: i32,

--- a/crates/noyalib/tests/coverage_regression.rs
+++ b/crates/noyalib/tests/coverage_regression.rs
@@ -11,7 +11,6 @@
 //!   * Duplicate-key policy `First` / `Last` / `Error` in the streaming path.
 
 use noyalib::{DuplicateKeyPolicy, ParserConfig, Value, from_str, from_str_with_config};
-use serde::Deserialize;
 use std::collections::BTreeMap;
 
 // ── Tagged-scalar resolution via AST fallback ────────────────────────────
@@ -190,7 +189,7 @@ second: &s
 target:
   <<: [*f, *s]
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         target: BTreeMap<String, i64>,
     }
@@ -203,7 +202,7 @@ target:
 #[test]
 fn merge_key_with_empty_anchor_target() {
     let yaml = "empty: &e {}\ntarget:\n  <<: *e\n  only: here\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         target: BTreeMap<String, String>,
     }

--- a/crates/noyalib/tests/coverage_remaining.rs
+++ b/crates/noyalib/tests/coverage_remaining.rs
@@ -17,7 +17,7 @@ use noyalib::{
     DuplicateKeyPolicy, Mapping, MappingAny, ParserConfig, Spanned, Tag, TaggedValue, Value,
     from_str, from_str_with_config, from_value, to_string,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 // ═══════════════════════════════════════════════════════════════════════
 // value.rs — TaggedValue Deserialize/Deserializer (lines 1446–1591)
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 // TaggedValueMapAccess, EnumAccess, and VariantAccess impls.
 // ═══════════════════════════════════════════════════════════════════════
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum Variant {
     Unit,
     Newtype(i32),
@@ -71,13 +71,13 @@ fn tagged_value_map_access_via_from_value() {
     // value.rs:1471-1477 (deserialize_any → TaggedValueMapAccess)
     // value.rs:1508-1526 (next_key_seed, next_value_seed)
     // Use singleton_map which routes through TaggedValue deserialization
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Blue,
     }
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Palette {
         #[serde(with = "noyalib::with::singleton_map")]
         color: Color,
@@ -169,7 +169,7 @@ fn value_deserializer_any_tagged() {
 #[test]
 fn value_deserializer_enum_string() {
     // value.rs:2799-2800 — enum from string
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Blue,
@@ -191,7 +191,7 @@ fn value_deserializer_enum_tagged() {
 #[test]
 fn value_deserializer_struct() {
     // value.rs:2828-2844 — deserialize_struct dispatches to deserialize_map
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Foo {
         x: i32,
         y: String,
@@ -216,7 +216,7 @@ fn value_deserializer_spanned_struct() {
     // de.rs:786-814 — SpannedMapAccess state machine
     // spanned.rs:117-156 — SpannedVisitor
     let yaml = "name: hello\ncount: 42";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         name: Spanned<String>,
         count: Spanned<i64>,
@@ -803,7 +803,7 @@ fn loader_large_integer_overflow() {
 #[test]
 fn deserialize_identifier_for_enum() {
     // de.rs:648-652
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Dir {
         North,
         South,
@@ -887,7 +887,7 @@ fn serialize_number_like_strings() {
 #[test]
 fn singleton_map_with_serialize_deserialize() {
     // singleton_map_with.rs:113-143, 175-189
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Action {
         GetRequest,
         PostData,
@@ -905,7 +905,7 @@ fn singleton_map_with_serialize_deserialize() {
         })
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Cmd {
         #[serde(serialize_with = "my_ser", deserialize_with = "my_de")]
         action: Action,
@@ -923,7 +923,7 @@ fn singleton_map_with_serialize_deserialize() {
 #[test]
 fn singleton_map_with_unit_variant() {
     // singleton_map_with.rs:134-139 — unit variant transform
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Flag {
         Active,
     }
@@ -943,7 +943,7 @@ fn singleton_map_with_unit_variant() {
         })
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         #[serde(serialize_with = "my_ser", deserialize_with = "my_de")]
         flag: Flag,
@@ -972,13 +972,13 @@ fn from_kebab_case_edge_cases() {
 #[test]
 fn singleton_map_recursive_tagged_value() {
     // singleton_map_recursive.rs:47-51
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Op {
         Add(i32),
         Sub(i32),
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Ops {
         #[serde(with = "noyalib::with::singleton_map_recursive")]
         ops: Vec<Op>,
@@ -1066,7 +1066,7 @@ fn merge_key_sequence_of_mappings() {
 #[test]
 fn spanned_nested_fields() {
     // spanned.rs:117-156, de.rs:786-814
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Item {
         name: Spanned<String>,
         value: Spanned<i64>,
@@ -1082,7 +1082,7 @@ fn spanned_nested_fields() {
 #[test]
 fn load_all_as_with_spans() {
     // loader.rs (public) — load_all_as exercises span context per doc
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         name: String,

--- a/crates/noyalib/tests/coverage_spanned_anchors.rs
+++ b/crates/noyalib/tests/coverage_spanned_anchors.rs
@@ -117,9 +117,7 @@ fn spanned_roundtrip_string() {
 
 #[test]
 fn spanned_in_struct() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         port: Spanned<u16>,
         name: Spanned<String>,
@@ -150,9 +148,7 @@ fn spanned_with_complex_inner() {
 
 #[test]
 fn spanned_nested_vec() {
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         items: Spanned<Vec<Spanned<String>>>,
     }
@@ -181,9 +177,7 @@ fn spanned_from_value_fallback() {
 
 #[test]
 fn spanned_multiline_document() {
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         first: Spanned<String>,
         second: Spanned<i64>,

--- a/crates/noyalib/tests/cst_schema_tag_audit.rs
+++ b/crates/noyalib/tests/cst_schema_tag_audit.rs
@@ -70,8 +70,8 @@ fn cst_coerce_to_schema_through_tagged_value() {
 #[test]
 fn schema_for_yaml_emits_tagged_value_correctly() {
     use noyalib::{JsonSchema, schema_for_yaml};
-    use serde::{Deserialize, Serialize};
-    #[derive(Serialize, Deserialize, JsonSchema)]
+
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Cfg {
         port: u16,

--- a/crates/noyalib/tests/de.rs
+++ b/crates/noyalib/tests/de.rs
@@ -173,7 +173,7 @@ fn test_mapping_inline() {
 // Struct Tests
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct SimpleStruct {
     name: String,
     value: i32,
@@ -189,7 +189,7 @@ fn test_simple_struct() {
     test_de(yaml, &expected);
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct NestedStruct {
     outer: String,
     inner: SimpleStruct,
@@ -208,7 +208,7 @@ fn test_nested_struct() {
     test_de(yaml, &expected);
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct OptionalFields {
     required: String,
     optional: Option<String>,
@@ -248,7 +248,7 @@ fn test_optional_null() {
 // Enum Tests
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum UnitEnum {
     A,
     B,
@@ -262,7 +262,7 @@ fn test_unit_enum() {
     test_de(yaml, &expected);
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum NewtypeEnum {
     Text(String),
     Number(i32),
@@ -279,7 +279,7 @@ fn test_newtype_enum() {
     test_de(yaml, &expected);
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum StructEnum {
     Point { x: i32, y: i32 },
     Named { name: String },
@@ -347,7 +347,7 @@ fn test_type_mismatch_error() {
 // Complex Structure Tests
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Config {
     name: String,
     version: u32,
@@ -420,7 +420,7 @@ fn test_empty_mapping() {
 #[test]
 fn test_multiline_literal() {
     let yaml = "text: |\n  line1\n  line2\n";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         text: String,
     }
@@ -436,7 +436,7 @@ fn test_multiline_literal() {
 #[test]
 fn test_unicode() {
     let yaml = "text: 日本語\n";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         text: String,
     }
@@ -447,7 +447,7 @@ fn test_unicode() {
 #[test]
 fn test_emoji() {
     let yaml = "emoji: 🎉\n";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         emoji: String,
     }
@@ -462,7 +462,7 @@ fn test_emoji() {
 #[test]
 fn test_from_slice() {
     let yaml = b"name: test\nvalue: 42\n";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         name: String,
         value: i32,
@@ -484,7 +484,7 @@ fn test_from_reader() {
     use std::io::Cursor;
     let yaml = "key: value\n";
     let reader = Cursor::new(yaml);
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         key: String,
     }
@@ -502,7 +502,7 @@ fn test_empty_yaml() {
 #[test]
 fn test_char_deserialization() {
     let yaml = "c: a\n";
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         c: char,
     }
@@ -518,7 +518,7 @@ fn test_unit_deserialization() {
 
 #[test]
 fn test_unit_struct_deserialization() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct UnitStruct;
 
     let yaml = "null\n";
@@ -527,7 +527,7 @@ fn test_unit_struct_deserialization() {
 
 #[test]
 fn test_newtype_struct() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Wrapper(i32);
 
     let yaml = "42\n";
@@ -544,7 +544,7 @@ fn test_tuple_deserialization() {
 
 #[test]
 fn test_tuple_struct() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Point(i32, i32);
 
     let yaml = "- 10\n- 20\n";
@@ -554,7 +554,7 @@ fn test_tuple_struct() {
 
 #[test]
 fn test_ignored_any() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Partial {
         keep: String,
         #[serde(skip)]
@@ -569,7 +569,7 @@ fn test_ignored_any() {
 #[test]
 fn test_sequence_of_bytes() {
     let yaml = "data: [104, 101, 108, 108, 111]\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         data: Vec<u8>,
     }
@@ -579,7 +579,7 @@ fn test_sequence_of_bytes() {
 
 #[test]
 fn test_enum_unit_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Green,
@@ -593,7 +593,7 @@ fn test_enum_unit_variant() {
 
 #[test]
 fn test_enum_tuple_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Message {
         Move { x: i32, y: i32 },
         Write(String),
@@ -607,7 +607,7 @@ fn test_enum_tuple_variant() {
 
 #[test]
 fn test_enum_struct_variant() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Shape {
         Rectangle { width: u32, height: u32 },
         Circle { radius: u32 },
@@ -713,7 +713,7 @@ fn test_deserialize_type_mismatch() {
 
 #[test]
 fn test_missing_field() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Required {
         name: String,
@@ -727,7 +727,7 @@ fn test_missing_field() {
 
 #[test]
 fn test_unknown_field_ignored() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Known {
         name: String,
     }
@@ -761,7 +761,7 @@ fn test_from_value_struct() {
     let _ = map.insert("value".to_string(), Value::Number(Number::Integer(42)));
     let value = Value::Mapping(map);
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         name: String,
         value: i32,
@@ -872,7 +872,7 @@ fn test_deserialize_negative_float_to_u64_fails() {
 
 #[test]
 fn test_deserialize_identifier() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     #[serde(rename_all = "lowercase")]
     enum Status {
         Active,
@@ -886,7 +886,7 @@ fn test_deserialize_identifier() {
 
 #[test]
 fn test_deserialize_enum_invalid_variant() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     enum Color {
         Red,
         Green,
@@ -900,7 +900,7 @@ fn test_deserialize_enum_invalid_variant() {
 
 #[test]
 fn test_deserialize_struct_with_extra_fields() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Simple {
         name: String,
     }
@@ -912,7 +912,7 @@ fn test_deserialize_struct_with_extra_fields() {
 
 #[test]
 fn test_deserialize_option_explicit_null() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Doc {
         value: Option<i32>,
     }
@@ -966,7 +966,7 @@ fn test_unit_type_mismatch() {
 #[test]
 fn test_enum_type_mismatch_on_sequence() {
     // Enum requires string or single-key map
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     enum Status {
         Active,
         Inactive,
@@ -1009,7 +1009,7 @@ fn test_deserialize_tagged_inner_value() {
 
 #[test]
 fn test_deserialize_enum_tuple_variant_from_map() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Data {
         Pair(i32, i32),
     }

--- a/crates/noyalib/tests/de_coverage_extra.rs
+++ b/crates/noyalib/tests/de_coverage_extra.rs
@@ -34,7 +34,7 @@ use serde::de::Deserializer as _;
 // from_str_strict / from_slice_strict / from_reader_strict — happy + error
 // ============================================================================
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct StrictCfg {
     port: u16,
 }
@@ -168,7 +168,7 @@ fn deserializer_str_mismatch_errors() {
 // Deserializer for bytes / byte_buf — !!binary path & errors (L1692, L1694)
 // ============================================================================
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Bin {
     #[serde(with = "serde_bytes")]
     data: Vec<u8>,
@@ -224,7 +224,7 @@ fn deserializer_bytes_other_value_errors() {
 fn deserialize_str_with_ignore_binary_tag_for_string_succeeds() {
     let yaml = "data: !!binary aGVsbG8=\n";
     let cfg = ParserConfig::default().ignore_binary_tag_for_string(true);
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct S {
         data: String,
     }
@@ -277,7 +277,7 @@ fn deserialize_map_mismatch_errors() {
 // deserialize_enum — fall-through / errors (L1851-L1854, L1864)
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum E {
     A,
     B,
@@ -342,7 +342,7 @@ fn deserialize_ignored_any_consumes_anything() {
 #[test]
 fn deserialize_spanned_struct_path() {
     use noyalib::Spanned;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct S {
         n: Spanned<i32>,
     }
@@ -366,7 +366,7 @@ fn preserve_tags_value_target_round_trip() {
 // VariantAccess — tuple/struct/newtype variants (L2003, L2021-L2022)
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum Choice {
     Plain,
     NewType(i32),
@@ -435,7 +435,7 @@ fn binary_tag_all_forms_decode() {
 
 #[test]
 fn wrap_err_type_mismatch_in_struct_field_attaches_location() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct S {
         n: i32,

--- a/crates/noyalib/tests/de_streaming_branch_extra.rs
+++ b/crates/noyalib/tests/de_streaming_branch_extra.rs
@@ -21,9 +21,8 @@
 use std::collections::BTreeMap;
 
 use noyalib::{Mapping, ParserConfig, Value, from_str, from_str_with_config, from_value};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Cfg {
     name: String,
     port: u16,
@@ -72,7 +71,7 @@ fn branch_de_float_to_u64_negative_errors() {
 
 // ── de.rs: enum from single-key mapping (struct variant) ───────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum Choice {
     Plain,
     Pair { a: i32, b: i32 },
@@ -223,7 +222,7 @@ combined:
 
 // ── streaming.rs: typed deserialise with anchor + alias ───────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct WithAnchor {
     base: String,
     alias_to_base: String,

--- a/crates/noyalib/tests/dup_key_spans.rs
+++ b/crates/noyalib/tests/dup_key_spans.rs
@@ -13,7 +13,6 @@
 
 use noyalib::cst::parse_document;
 use noyalib::{Spanned, from_str};
-use serde::Deserialize;
 
 /// Parse `src`, resolve `path`, and return the raw source slice the
 /// span denotes.
@@ -147,7 +146,7 @@ fn remove_of_a_duplicated_key_targets_the_typed_view_occurrence() {
 
 #[test]
 fn spanned_fields_stay_aligned_after_duplicate_key() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         k: Spanned<String>,
         z: Spanned<i64>,

--- a/crates/noyalib/tests/edge_audit.rs
+++ b/crates/noyalib/tests/edge_audit.rs
@@ -6,7 +6,6 @@
 //! work but weren't covered by the headline phases.
 
 use noyalib::{Spanned, Tag, TaggedValue, Value, from_str, from_value, to_string_value};
-use serde::Deserialize;
 
 // 1) Round-trip a Tagged scalar via to_string.
 #[test]
@@ -86,7 +85,7 @@ fn from_value_value_identity_with_tagged() {
 }
 
 // 5) Typed deserialise sees through tag (the contract for
-// `#[derive(Deserialize)]` targets).
+// `#[derive(serde::Deserialize)]` targets).
 #[test]
 fn typed_target_sees_through_tagged_collection() {
     use std::collections::HashMap;
@@ -116,7 +115,7 @@ fn typed_target_sees_through_tagged_collection() {
 // (and document the new contract in the migration guide).
 #[test]
 fn spanned_value_with_tagged_scalar_known_limitation() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Cfg {
         value: Spanned<Value>,
     }

--- a/crates/noyalib/tests/edge_cases.rs
+++ b/crates/noyalib/tests/edge_cases.rs
@@ -6,7 +6,6 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{Value, from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // Number Edge Cases
@@ -470,7 +469,7 @@ name: test
 
 #[test]
 fn test_type_mismatch_error() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Typed {
         count: i32,
@@ -483,7 +482,7 @@ fn test_type_mismatch_error() {
 
 #[test]
 fn test_missing_required_field_error() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Required {
         name: String,
@@ -523,7 +522,7 @@ fn test_error_location() {
 
 #[test]
 fn test_serialize_option_none() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct WithOption {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -540,7 +539,7 @@ fn test_serialize_option_none() {
 
 #[test]
 fn test_serialize_option_some() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct WithOption {
         name: String,
         optional: Option<i32>,
@@ -557,7 +556,7 @@ fn test_serialize_option_some() {
 
 #[test]
 fn test_serialize_unit_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct UnitStruct;
 
     let value = UnitStruct;
@@ -568,7 +567,7 @@ fn test_serialize_unit_struct() {
 
 #[test]
 fn test_serialize_newtype_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper(i32);
 
     let value = Wrapper(42);
@@ -579,7 +578,7 @@ fn test_serialize_newtype_struct() {
 
 #[test]
 fn test_serialize_tuple_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Point(i32, i32);
 
     let value = Point(10, 20);
@@ -590,7 +589,7 @@ fn test_serialize_tuple_struct() {
 
 #[test]
 fn test_serialize_enum_variants() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum MyEnum {
         Unit,
         Newtype(i32),

--- a/crates/noyalib/tests/figment_provider.rs
+++ b/crates/noyalib/tests/figment_provider.rs
@@ -13,9 +13,8 @@
 use figment::Figment;
 use figment::providers::Format;
 use noyalib::figment::Yaml;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Cfg {
     name: String,
     port: u16,
@@ -104,12 +103,12 @@ fn missing_required_field_surfaces_clear_error() {
 
 #[test]
 fn nested_struct_round_trip() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Db {
         url: String,
         pool_size: u16,
     }
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct App {
         name: String,
         db: Db,
@@ -138,7 +137,7 @@ db:
 fn anchor_and_alias_resolved_through_provider() {
     // The provider must honour YAML 1.2 anchor / alias semantics —
     // `<<: *anchor` should produce a merged mapping when extracted.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Service {
         host: String,
         port: u16,

--- a/crates/noyalib/tests/flatten_value.rs
+++ b/crates/noyalib/tests/flatten_value.rs
@@ -19,11 +19,10 @@
 #![allow(missing_docs)]
 
 use noyalib::{Spanned, Value, from_str};
-use serde::{Deserialize, Serialize};
 
 // ── Supported: flatten Value ─────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
 struct Config {
     name: String,
     version: String,
@@ -83,7 +82,7 @@ fn flatten_value_with_no_residue() {
 
 // ── Documented limitation: flatten Spanned<Value> ────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct ConfigSpanned {
     #[allow(dead_code)]
     name: String,
@@ -119,7 +118,7 @@ port: 8080
 
 // ── Spanned<Value> in regular (non-flatten) position ─────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct WithSpannedField {
     name: String,
     extra: Spanned<Value>,
@@ -163,7 +162,7 @@ fn spanned_value_for_scalar() {
     // whichever variant the YAML produced.
     let yaml = "name: noyalib\nport: 8080\n";
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Sc {
         #[allow(dead_code)]
         name: String,

--- a/crates/noyalib/tests/flattened_capture.rs
+++ b/crates/noyalib/tests/flattened_capture.rs
@@ -7,15 +7,14 @@
 #![allow(missing_docs)]
 
 use noyalib::{Flattened, Value, from_str, to_string};
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
 struct Inner {
     port: u16,
     host: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
 struct Config {
     name: String,
     inner: Flattened<Inner>,
@@ -87,7 +86,7 @@ fn flatten_attribute_works_with_wrapper() {
     // pointing at a `Flattened<T>` field. The wrapper captures
     // every residue key the source supplied, so callers see the
     // typed view AND the raw extras.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Outer {
         version: u8,
         #[serde(flatten)]
@@ -124,7 +123,7 @@ debug: true
 
 #[test]
 fn flattened_inside_sequence() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Item {
         id: u32,

--- a/crates/noyalib/tests/fmt.rs
+++ b/crates/noyalib/tests/fmt.rs
@@ -9,7 +9,6 @@ use noyalib::fmt::{
     Commented, FlowMap, FlowSeq, FoldStr, FoldString, LitStr, LitString, SpaceAfter,
 };
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 #[test]
 fn test_flow_seq_serialize() {
@@ -79,7 +78,7 @@ fn test_fold_string_deserialize() {
 
 #[test]
 fn test_flow_seq_in_struct() {
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
     struct Config {
         tags: FlowSeq<Vec<String>>,
     }
@@ -98,7 +97,7 @@ fn test_flow_seq_in_struct() {
 
 #[test]
 fn test_flow_map_in_struct() {
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
     struct Config {
         env: FlowMap<BTreeMap<String, String>>,
     }

--- a/crates/noyalib/tests/include_directive.rs
+++ b/crates/noyalib/tests/include_directive.rs
@@ -145,8 +145,7 @@ fn non_string_spec_errors() {
 
 #[test]
 fn typed_target_sees_substituted_value() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Server {
         host: String,
         port: u16,
@@ -155,7 +154,7 @@ fn typed_target_sees_substituted_value() {
     let _ = files.insert("server.yaml", "host: db.local\nport: 5432\n");
     let cfg = ParserConfig::new().include_resolver(mem_resolver(files));
     let yaml = "server: !include server.yaml\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Root {
         server: Server,
     }

--- a/crates/noyalib/tests/issue_46.rs
+++ b/crates/noyalib/tests/issue_46.rs
@@ -165,10 +165,9 @@ fn pnpm_lockfile_50000_pkgs_does_not_recursion_limit() {
 /// migrate to when leaving `serde_yml`.
 #[test]
 fn pnpm_lockfile_typed_struct_parses_with_default_config() {
-    use serde::Deserialize;
     use std::collections::BTreeMap;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Lockfile {
         #[serde(rename = "lockfileVersion")]

--- a/crates/noyalib/tests/legacy_sexagesimal.rs
+++ b/crates/noyalib/tests/legacy_sexagesimal.rs
@@ -135,8 +135,7 @@ fn does_not_misinterpret_iso_timestamps_as_sexagesimal() {
 
 #[test]
 fn typed_deserialize_minutes_seconds() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         timeout: u64,
     }

--- a/crates/noyalib/tests/merge_keys_streaming.rs
+++ b/crates/noyalib/tests/merge_keys_streaming.rs
@@ -9,14 +9,13 @@
 //! AST path — these tests verify correctness on both paths.
 
 use noyalib::from_str;
-use serde::Deserialize;
 use std::collections::BTreeMap;
 
 // ── Native: single-anchor merge at start of mapping ──────────────────────
 
 #[test]
 fn native_merge_at_start_single_anchor() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Cfg {
         timeout: u32,
         retries: u32,
@@ -30,7 +29,7 @@ server:
   <<: *d
   host: example.com
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         server: Cfg,
     }
@@ -42,7 +41,7 @@ server:
 
 #[test]
 fn native_merge_local_key_overrides_merged() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Cfg {
         host: String,
         port: u16,
@@ -55,7 +54,7 @@ server:
   <<: *b
   host: override.local
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         server: Cfg,
     }
@@ -89,7 +88,7 @@ target:
   <<: *e
   only: here
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         target: BTreeMap<String, String>,
     }
@@ -100,12 +99,12 @@ target:
 
 #[test]
 fn native_merge_preserves_merged_nested_value() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Limits {
         max: u32,
         min: u32,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         limits: Limits,
         name: String,
@@ -119,7 +118,7 @@ target:
   <<: *b
   name: test
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         target: Cfg,
     }
@@ -136,7 +135,7 @@ fn fallback_locals_before_merge_still_correct() {
     // `host` appears BEFORE the merge, so native path would let the merged
     // `host` override the local (wrong). We fall back to the AST which
     // implements correct "local wins" semantics.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Cfg {
         host: String,
         port: u16,
@@ -149,7 +148,7 @@ server:
   host: local.local
   <<: *b
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         server: Cfg,
     }
@@ -161,7 +160,7 @@ server:
 #[test]
 fn fallback_sequence_merge_still_correct() {
     // `<<: [*a, *b]` is not handled by native path, falls back.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Cfg {
         a: u32,
         b: u32,
@@ -177,7 +176,7 @@ src2: &s2
 target:
   <<: [*s1, *s2]
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         target: Cfg,
     }
@@ -197,12 +196,12 @@ target:
   <<: *missing
   host: x
 "#;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Cfg {
         host: String,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         target: Cfg,
@@ -224,7 +223,7 @@ target:
 #[test]
 fn roundtrip_after_native_merge() {
     use noyalib::to_string;
-    #[derive(Debug, Deserialize, serde::Serialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
     struct Cfg {
         host: String,
         port: u16,
@@ -236,7 +235,7 @@ base: &b
 target:
   <<: *b
 "#;
-    #[derive(Deserialize, serde::Serialize)]
+    #[derive(serde::Deserialize, serde::Serialize)]
     struct Doc {
         target: Cfg,
     }
@@ -260,7 +259,7 @@ one:
 two:
   <<: *bb
 "#;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         one: BTreeMap<String, i64>,
         two: BTreeMap<String, i64>,

--- a/crates/noyalib/tests/parser_coverage_extra.rs
+++ b/crates/noyalib/tests/parser_coverage_extra.rs
@@ -16,7 +16,6 @@ use noyalib::{
     BudgetBreach, DuplicateKeyPolicy, Error, MergeKeyPolicy, ParserConfig, Spanned, Value,
     document::load_all_with_config, from_str, from_str_with_config,
 };
-use serde::Deserialize;
 
 // ════════════════════════════════════════════════════════════════════
 // scanner.rs
@@ -465,7 +464,7 @@ fn parser_scanner_directive_with_trailing_comment() {
 // ════════════════════════════════════════════════════════════════════
 
 // Helper struct that forces the AST loader path via `Spanned`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct AstDoc {
     a: Spanned<i64>,
@@ -487,7 +486,7 @@ fn parser_loader_max_total_scalar_bytes_breach() {
     let big = "x".repeat(2_000);
     let yaml = format!("a: '{big}'\nb: '{big}'\n");
     let cfg = ParserConfig::new().max_total_scalar_bytes(1_000);
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         a: Spanned<String>,
@@ -519,7 +518,7 @@ fn parser_loader_alias_anchor_ratio_breach() {
     let cfg = ParserConfig::new()
         .alias_anchor_ratio(Some(2.0))
         .max_alias_expansions(1_000);
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         anchor: Spanned<i64>,
@@ -535,7 +534,7 @@ fn parser_loader_alias_anchor_ratio_breach() {
 #[test]
 fn parser_loader_unknown_alias_at_errors() {
     let yaml = "v: *missing\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         v: Spanned<String>,
@@ -586,7 +585,7 @@ fn parser_loader_merge_key_policy_as_ordinary_keeps_key() {
 #[test]
 fn parser_loader_anchor_on_tagged_scalar() {
     let yaml = "anchor: &a !!int 42\nuse: *a\n";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         anchor: Spanned<i64>,

--- a/crates/noyalib/tests/phase2.rs
+++ b/crates/noyalib/tests/phase2.rs
@@ -6,7 +6,6 @@
 use std::collections::BTreeMap;
 
 use noyalib::{Value, from_str, load_all, load_all_as, try_load_all};
-use serde::Deserialize;
 
 // ============================================================================
 // Anchor and Alias Tests
@@ -196,7 +195,7 @@ fn test_try_load_all() {
 
 #[test]
 fn test_load_all_as_typed() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Config {
         name: String,
         value: i32,

--- a/crates/noyalib/tests/phase3.rs
+++ b/crates/noyalib/tests/phase3.rs
@@ -6,20 +6,19 @@
 use std::collections::BTreeMap;
 
 use noyalib::{from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // singleton_map Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Action {
     Start,
     Stop,
     Restart { delay: u32 },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Task {
     name: String,
     #[serde(with = "noyalib::with::singleton_map")]
@@ -57,7 +56,7 @@ fn test_singleton_map_struct_variant() {
 // singleton_map_optional Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct OptionalTask {
     name: String,
     #[serde(
@@ -113,14 +112,14 @@ fn test_singleton_map_optional_struct_variant() {
 // singleton_map_recursive Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Status {
     Active,
     Inactive,
     Error { code: i32 },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct ServiceList {
     name: String,
     #[serde(with = "noyalib::with::singleton_map_recursive")]
@@ -139,7 +138,7 @@ fn test_singleton_map_recursive_vec() {
     assert_eq!(parsed, list);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct ServiceMap {
     name: String,
     #[serde(with = "noyalib::with::singleton_map_recursive")]
@@ -166,7 +165,7 @@ fn test_singleton_map_recursive_map() {
 // nested_singleton_map Alias Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct AliasTest {
     #[serde(with = "noyalib::with::nested_singleton_map")]
     items: Vec<Status>,
@@ -187,14 +186,14 @@ fn test_nested_singleton_map_alias() {
 // Complex Nested Structures
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Command {
     Run { script: String },
     Wait { seconds: u32 },
     Parallel(Vec<Command>),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Pipeline {
     name: String,
     #[serde(with = "noyalib::with::singleton_map_recursive")]
@@ -242,14 +241,14 @@ fn test_empty_collections() {
     assert_eq!(parsed, list);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Mixed {
     StringVal(String),
     IntVal(i32),
     Nested { inner: Box<Mixed> },
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct MixedContainer {
     #[serde(with = "noyalib::with::singleton_map")]
     value: Mixed,

--- a/crates/noyalib/tests/phase4.rs
+++ b/crates/noyalib/tests/phase4.rs
@@ -4,13 +4,12 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{SerializerConfig, Value, from_str, to_string, to_string_with_config};
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // SerializerConfig Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct SimpleConfig {
     name: String,
     port: u16,
@@ -74,12 +73,12 @@ fn test_both_document_markers() {
     assert!(yaml.ends_with("\n..."));
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Nested {
     outer: Inner,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Inner {
     value: i32,
 }
@@ -118,7 +117,7 @@ fn test_custom_indent_4() {
 // Block Scalar Tests
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct ScriptConfig {
     name: String,
     script: String,
@@ -236,7 +235,7 @@ fn test_full_config_combination() {
 
 #[test]
 fn test_empty_string_not_block() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Empty {
         value: String,
     }
@@ -266,17 +265,17 @@ fn test_config_builder_chaining() {
     assert_eq!(config.block_scalar_threshold, 2);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct DeepNested {
     level1: Level1,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Level1 {
     level2: Level2,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Level2 {
     value: String,
 }

--- a/crates/noyalib/tests/properties_interpolation.rs
+++ b/crates/noyalib/tests/properties_interpolation.rs
@@ -103,8 +103,7 @@ fn strict_config_defaults_strict_properties_true() {
 
 #[test]
 fn typed_target_sees_substituted_value() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         url: String,
     }

--- a/crates/noyalib/tests/read_iterator.rs
+++ b/crates/noyalib/tests/read_iterator.rs
@@ -19,10 +19,9 @@
 #![allow(clippy::unwrap_used)]
 
 use noyalib::{DocumentReadIterator, ParserConfig, Value, read, read_with_config};
-use serde::Deserialize;
 use std::io::Cursor;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Doc {
     id: u32,
     name: String,

--- a/crates/noyalib/tests/scalar_resolution_toggles.rs
+++ b/crates/noyalib/tests/scalar_resolution_toggles.rs
@@ -125,8 +125,8 @@ fn typed_deserialization_respects_no_schema() {
     // When no_schema is on, a `port: 8080` line surfaces as a
     // string. Asking for `u16` should error — the user must quote
     // intent or the schema breaks. This is the contract.
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+
+    #[derive(Debug, serde::Deserialize)]
     struct Cfg {
         #[allow(dead_code)]
         port: u16,
@@ -141,8 +141,7 @@ fn typed_deserialization_respects_no_schema() {
 
 #[test]
 fn typed_deserialization_with_legacy_octal_round_trip() {
-    use serde::Deserialize;
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Perms {
         umask: i64,
     }

--- a/crates/noyalib/tests/schema_codegen.rs
+++ b/crates/noyalib/tests/schema_codegen.rs
@@ -13,9 +13,8 @@
 #![allow(missing_docs)]
 
 use noyalib::{JsonSchema, Value, from_str, schema_for, schema_for_yaml};
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct ServerConfig {
     /// Port the server binds on.
@@ -85,14 +84,14 @@ fn integer_bounds_are_emitted_for_fixed_width_ints() {
 
 // ── Nested types ────────────────────────────────────────────────────
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct Database {
     host: String,
     port: u16,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 #[allow(dead_code)]
 struct App {
     name: String,
@@ -112,7 +111,7 @@ fn nested_types_are_emitted_via_definitions() {
 
 // ── Enums ────────────────────────────────────────────────────────────
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 #[allow(dead_code)]
 #[serde(rename_all = "lowercase")]
 enum LogLevel {
@@ -129,7 +128,7 @@ enum LogLevel {
 fn json_schema_for_value_field() {
     use noyalib::Value;
 
-    #[derive(Deserialize, JsonSchema)]
+    #[derive(serde::Deserialize, JsonSchema)]
     #[allow(dead_code)]
     struct Envelope {
         id: String,

--- a/crates/noyalib/tests/schema_validate.rs
+++ b/crates/noyalib/tests/schema_validate.rs
@@ -151,9 +151,7 @@ fn malformed_schema_distinguished_from_data_error() {
 
 #[test]
 fn validate_data_against_schemars_emitted_schema() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Serialize, Deserialize, noyalib::JsonSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, noyalib::JsonSchema)]
     #[allow(dead_code)]
     struct ServerConfig {
         port: u16,

--- a/crates/noyalib/tests/ser.rs
+++ b/crates/noyalib/tests/ser.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeMap;
 
 use noyalib::{Mapping, Number, SerializerConfig, Value, to_string};
-use serde::Serialize;
 
 // ============================================================================
 // Basic Type Tests
@@ -112,7 +111,7 @@ fn test_serialize_empty_map() {
 // Struct Tests
 // ============================================================================
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct SimpleStruct {
     name: String,
     value: i32,
@@ -129,7 +128,7 @@ fn test_serialize_simple_struct() {
     assert!(yaml.contains("value: 42") || yaml.contains("value:"));
 }
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct NestedStruct {
     outer: String,
     inner: SimpleStruct,
@@ -149,7 +148,7 @@ fn test_serialize_nested_struct() {
     assert!(yaml.contains("inner:"));
 }
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct OptionalFields {
     required: String,
     optional: Option<String>,
@@ -181,7 +180,7 @@ fn test_serialize_optional_none() {
 // Enum Tests
 // ============================================================================
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 #[allow(dead_code)]
 enum UnitEnum {
     A,
@@ -195,7 +194,7 @@ fn test_serialize_unit_enum() {
     assert!(yaml.contains("A"));
 }
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 enum NewtypeEnum {
     Text(String),
     Number(i32),
@@ -212,7 +211,7 @@ fn test_serialize_newtype_enum() {
     assert!(yaml.contains("42"));
 }
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 enum StructEnum {
     Point { x: i32, y: i32 },
 }
@@ -229,7 +228,7 @@ fn test_serialize_struct_enum() {
 // Complex Structure Tests
 // ============================================================================
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct Config {
     name: String,
     version: u32,
@@ -289,9 +288,8 @@ fn test_serialize_emoji() {
 #[test]
 fn test_roundtrip_simple() {
     use noyalib::from_str;
-    use serde::Deserialize;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Data {
         name: String,
         value: i32,
@@ -310,15 +308,14 @@ fn test_roundtrip_simple() {
 #[test]
 fn test_roundtrip_nested() {
     use noyalib::from_str;
-    use serde::Deserialize;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Inner {
         x: i32,
         y: i32,
     }
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Outer {
         name: String,
         inner: Inner,
@@ -339,9 +336,8 @@ fn test_roundtrip_nested() {
 #[test]
 fn test_roundtrip_collections() {
     use noyalib::from_str;
-    use serde::Deserialize;
 
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Data {
         items: Vec<i32>,
         lookup: BTreeMap<String, String>,
@@ -368,7 +364,7 @@ fn test_roundtrip_collections() {
 
 #[test]
 fn test_serialize_to_writer() {
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, serde::Serialize)]
     struct Data {
         name: String,
         value: i32,
@@ -389,7 +385,7 @@ fn test_serialize_to_writer() {
 
 #[test]
 fn test_serialize_with_config() {
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, serde::Serialize)]
     struct Data {
         name: String,
     }
@@ -413,7 +409,7 @@ fn test_serialize_with_config() {
 
 #[test]
 fn test_serialize_to_writer_with_config() {
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, serde::Serialize)]
     struct Data {
         name: String,
     }
@@ -452,7 +448,7 @@ fn test_serialize_unit() {
 
 #[test]
 fn test_serialize_unit_struct() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct UnitStruct;
 
     let yaml = to_string(&UnitStruct).unwrap();
@@ -461,7 +457,7 @@ fn test_serialize_unit_struct() {
 
 #[test]
 fn test_serialize_newtype_struct() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Wrapper(i32);
 
     let wrapper = Wrapper(42);
@@ -480,7 +476,7 @@ fn test_serialize_tuple() {
 
 #[test]
 fn test_serialize_tuple_struct() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Point(i32, i32);
 
     let point = Point(10, 20);
@@ -491,7 +487,7 @@ fn test_serialize_tuple_struct() {
 
 #[test]
 fn test_serialize_enum_unit_variant() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum Color {
         Red,
     }
@@ -502,7 +498,7 @@ fn test_serialize_enum_unit_variant() {
 
 #[test]
 fn test_serialize_enum_tuple_variant() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum Message {
         Write(String),
     }
@@ -515,7 +511,7 @@ fn test_serialize_enum_tuple_variant() {
 
 #[test]
 fn test_serialize_enum_struct_variant() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum Shape {
         Rectangle { width: u32, height: u32 },
     }
@@ -602,7 +598,7 @@ fn test_serialize_floats_precision() {
 
 #[test]
 fn test_to_value() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Data {
         name: String,
         value: i32,
@@ -809,7 +805,7 @@ fn test_serialize_sequence_with_nested_sequence() {
 
 #[test]
 fn test_serialize_bytes_array() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct WithBytes<'a> {
         #[serde(with = "serde_bytes")]
         data: &'a [u8],

--- a/crates/noyalib/tests/ser_cst_coverage_extra.rs
+++ b/crates/noyalib/tests/ser_cst_coverage_extra.rs
@@ -26,7 +26,6 @@ use noyalib::{
     to_writer_tracking_shared_with_config, to_writer_value, to_writer_value_with_config,
     to_writer_with_config,
 };
-use serde::Serialize;
 
 // ============================================================================
 // ser.rs — `to_string_with_config` / `to_writer_*` thin wrappers
@@ -177,7 +176,7 @@ fn ser_ser_anchor_tagged_block_mapping_value() {
     // Drives 1117-1122 (mapping value with MAGIC_ANCHOR_DEF needing
     // space after `:`) and 1213-1219 (anchor wrapping a non-empty
     // mapping → newline + write_mapping with is_root=true).
-    #[derive(Clone, Serialize)]
+    #[derive(Clone, serde::Serialize)]
     struct Inner {
         a: i32,
         b: i32,
@@ -303,7 +302,7 @@ fn ser_ser_magic_commented_non_sequence_value_falls_through() {
 #[test]
 fn ser_ser_flow_seq_newtype() {
     // Drives 1523-1532: serialize_newtype_struct with MAGIC_FLOW_SEQ.
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         items: FlowSeq<Vec<i32>>,
     }
@@ -319,7 +318,7 @@ fn ser_ser_flow_map_newtype() {
     let mut m = BTreeMap::new();
     let _ = m.insert("a".to_string(), 1i32);
     let _ = m.insert("b".to_string(), 2);
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         flow: FlowMap<BTreeMap<String, i32>>,
     }
@@ -329,7 +328,7 @@ fn ser_ser_flow_map_newtype() {
 
 #[test]
 fn ser_ser_lit_string_newtype() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         body: LitString,
     }
@@ -342,7 +341,7 @@ fn ser_ser_lit_string_newtype() {
 
 #[test]
 fn ser_ser_fold_string_newtype() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         body: FoldString,
     }
@@ -363,7 +362,7 @@ fn ser_ser_commented_newtype() {
 
 #[test]
 fn ser_ser_space_after_newtype() {
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         a: SpaceAfter<i32>,
         b: i32,
@@ -383,7 +382,7 @@ fn ser_ser_space_after_newtype() {
 #[test]
 fn ser_ser_newtype_variant() {
     // Drives 1565-1567 (serialize_newtype_variant).
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum E {
         N(i32),
     }
@@ -395,7 +394,7 @@ fn ser_ser_newtype_variant() {
 #[test]
 fn ser_ser_tuple_variant() {
     // Drives 1696 (SerializeTupleVariant::serialize_field).
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum E {
         T(i32, i32, i32),
     }
@@ -406,7 +405,7 @@ fn ser_ser_tuple_variant() {
 #[test]
 fn ser_ser_struct_variant() {
     // Drives 1786 (SerializeStructVariant::serialize_field).
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     enum E {
         S { x: i32, y: i32 },
     }
@@ -465,7 +464,7 @@ fn ser_ser_flow_style_auto_threshold_below_uses_flow() {
 #[test]
 fn ser_ser_compact_list_indent_branch() {
     // Drives 1130-1135: compact_list_indent toggling sequence next_indent.
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         items: Vec<i32>,
     }
@@ -653,7 +652,7 @@ fn ser_ser_recursion_limit_triggers_error() {
 #[test]
 fn ser_ser_flow_sequence_two_elements_emits_comma() {
     // Drives the `i > 0` branch in write_flow_sequence.
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         items: FlowSeq<Vec<i32>>,
     }
@@ -669,7 +668,7 @@ fn ser_ser_flow_mapping_two_elements_emits_comma() {
     let mut m = BTreeMap::new();
     let _ = m.insert("a".to_string(), 1i32);
     let _ = m.insert("b".to_string(), 2);
-    #[derive(Serialize)]
+    #[derive(serde::Serialize)]
     struct Doc {
         flow: FlowMap<BTreeMap<String, i32>>,
     }

--- a/crates/noyalib/tests/serde.rs
+++ b/crates/noyalib/tests/serde.rs
@@ -60,7 +60,7 @@ fn test_serde_unsigned() {
 #[cfg(feature = "lossless-u64")]
 #[test]
 fn test_serde_lossless_u64_struct_field() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Record {
         id: u64,
     }
@@ -130,7 +130,7 @@ fn test_serde_btreemap() {
 // Structs
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Point {
     x: i32,
     y: i32,
@@ -142,7 +142,7 @@ fn test_serde_simple_struct() {
     test_serde(&point, &["x:", "y:"]);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Rectangle {
     top_left: Point,
     bottom_right: Point,
@@ -157,7 +157,7 @@ fn test_serde_nested_struct() {
     test_serde(&rect, &["top_left:", "bottom_right:"]);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct WithOptional {
     required: String,
     optional: Option<String>,
@@ -183,7 +183,7 @@ fn test_serde_optional_none() {
     assert_eq!(value, parsed);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Default)]
 struct WithDefault {
     value: i32,
     #[serde(default)]
@@ -202,7 +202,7 @@ fn test_serde_default() {
 // Enums
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Color {
     Red,
     Green,
@@ -216,7 +216,7 @@ fn test_serde_unit_enum() {
     test_serde(&Color::Blue, &["Blue"]);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Wrapper {
     Int(i32),
     Str(String),
@@ -228,7 +228,7 @@ fn test_serde_newtype_enum() {
     test_serde(&Wrapper::Str("hello".to_string()), &["Str:", "hello"]);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Shape {
     Circle { radius: f64 },
     Rectangle { width: i32, height: i32 },
@@ -246,7 +246,7 @@ fn test_serde_struct_enum() {
     );
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 enum Tuple {
     Pair(i32, i32),
     Triple(i32, i32, i32),
@@ -269,7 +269,7 @@ fn test_serde_tuple_enum() {
 // Tuple and Newtype Structs
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Newtype(i32);
 
 #[test]
@@ -277,7 +277,7 @@ fn test_serde_newtype_struct() {
     test_serde(&Newtype(42), &["42"]);
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct TupleStruct(i32, String, bool);
 
 #[test]
@@ -292,7 +292,7 @@ fn test_serde_tuple_struct() {
 // Complex Types
 // ============================================================================
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 struct Config {
     name: String,
     version: u32,
@@ -378,7 +378,7 @@ fn test_serde_string_with_colon() {
 
 #[test]
 fn test_serde_numeric_string() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Data {
         value: String,
     }
@@ -393,7 +393,7 @@ fn test_serde_numeric_string() {
 
 #[test]
 fn test_serde_bool_like_string() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Data {
         value: String,
     }

--- a/crates/noyalib/tests/serde_ecosystem.rs
+++ b/crates/noyalib/tests/serde_ecosystem.rs
@@ -14,24 +14,23 @@
 #![allow(missing_docs)]
 
 use noyalib::{Deserializer, Value, from_str};
-use serde::Deserialize;
 
 // ── serde_path_to_error ─────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct App {
     name: String,
     server: Server,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Server {
     host: String,
     port: u16,
     database: Database,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Database {
     url: String,
     pool_size: u16,
@@ -113,7 +112,7 @@ server:
 
 #[test]
 fn path_to_error_inside_sequence() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Replicas {
         replicas: Vec<Server>,
@@ -147,7 +146,7 @@ replicas:
 
 // ── serde_ignored ───────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Slim {
     name: String,
     port: u16,
@@ -176,12 +175,12 @@ another_unknown: 1
 
 #[test]
 fn serde_ignored_collects_unknown_nested_keys() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Outer {
         inner: Inner,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Inner {
         a: u16,

--- a/crates/noyalib/tests/spanned.rs
+++ b/crates/noyalib/tests/spanned.rs
@@ -4,11 +4,10 @@
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
 use noyalib::{Spanned, from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 #[test]
 fn test_spanned_basic() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         port: Spanned<u16>,
     }
@@ -39,7 +38,7 @@ fn test_spanned_locations_real() {
 
 #[test]
 fn test_spanned_in_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         name: Spanned<String>,
         port: Spanned<u16>,

--- a/crates/noyalib/tests/spec/edge_cases.rs
+++ b/crates/noyalib/tests/spec/edge_cases.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use noyalib::{Value, from_str, to_string};
-use serde::{Deserialize, Serialize};
 
 #[test]
 fn unicode_string() {
@@ -73,7 +72,7 @@ fn carriage_return_in_string() {
 
 #[test]
 fn roundtrip_complex_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Config {
         name: String,
         port: u16,
@@ -95,11 +94,11 @@ fn roundtrip_complex_struct() {
 
 #[test]
 fn roundtrip_nested_option() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Outer {
         inner: Option<Inner>,
     }
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Inner {
         value: i64,
     }
@@ -114,7 +113,7 @@ fn roundtrip_nested_option() {
 
 #[test]
 fn roundtrip_enum_variants() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     enum Color {
         Red,
         Green,
@@ -130,7 +129,7 @@ fn roundtrip_enum_variants() {
 
 #[test]
 fn roundtrip_newtype_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper(i64);
 
     let orig = Wrapper(42);
@@ -141,7 +140,7 @@ fn roundtrip_newtype_struct() {
 
 #[test]
 fn roundtrip_tuple_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Point(f64, f64);
 
     let orig = Point(1.5, 2.5);
@@ -152,7 +151,7 @@ fn roundtrip_tuple_struct() {
 
 #[test]
 fn roundtrip_unit_struct() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Unit;
 
     let yaml = to_string(&Unit).unwrap();

--- a/crates/noyalib/tests/spec/errors.rs
+++ b/crates/noyalib/tests/spec/errors.rs
@@ -87,10 +87,8 @@ fn max_document_length_exceeded() {
 
 #[test]
 fn missing_required_struct_field() {
-    use serde::Deserialize;
-
     #[allow(dead_code)]
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Required {
         name: String,
         age: i64,

--- a/crates/noyalib/tests/spec/mappings.rs
+++ b/crates/noyalib/tests/spec/mappings.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 #[test]
 fn block_mapping_string_values() {
@@ -31,11 +30,11 @@ fn empty_mapping() {
 
 #[test]
 fn nested_mappings() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         database: Database,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Database {
         host: String,
         port: u16,
@@ -83,15 +82,15 @@ fn mapping_preserves_order() {
 
 #[test]
 fn deeply_nested_mapping() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct A {
         b: B,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct B {
         c: C,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct C {
         value: i64,
     }

--- a/crates/noyalib/tests/spec/nested.rs
+++ b/crates/noyalib/tests/spec/nested.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 #[test]
 fn mapping_of_sequences() {
@@ -21,7 +20,7 @@ fn mapping_of_sequences() {
 
 #[test]
 fn sequence_of_mappings_complex() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Item {
         item: String,
         quantity: i64,
@@ -74,17 +73,17 @@ fn sequence_of_sequences_of_mappings() {
 
 #[test]
 fn real_world_config() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         server: Server,
         database: Database,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Server {
         host: String,
         port: u16,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Database {
         url: String,
@@ -102,7 +101,7 @@ fn real_world_config() {
 
 #[test]
 fn optional_nested_fields() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Config {
         name: String,
         debug: Option<bool>,

--- a/crates/noyalib/tests/spec/sequences.rs
+++ b/crates/noyalib/tests/spec/sequences.rs
@@ -4,7 +4,6 @@
 // YAML spec: Sequences
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 #[test]
 fn block_sequence_of_scalars() {
@@ -34,7 +33,7 @@ fn nested_block_sequences() {
 
 #[test]
 fn sequence_in_block_sequence() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     #[serde(untagged)]
     enum Item {
         Seq(Vec<String>),
@@ -52,7 +51,7 @@ fn sequence_in_block_sequence() {
 
 #[test]
 fn sequence_of_mappings() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Player {
         name: String,
         hr: i32,

--- a/crates/noyalib/tests/spec/tags.rs
+++ b/crates/noyalib/tests/spec/tags.rs
@@ -4,7 +4,6 @@
 // YAML spec: Tags
 
 use noyalib::{Value, from_str};
-use serde::Deserialize;
 
 #[test]
 fn explicit_str_tag() {
@@ -53,7 +52,7 @@ fn explicit_map_tag() {
 
 #[test]
 fn tagged_sequence_with_scalar_tags() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct TaggedSeq(String, String, i64, String);
 
     let v: TaggedSeq = from_str("- !!str a\n- b\n- !!int 42\n- d\n").unwrap();
@@ -79,7 +78,7 @@ fn unordered_set_as_map() {
 
 #[test]
 fn tags_for_block_objects() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         foo: Vec<Value>,
     }

--- a/crates/noyalib/tests/streaming_binary.rs
+++ b/crates/noyalib/tests/streaming_binary.rs
@@ -12,10 +12,10 @@
 #![allow(missing_docs)]
 
 use noyalib::StreamingDeserializer;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_bytes::ByteBuf;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Payload {
     name: String,
     #[serde(with = "serde_bytes")]
@@ -50,7 +50,7 @@ body: !!binary |
 
 #[test]
 fn streaming_byte_buf_roundtrip() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Wrapper {
         data: ByteBuf,
     }
@@ -62,7 +62,7 @@ fn streaming_byte_buf_roundtrip() {
 
 #[test]
 fn streaming_full_byte_range() {
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
     struct Wrapper {
         data: ByteBuf,
     }
@@ -91,7 +91,7 @@ fn streaming_untagged_string_visits_raw_bytes() {
     // Without a `!!binary` tag, deserialising into a byte target
     // surfaces the underlying scalar bytes verbatim — base64-decoding
     // is opt-in via the tag.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Wrapper {
         data: ByteBuf,
     }

--- a/crates/noyalib/tests/streaming_coverage_extra.rs
+++ b/crates/noyalib/tests/streaming_coverage_extra.rs
@@ -18,7 +18,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use noyalib::{ParserConfig, TagRegistry, from_str, from_str_with_config};
-use serde::Deserialize;
 use serde_bytes::ByteBuf;
 
 // ── L170-L182 — peek_parser_event / next_parser_event parser-error paths ───
@@ -167,7 +166,7 @@ target:
 
 #[test]
 fn coverage_stream_option_some_scalar() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         x: Option<i64>,
         y: Option<i64>,
@@ -186,7 +185,7 @@ fn coverage_stream_option_some_scalar() {
 
 #[test]
 fn coverage_stream_ignored_any_skips_complex_value() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Small {
         keep: i64,
     }
@@ -215,7 +214,7 @@ extra:
 fn coverage_stream_tagged_str_restores_tag_for_fallback() {
     // A `!!str`-tagged scalar that targets a String field must restore
     // the tag so the AST path resolves it correctly.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         value: String,
     }
@@ -314,7 +313,7 @@ fn coverage_stream_str_block_scalar_passes() {
 #[test]
 fn coverage_stream_unit_mismatch_errors() {
     // Plain non-null scalar can't deserialise as `()`.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct UnitField {
         u: (),
@@ -325,9 +324,9 @@ fn coverage_stream_unit_mismatch_errors() {
 
 #[test]
 fn coverage_stream_unit_struct_accepts_null() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct U;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         u: U,
@@ -342,7 +341,7 @@ fn coverage_stream_spanned_falls_back() {
     // `Spanned<T>` must bail to AST fallback. Verify via from_str_with_config
     // since Spanned support is in the loader path.
     use noyalib::Spanned;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         inner: Spanned<String>,
     }
@@ -355,9 +354,9 @@ fn coverage_stream_spanned_falls_back() {
 
 #[test]
 fn coverage_stream_newtype_with_core_tag() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Wrap(i64);
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         v: Wrap,
     }
@@ -386,7 +385,7 @@ fn coverage_stream_map_typemismatch() {
 // ── L960-L997 — deserialize_enum: unit variant from scalar, struct
 // variant from single-key mapping, error on non-scalar variant name.
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum E {
     Unit,
     Tup(i32, i32),
@@ -396,7 +395,7 @@ enum E {
 
 #[test]
 fn coverage_stream_enum_unit_from_scalar() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         e: E,
     }
@@ -406,7 +405,7 @@ fn coverage_stream_enum_unit_from_scalar() {
 
 #[test]
 fn coverage_stream_enum_newtype_variant() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         e: E,
     }
@@ -416,7 +415,7 @@ fn coverage_stream_enum_newtype_variant() {
 
 #[test]
 fn coverage_stream_enum_struct_variant() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         e: E,
     }
@@ -426,7 +425,7 @@ fn coverage_stream_enum_struct_variant() {
 
 #[test]
 fn coverage_stream_enum_tuple_variant() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         e: E,
     }
@@ -447,7 +446,7 @@ fn coverage_stream_ignored_any_at_top_level() {
 
 #[test]
 fn coverage_stream_bytes_from_plain_string() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         b: ByteBuf,
     }
@@ -457,7 +456,7 @@ fn coverage_stream_bytes_from_plain_string() {
 
 #[test]
 fn coverage_stream_bytes_rejects_null() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: ByteBuf,
@@ -468,7 +467,7 @@ fn coverage_stream_bytes_rejects_null() {
 
 #[test]
 fn coverage_stream_bytes_rejects_bool() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: ByteBuf,
@@ -479,7 +478,7 @@ fn coverage_stream_bytes_rejects_bool() {
 
 #[test]
 fn coverage_stream_bytes_rejects_int() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: ByteBuf,
@@ -490,7 +489,7 @@ fn coverage_stream_bytes_rejects_int() {
 
 #[test]
 fn coverage_stream_bytes_rejects_float() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: ByteBuf,
@@ -501,7 +500,7 @@ fn coverage_stream_bytes_rejects_float() {
 
 #[test]
 fn coverage_stream_bytes_binary_invalid() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: ByteBuf,
@@ -565,7 +564,7 @@ fn coverage_stream_duplicate_error_returns_error() {
 
 #[test]
 fn coverage_stream_enum_with_struct_variant_mapping() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum Choice {
         Pair { a: i32, b: i32 },
     }
@@ -579,9 +578,9 @@ fn coverage_stream_enum_with_struct_variant_mapping() {
 
 #[test]
 fn coverage_stream_tag_registry_strips_custom_tag() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Celsius(f64);
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         t: Celsius,
     }
@@ -597,7 +596,7 @@ fn coverage_stream_tag_registry_strips_seq_tag() {
     let registry = Arc::new(TagRegistry::new().with("!Items"));
     let cfg = ParserConfig::new().tag_registry(Arc::clone(&registry));
     let yaml = "items: !Items [1, 2, 3]\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         items: Vec<i64>,
     }
@@ -610,7 +609,7 @@ fn coverage_stream_tag_registry_strips_map_tag() {
     let registry = Arc::new(TagRegistry::new().with("!Cfg"));
     let cfg = ParserConfig::new().tag_registry(Arc::clone(&registry));
     let yaml = "cfg: !Cfg {a: 1, b: 2}\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         cfg: BTreeMap<String, i64>,
     }
@@ -894,7 +893,7 @@ fn coverage_stream_core_tag_str_via_streaming_de() {
     let registry = Arc::new(TagRegistry::new().with("!!str"));
     let cfg = ParserConfig::new().tag_registry(Arc::clone(&registry));
     let yaml = "v: !!str 42\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         v: String,
     }
@@ -912,7 +911,7 @@ fn coverage_stream_partial_consumption_drops_seq() {
     // contains an element of the wrong type (string in i64 seq), causing
     // mid-iteration failure that exercises the Drop drain loop.
     let yaml = "values:\n  - 1\n  - 2\n  - not_a_number\n";
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         values: Vec<i64>,

--- a/crates/noyalib/tests/streaming_de_final_push.rs
+++ b/crates/noyalib/tests/streaming_de_final_push.rs
@@ -23,7 +23,6 @@ use noyalib::{
     ParserConfig, Spanned, Tag, TagRegistry, TaggedValue, Value, from_str, from_str_with_config,
     from_value,
 };
-use serde::Deserialize;
 
 // ─────────────────────────────────────────────────────────────────
 // de.rs ▼
@@ -122,7 +121,7 @@ impl noyalib::policy::Policy for NoOpPolicy {}
 
 #[test]
 fn final_de_wrap_err_attaches_location_when_span_present() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         b: serde_bytes::ByteBuf,
@@ -190,7 +189,7 @@ fn final_de_deserialize_any_preserve_tags_visits_map() {
 
 #[test]
 fn final_de_deserialize_str_binary_tag_non_string_errors() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct S {
         s: String,
@@ -240,7 +239,7 @@ fn final_de_deserialize_bytes_invalid_base64() {
 
 #[test]
 fn final_de_spanned_through_ast_path() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         n: Spanned<i32>,
     }
@@ -269,7 +268,7 @@ fn final_de_spanned_through_ast_path() {
 
 #[test]
 fn final_de_variant_seed_unknown_variant_errors() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         A,
         B,
@@ -287,7 +286,7 @@ fn final_de_variant_seed_unknown_variant_errors() {
 // span context (forced via the AST path) the `Some(ctx)` arm on
 // line 2021-2022 fires.
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum Choice {
     A,
     #[allow(dead_code)]
@@ -358,7 +357,7 @@ fn final_de_figment_provider_with_spanned_field_uses_ast_fallback() {
     use figment::Figment;
     use figment::providers::Format as _;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Cfg {
         port: u16,
@@ -420,7 +419,7 @@ fn final_streaming_anchor_scalar_seq_map_typed_target() {
     // would short-circuit via the Value-fast-path). Hits the
     // depth==0 anchor-completion branches (Scalar, SeqEnd, MapEnd)
     // of `maybe_record` (lines 323-359).
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         a: i64,
         b: Vec<i64>,
@@ -449,7 +448,7 @@ e: *x2
 
 #[test]
 fn final_streaming_anchor_records_alias_typed_target() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Doc {
         shared: i64,
         copy: BTreeMap<String, i64>,
@@ -550,7 +549,7 @@ fn final_streaming_skip_to_content_with_directives() {
 
 #[test]
 fn final_streaming_ignored_any_skips_tagged_seq_in_map() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Small {
         keep: i64,
     }
@@ -624,7 +623,7 @@ fn final_streaming_f64_happy() {
 fn final_streaming_deserialize_str_mapping_event_errors() {
     // A mapping target where the field expects a string but the YAML
     // hands a mapping. Streaming yields a TypeMismatch.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct Doc {
         s: String,
@@ -640,7 +639,7 @@ fn final_streaming_deserialize_str_mapping_event_errors() {
 
 #[test]
 fn final_streaming_option_some_string() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         x: Option<String>,
     }
@@ -660,7 +659,7 @@ fn final_streaming_unit_rejects_non_null() {
 
 #[test]
 fn final_streaming_spanned_newtype_falls_back() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         v: Spanned<i32>,
     }
@@ -675,9 +674,9 @@ fn final_streaming_spanned_newtype_falls_back() {
 
 #[test]
 fn final_streaming_newtype_with_core_str_tag() {
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(serde::Deserialize, PartialEq, Debug)]
     struct Wrap(String);
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         v: Wrap,
     }
@@ -712,7 +711,7 @@ fn final_streaming_enum_via_unregistered_tag_dispatch() {
     // through `StreamingTagEnumAccess` (line 971) where the tag
     // itself names the variant. The tag-to-variant string is
     // `!Tagged`, so the variant must match exactly.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!Tagged")]
         Tagged(i32),
@@ -726,7 +725,7 @@ fn final_streaming_enum_via_unregistered_tag_dispatch() {
 
 #[test]
 fn final_streaming_enum_top_level_unit_scalar() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         Unit,
         #[allow(dead_code)]
@@ -738,7 +737,7 @@ fn final_streaming_enum_top_level_unit_scalar() {
 
 #[test]
 fn final_streaming_enum_non_scalar_non_mapping_errors() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     #[allow(dead_code)]
     enum E {
         Unit,
@@ -767,7 +766,7 @@ fn final_streaming_identifier_mapping_value_errors() {
 
 #[test]
 fn final_streaming_bytes_binary_decode_success() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         b: serde_bytes::ByteBuf,
     }
@@ -780,7 +779,7 @@ fn final_streaming_bytes_binary_decode_success() {
 
 #[test]
 fn final_streaming_bytes_from_quoted_string() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         b: serde_bytes::ByteBuf,
     }
@@ -841,7 +840,7 @@ fn final_streaming_duplicate_first_keeps_first_three_collisions() {
 
 #[test]
 fn final_streaming_tagged_enum_variant_access_unit() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         Plain,
         #[allow(dead_code)]
@@ -998,7 +997,7 @@ target:
 
 #[test]
 fn final_streaming_spanned_recursive_into_seq() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct D {
         items: Spanned<Vec<i32>>,
     }
@@ -1011,7 +1010,7 @@ fn final_streaming_spanned_recursive_into_seq() {
 
 #[test]
 fn final_streaming_spanned_option_none() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct D {
         x: Spanned<Option<i32>>,
     }
@@ -1039,7 +1038,7 @@ fn final_streaming_hashmap_typed_target() {
 
 #[test]
 fn final_streaming_drop_drains_map_after_late_error() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         a: i32,
@@ -1073,7 +1072,7 @@ fn final_de_from_value_spanned_default_location() {
 
 #[test]
 fn final_streaming_drop_drains_seq_after_error() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         nums: Vec<i32>,

--- a/crates/noyalib/tests/streaming_failsafe_tags.rs
+++ b/crates/noyalib/tests/streaming_failsafe_tags.rs
@@ -11,7 +11,6 @@
 #![allow(clippy::unwrap_used)]
 
 use noyalib::from_str;
-use serde::Deserialize;
 
 #[test]
 fn int_tag_resolves_to_integer() {
@@ -39,7 +38,7 @@ fn bool_tag_resolves_to_bool() {
 
 #[test]
 fn null_tag_resolves_to_unit() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct N {
         x: Option<i64>,
     }
@@ -55,7 +54,7 @@ fn seq_tag_resolves_to_sequence() {
 
 #[test]
 fn map_tag_resolves_to_mapping() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         a: i64,
         b: i64,

--- a/crates/noyalib/tests/streaming_public_api.rs
+++ b/crates/noyalib/tests/streaming_public_api.rs
@@ -36,7 +36,7 @@ fn with_config_accepts_custom_parser_settings() {
 
 #[test]
 fn struct_deserialisation_skips_ast() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Server {
         host: String,
         port: u16,
@@ -61,12 +61,12 @@ fn nested_collections_work() {
 
 #[test]
 fn anchor_alias_handled_natively() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Endpoint {
         host: String,
         port: u16,
     }
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc {
         primary: Endpoint,
         replica: Endpoint,
@@ -175,7 +175,7 @@ fn debug_impl_does_not_panic() {
 
 #[test]
 fn equivalent_to_from_str_for_simple_inputs() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Cfg {
         name: String,
         count: u32,

--- a/crates/noyalib/tests/streaming_round3_push.rs
+++ b/crates/noyalib/tests/streaming_round3_push.rs
@@ -130,7 +130,7 @@ fn r3_restore_tag_to_seq_event_for_str_target() {
     // A custom-tagged sequence at a String field triggers
     // `deserialize_str` → `take_tag_from_current` → `restore_tag_to_current`
     // on a SequenceStart event before falling back to AST.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         s: String,
@@ -186,7 +186,7 @@ fn r3_f64_from_sequence_errors() {
 
 #[test]
 fn r3_string_field_rejects_plain_int() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         s: String,
@@ -197,7 +197,7 @@ fn r3_string_field_rejects_plain_int() {
 
 #[test]
 fn r3_string_field_rejects_plain_bool() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         s: String,
@@ -208,7 +208,7 @@ fn r3_string_field_rejects_plain_bool() {
 
 #[test]
 fn r3_string_field_rejects_plain_float() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         s: String,
@@ -219,7 +219,7 @@ fn r3_string_field_rejects_plain_float() {
 
 #[test]
 fn r3_string_field_rejects_plain_null() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         s: String,
@@ -244,7 +244,7 @@ fn r3_string_target_with_top_level_quoted_passes() {
 
 #[test]
 fn r3_option_some_seq_inner() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         x: Option<Vec<i32>>,
     }
@@ -254,7 +254,7 @@ fn r3_option_some_seq_inner() {
 
 #[test]
 fn r3_option_some_map_inner() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         x: Option<BTreeMap<String, i32>>,
     }
@@ -282,7 +282,7 @@ fn r3_unit_top_level_via_streaming_de() {
 
 #[test]
 fn r3_unit_struct_top_level() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct U;
     let _: U = from_str("~\n").unwrap();
 }
@@ -293,7 +293,7 @@ fn r3_unit_struct_top_level() {
 
 #[test]
 fn r3_newtype_with_core_null_tag() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct N(Option<String>);
     let n: N = from_str("!!null ~\n").unwrap();
     assert_eq!(n, N(None));
@@ -301,7 +301,7 @@ fn r3_newtype_with_core_null_tag() {
 
 #[test]
 fn r3_newtype_with_core_bool_tag() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct N(bool);
     let n: N = from_str("!!bool true\n").unwrap();
     assert_eq!(n, N(true));
@@ -309,7 +309,7 @@ fn r3_newtype_with_core_bool_tag() {
 
 #[test]
 fn r3_newtype_with_core_float_tag() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct N(f64);
     let n: N = from_str("!!float 1.5\n").unwrap();
     assert!((n.0 - 1.5).abs() < 1e-9);
@@ -317,7 +317,7 @@ fn r3_newtype_with_core_float_tag() {
 
 #[test]
 fn r3_newtype_with_core_seq_tag() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct N(Vec<i64>);
     let n: N = from_str("!!seq [1, 2]\n").unwrap();
     assert_eq!(n, N(vec![1, 2]));
@@ -325,7 +325,7 @@ fn r3_newtype_with_core_seq_tag() {
 
 #[test]
 fn r3_newtype_with_core_map_tag() {
-    #[derive(Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq)]
     struct N(BTreeMap<String, i64>);
     let n: N = from_str("!!map {a: 1}\n").unwrap();
     assert_eq!(n.0["a"], 1);
@@ -355,7 +355,7 @@ fn r3_map_target_sees_sequence_event_errors() {
 
 #[test]
 fn r3_enum_mapping_with_non_scalar_variant_name_errors() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     #[allow(dead_code)]
     enum E {
         A(i32),
@@ -369,7 +369,7 @@ fn r3_enum_mapping_with_non_scalar_variant_name_errors() {
 // ── L1342-L1351 — unit_variant: variant body is null/empty ────────────
 // Use serde's enum-variant-as-mapping form where the variant value is `~`.
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum E2 {
     Unit,
     Wrap(i32),
@@ -416,7 +416,7 @@ fn r3_streaming_struct_variant_value() {
 fn r3_identifier_via_struct_field_name() {
     // serde's struct deserialise calls `deserialize_identifier` for
     // each key — exercise the success arm.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         alpha: i32,
@@ -429,7 +429,7 @@ fn r3_identifier_via_struct_field_name() {
 #[test]
 fn r3_ignored_any_skips_seq_inside_map() {
     use serde::de::IgnoredAny;
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     #[allow(dead_code)]
     struct D {
         keep: i32,
@@ -542,7 +542,7 @@ fn r3_tag_enum_access_unit_variant_dispatch() {
     // Tagged enum where the tag string IS the variant name. The
     // streaming path routes tagged scalars on enum targets through
     // `StreamingTagEnumAccess::variant_seed` then unit_variant.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!Tag")]
         Tag,
@@ -555,7 +555,7 @@ fn r3_tag_enum_access_unit_variant_dispatch() {
 #[test]
 fn r3_tag_enum_access_newtype_variant_dispatch() {
     // Tag-as-variant name with newtype payload.
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!Wrap")]
         Wrap(i32),
@@ -567,7 +567,7 @@ fn r3_tag_enum_access_newtype_variant_dispatch() {
 
 #[test]
 fn r3_tag_enum_access_struct_variant_dispatch() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!S")]
         S { a: i32 },
@@ -579,7 +579,7 @@ fn r3_tag_enum_access_struct_variant_dispatch() {
 
 #[test]
 fn r3_tag_enum_access_tuple_variant_dispatch() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     enum E {
         #[serde(rename = "!P")]
         P(i32, i32),
@@ -795,7 +795,7 @@ target:
 
 #[test]
 fn r3_spanned_map_shape() {
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct D {
         m: Spanned<BTreeMap<String, i32>>,
     }
@@ -858,7 +858,7 @@ fn r3_streaming_de_with_registry_strips_custom_tag() {
 // path and variant-name routing (L1219, L1222, L1224, L1229)
 // ─────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 #[serde(tag = "kind")]
 enum InternallyTagged {
     First { x: i32 },

--- a/crates/noyalib/tests/tag_registry.rs
+++ b/crates/noyalib/tests/tag_registry.rs
@@ -21,7 +21,7 @@ fn cfg(tags: &[&str]) -> ParserConfig {
 
 // ── Scalar newtype pass-through ──────────────────────────────────────
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 struct Celsius(f64);
 
 #[test]
@@ -44,9 +44,9 @@ fn scalar_tag_not_registered_errors_on_newtype_without_registry() {
 
 #[test]
 fn multiple_tags_in_registry() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Meters(f64);
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Seconds(f64);
 
     let cfg = cfg(&["!Meters", "!Seconds"]);
@@ -69,7 +69,7 @@ fn registered_tag_on_sequence_strips_and_deserializes() {
 
 #[test]
 fn registered_tag_on_mapping_strips_and_deserializes() {
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, serde::Deserialize, PartialEq)]
     struct Point {
         x: i32,
         y: i32,

--- a/crates/noyalib/tests/ux_diagnostics.rs
+++ b/crates/noyalib/tests/ux_diagnostics.rs
@@ -20,9 +20,8 @@
 #![allow(missing_docs)]
 
 use noyalib::{Error, from_reader_strict, from_slice_strict, from_str, from_str_strict};
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(dead_code)]
 struct ServerConfig {
     port: u16,
@@ -89,7 +88,7 @@ unknown_c: 3
 
 #[test]
 fn strict_walks_into_nested_structs() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[allow(dead_code)]
     struct Outer {
         name: String,

--- a/crates/noyalib/tests/validated_garde.rs
+++ b/crates/noyalib/tests/validated_garde.rs
@@ -11,11 +11,10 @@
 
 use garde::Validate;
 use noyalib::{Validated, from_str};
-use serde::{Deserialize, Serialize};
 
 // ── Basic: passing validation returns Validated(T) ──────────────────────
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Validate)]
 struct Server {
     #[garde(length(min = 1, max = 64))]
     host: String,
@@ -78,7 +77,7 @@ fn multiple_errors_reported_together() {
 
 // ── Nested validation ───────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 struct Database {
     #[garde(length(min = 1))]
     name: String,
@@ -99,7 +98,7 @@ fn nested_validation_reports_dotted_path() {
 
 // ── Collection validation ────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, serde::Deserialize, Validate)]
 struct Cluster {
     #[garde(length(min = 1, max = 10))]
     nodes: Vec<String>,

--- a/crates/noyalib/tests/validated_miette_bridge.rs
+++ b/crates/noyalib/tests/validated_miette_bridge.rs
@@ -16,9 +16,8 @@ mod garde_bridge {
     use super::*;
     use garde::Validate;
     use noyalib::validated_miette::garde_errors_to_miette;
-    use serde::Deserialize;
 
-    #[derive(Debug, Deserialize, Validate)]
+    #[derive(Debug, serde::Deserialize, Validate)]
     struct Cfg {
         #[garde(range(min = 1024, max = 65535))]
         port: u16,
@@ -61,10 +60,10 @@ mod garde_bridge {
 mod validator_bridge {
     use super::*;
     use noyalib::validated_miette::validator_errors_to_miette;
-    use serde::Deserialize;
+
     use validator::Validate;
 
-    #[derive(Debug, Deserialize, Validate)]
+    #[derive(Debug, serde::Deserialize, Validate)]
     struct Cfg {
         #[validate(range(min = 1024, max = 65535))]
         port: u16,

--- a/crates/noyalib/tests/validated_validator.rs
+++ b/crates/noyalib/tests/validated_validator.rs
@@ -8,11 +8,10 @@
 #![cfg(feature = "validator")]
 
 use noyalib::{from_str, to_string, validated::ValidatedValidator};
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use validator::Validate;
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Validate)]
 struct Server {
     #[validate(length(min = 1, max = 64))]
     host: String,
@@ -86,7 +85,7 @@ fn multiple_errors_reported_together() {
 
 // ── Collection validation ────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Serialize, Validate)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Validate)]
 struct Cluster {
     #[validate(length(min = 1, max = 10))]
     nodes: Vec<String>,
@@ -149,7 +148,7 @@ fn roundtrip_value_equivalence() {
 #[test]
 fn sibling_type_without_wrapper_works() {
     // Non-validator Server variant must still parse normally.
-    #[derive(Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Plain {
         #[allow(dead_code)]
         host: String,

--- a/crates/noyalib/tests/value.rs
+++ b/crates/noyalib/tests/value.rs
@@ -1449,8 +1449,8 @@ fn test_value_visitor_none() {
 #[test]
 fn test_value_visitor_unit() {
     // JSON doesn't have a unit type, but this tests the visitor path
-    use serde::Deserialize;
-    #[derive(Deserialize)]
+
+    #[derive(serde::Deserialize)]
     struct UnitWrapper(Value);
 
     let json = "null";

--- a/crates/noyalib/tests/value_coverage_extra.rs
+++ b/crates/noyalib/tests/value_coverage_extra.rs
@@ -17,7 +17,6 @@ use std::collections::HashMap;
 use noyalib::{
     Mapping, MappingAny, Number, Tag, TaggedValue, Value, from_str, from_value, to_string,
 };
-use serde::{Deserialize, Serialize};
 
 // ============================================================================
 // Mapping — Display via multi-entry walk + comma branch (L790, L793, L795)
@@ -367,7 +366,7 @@ fn value_index_into_via_value_negative_int_returns_none() {
 // from_value (L4010-L4011, L4027-L4029, L4051-L4053)
 // ============================================================================
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
 struct Wrapper {
     data: Value,
 }
@@ -448,7 +447,7 @@ fn value_visit_map_tag_preserving_with_complex_inner() {
 // deserialize_enum string variant (L4282)
 // ============================================================================
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde::Deserialize, PartialEq)]
 enum E {
     A,
     B,

--- a/crates/noyalib/tests/zero_copy_str_deser.rs
+++ b/crates/noyalib/tests/zero_copy_str_deser.rs
@@ -27,12 +27,11 @@
 
 use noyalib::borrowed::TransformReason;
 use noyalib::from_str_borrowing;
-use serde::Deserialize;
 use std::borrow::Cow;
 
 #[test]
 fn cow_str_target_handles_plain_and_escaped() {
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct CowDoc<'a> {
         #[serde(borrow)]
         plain: Cow<'a, str>,
@@ -52,7 +51,7 @@ fn terminal_scalar_borrows_zero_copy() {
     // allowing the streaming deserialiser to call
     // `visit_borrowed_str` and satisfy `Deserialize<'de> for &'de str`.
     let yaml = "value: terminal";
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct One<'a> {
         value: &'a str,
     }
@@ -71,7 +70,7 @@ fn typical_yaml_borrows_zero_copy() {
     // covers `key: value\n`), the typical YAML shape now produces
     // `Cow::Borrowed` events. `&'a str` deserialise should succeed
     // and point back into the input buffer.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct Doc<'a> {
         name: &'a str,
         role: &'a str,
@@ -91,7 +90,7 @@ fn cow_target_works_with_typical_yaml() {
     // The common `key: value\n` shape produces an owned scalar event
     // (parser slow-path), so `&str` targets fail. `Cow<'a, str>`
     // accepts both forms — the recommended target shape today.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct One<'a> {
         #[serde(borrow)]
         value: Cow<'a, str>,
@@ -105,7 +104,7 @@ fn strict_str_target_errors_clearly_when_owned() {
     // For inputs where the parser allocated, `&'de str` deserialise
     // fails with serde's "expected a borrowed string" — a clean
     // error rather than a silent allocation.
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct One<'a> {
         #[allow(dead_code)]
         s: &'a str,

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -32,9 +32,8 @@ The simplest case — read into a typed struct via `serde`:
 
 ```rust
 use noyalib::from_str;
-use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct Server {
     host: String,
     port: u16,
@@ -69,7 +68,7 @@ Mirror surface for the write side:
 use noyalib::to_string;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(serde::Serialize)]
 struct Server { host: String, port: u16 }
 
 let yaml = to_string(&Server {
@@ -323,9 +322,8 @@ Under `--features validate-schema`:
 
 ```rust
 use noyalib::{from_str, schema_for, validate_against_schema, JsonSchema};
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
 struct ServerConfig {
     /// Port the server binds on.
     port: u16,

--- a/fuzz/fuzz_targets/fuzz_from_value.rs
+++ b/fuzz/fuzz_targets/fuzz_from_value.rs
@@ -12,7 +12,7 @@ use noyalib::Value;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 #[allow(dead_code)]
 struct Config {
     name: Option<String>,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->

## Summary

<!-- What does this change and why? One or two sentences. -->

This is a part of what #91 originally started. For now this only migrates serde derive to use fully qualified paths in the derive itself:

```diff
-#[derive(Debug, Serialize, Deserialize, PartialEq)
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)
```

This has the benefit of seeing easier where the derive comes from, if it's something of the default std derives like Debug or PartialEq or something from an external crate.

This also helps with the migration from serde to serde_core as the derive are the usages which don't work on serde_core so they need to be specific to `serde::` rather than `serde_core::`.

More changes of #91 will be supplied in their own pull requests but its likely helpful to not do everything all at once so merge conflicts are less of an issue.

## Approach

- Regex replace with `/(#\[derive\((?:.+, ))(Deserialize)/` to `${1}serde::$2` (same for Serialize).
- Check all the occurrences so that some comments are not included.
- adapt Cargo.toml temporarily to allow `unused_qualifications` and only warn on `unused_imports`
- `cargo clippy --all-features --all-targets --workspace --fix --allow-staged --allow-dirty ; cargo +nightly fmt`
- cleanup the doc code examples as they don't get checked / fixed by clippy. (Code in Markdown files is not even run by the doctests or are they?)
- check all the changes again so they are hopefully all correct.

## Related issue

<!-- e.g. "Closes #123". Use "N/A" if none. -->

see #91 and #146

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API or behaviour)
- [x] Docs / CI / tooling only

## Checklist

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --all-features` passes (added/updated tests for the change)
- [ ] Public API changes are documented and reflected in `CHANGELOG.md`
- [x] No new `unsafe` (the workspace is `#![forbid(unsafe_code)]`)
- [x] Commits are signed (CI verifies this)
- [x] Considered MSRV (1.85) and `no_std` impact, where relevant
