### PR TITLE
test(compat): cover serde_yaml from_reader / to_writer drop-ins

### DIFF
--- a/crates/noyalib/src/compat/serde_yaml.rs
+++ b/crates/noyalib/src/compat/serde_yaml.rs
@@ -432,6 +432,38 @@ mod tests {
     }
 
     #[test]
+    fn from_reader_typed() {
+        // `serde_yaml::from_reader` drop-in: deserialize straight from
+        // an `io::Read` (a `&[u8]` is one).
+        let bytes = b"name: noyalib\nport: 8080\n";
+        let cfg: Config = from_reader(&bytes[..]).unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                name: "noyalib".into(),
+                port: 8080
+            }
+        );
+    }
+
+    #[test]
+    fn to_writer_then_from_str_round_trips() {
+        // `serde_yaml::to_writer` drop-in: serialize into an
+        // `io::Write` sink and confirm the emitted YAML round-trips.
+        let cfg = Config {
+            name: "noyalib".into(),
+            port: 8080,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        to_writer(&mut buf, &cfg).unwrap();
+        let s = String::from_utf8(buf).expect("valid utf-8");
+        assert!(s.contains("name: noyalib"), "{s}");
+        assert!(s.contains("port: 8080"), "{s}");
+        let back: Config = from_str(&s).unwrap();
+        assert_eq!(cfg, back);
+    }
+
+    #[test]
     fn from_value_takes_by_value_like_serde_yaml() {
         let mut m = Mapping::new();
         let _ = m.insert("name", Value::String("noyalib".into()));
@@ -484,9 +516,13 @@ mod tests {
         // `noyalib::Error` are the same type, so callers' existing
         // error-handling code keeps working.
         #[allow(unused_qualifications)]
-        fn _identity(e: super::Error) -> crate::error::Error {
+        fn identity(e: super::Error) -> crate::error::Error {
             e
         }
+        // Exercise it at runtime so the coincidence of the two paths is
+        // observed, not merely compiled.
+        let e = identity(Error::Custom("compat".into()));
+        assert!(e.to_string().contains("compat"), "{e}");
     }
 
     #[test]


### PR DESCRIPTION
The `compat::serde_yaml` shim's in-crate tests exercised `from_str` /
`from_slice` / `from_value` / `to_string` / `to_value` but not the
io-based drop-ins, leaving `from_reader` and `to_writer` uncovered.

| file | region | line | fn |
|---|---|---|---|
| `compat/serde_yaml.rs` | 92.57% → **99.54%** | 86.99% → **99.32%** | 86.36% → **100%** |

Adds round-trip tests for both (deserialize from a `&[u8]` reader;
serialize into a `Vec<u8>` writer) and invokes the previously-uncalled
`Error`-type-identity check at runtime. Residual: line 489 is a
`_ => panic!("expected Mapping")` never-taken arm inside a test.

`fmt`+`clippy` clean; 15 compat tests pass. Test-only change.

Assisted-by: Claude <noreply@anthropic.com>