### PR TITLE
test(recovery): cover recover_one / try_line_truncation branch arms

### DIFF
--- a/crates/noyalib/tests/coverage_recovery.rs
+++ b/crates/noyalib/tests/coverage_recovery.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Coverage for the lenient-recovery branch arms in `recovery.rs`:
+//! the zero-budget short-circuit, the Pass-2 (duplicate-key) error
+//! collection, and the line-truncation whitespace-candidate skip.
+
+#![cfg(feature = "recovery")]
+#![allow(missing_docs)]
+#![allow(clippy::unwrap_used)]
+
+use noyalib::recovery::{LenientConfig, parse_lenient_with};
+use noyalib::{DuplicateKeyPolicy, ParserConfig};
+
+#[test]
+fn zero_error_budget_short_circuits_to_null() {
+    // `budget == 0` (max_errors: 0) makes recover_one bail before even
+    // the strict pass, returning Null with no diagnostics.
+    let cfg = LenientConfig {
+        max_errors: 0,
+        ..LenientConfig::default()
+    };
+    let r = parse_lenient_with("a: [unclosed\n", &cfg);
+    assert!(r.value.is_null(), "zero budget must yield Null");
+    assert!(r.errors.is_empty(), "zero budget collects no errors");
+}
+
+#[test]
+fn pass2_duplicate_key_error_is_collected() {
+    // With a non-`Last` base policy, a duplicate key fails the strict
+    // pass; the Pass-2 retry switches to `Last` but the *other* error
+    // (an unterminated flow sequence) still fails — so the Pass-2 error
+    // is pushed alongside the strict one.
+    let base = ParserConfig::default().duplicate_key_policy(DuplicateKeyPolicy::Error);
+    let cfg = LenientConfig {
+        base_config: base,
+        line_truncation: false, // isolate the Pass-2 behaviour
+        ..LenientConfig::default()
+    };
+    let r = parse_lenient_with("a: 1\na: 2\nb: [unclosed\n", &cfg);
+    assert!(
+        r.errors.len() >= 2,
+        "strict + pass-2 errors both collected, got {:?}",
+        r.errors
+    );
+}
+
+#[test]
+fn line_truncation_skips_whitespace_only_candidates() {
+    // Leading blank lines before unrecoverable garbage force the
+    // truncation loop to encounter whitespace-only prefixes, which it
+    // skips (`continue`) rather than re-parsing.
+    let cfg = LenientConfig::default();
+    let r = parse_lenient_with("\n\n\n{[garbage", &cfg);
+    // Best-effort recovery must not panic and reports the failure.
+    assert!(!r.errors.is_empty(), "unrecoverable garbage yields errors");
+    assert!(!r.is_complete);
+}


### PR DESCRIPTION
Bucket-1 slice via the public `parse_lenient_with`:
- zero error budget (`max_errors: 0`) short-circuits `recover_one` to
  `Null` before the strict pass (line 214);
- a duplicate key under a non-`Last` base policy plus an unterminated flow
  sequence fails both the strict and Pass-2 retries, so the Pass-2 error
  is collected (line 243);
- leading blank lines before unrecoverable garbage make the truncation
  loop skip whitespace-only candidates (line 309).

| file | region | fn |
|---|---|---|
| `recovery.rs` | 96.12% → **96.53%** | **100%** |

Residual (397/407/505/516/530-532/543/560) are all `_ => panic!("expected …")`
never-taken arms **inside the in-file `#[cfg(test)]` assertions** — not
source paths.

`fmt`+`clippy` clean; 3 tests. Test-only change.

Assisted-by: Claude <noreply@anthropic.com>