### PR TITLE
fix(loader,streaming): re-land #172 — DoS-budget parity + key-collision guard (lost from main)

### DIFF
--- a/crates/noyalib/src/de/deserializer.rs
+++ b/crates/noyalib/src/de/deserializer.rs
@@ -32,19 +32,6 @@ pub struct Deserializer<'de> {
     /// `"ABCD"` (no base64 decode). Default `false` preserves YAML
     /// 1.2 semantics.
     pub(crate) ignore_binary_tag_for_string: bool,
-    /// When `true`, [`Value::Tagged`] is surfaced through the
-    /// magic-key [`crate::value::TagPreservingMapAccess`] so the
-    /// outer [`Value::deserialize`] visitor can reconstruct
-    /// `Value::Tagged(...)` losslessly. When `false` (default), a
-    /// tagged scalar is unwrapped to its inner value — the
-    /// transparent behaviour every typed `T::deserialize` expects.
-    ///
-    /// Set automatically by [`from_str_with_config`] /
-    /// [`from_value`] when the caller's `T` is `Value` (detected
-    /// via [`std::any::TypeId`]). Threaded through every
-    /// `descend()` site so nested tagged values inside a
-    /// `Mapping` / `Sequence` also survive.
-    pub(crate) preserve_tags: bool,
 }
 
 impl<'de> Deserializer<'de> {
@@ -63,7 +50,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: None,
             ignore_binary_tag_for_string: false,
-            preserve_tags: false,
         }
     }
 
@@ -89,7 +75,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: Some(span_ctx),
             ignore_binary_tag_for_string: false,
-            preserve_tags: false,
         }
     }
 
@@ -106,25 +91,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx,
             ignore_binary_tag_for_string,
-            preserve_tags: false,
-        }
-    }
-
-    /// Internal constructor used by [`from_str_with_config`] /
-    /// [`from_value`] when the caller's `T` is detected as
-    /// [`Value`] via [`std::any::TypeId`]. Sets `preserve_tags`
-    /// so [`Value::Tagged`] survives the data-binding return
-    /// path. See `Deserializer::preserve_tags` for the contract.
-    pub(crate) fn with_options_preserving_tags(
-        value: &'de Value,
-        span_ctx: Option<&'de span_context::SpanContext>,
-        ignore_binary_tag_for_string: bool,
-    ) -> Self {
-        Deserializer {
-            value,
-            span_ctx,
-            ignore_binary_tag_for_string,
-            preserve_tags: true,
         }
     }
 
@@ -137,7 +103,6 @@ impl<'de> Deserializer<'de> {
             value,
             span_ctx: self.span_ctx,
             ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-            preserve_tags: self.preserve_tags,
         }
     }
 
@@ -176,24 +141,13 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
             Value::Sequence(_) => self.deserialize_seq(visitor),
             Value::Mapping(_) => self.deserialize_map(visitor),
             Value::Tagged(tagged) => {
-                if self.preserve_tags {
-                    // Tag-preserving path (`from_str::<Value>` /
-                    // `from_value::<Value>`): surface the tag via
-                    // a magic-key MapAccess so the outer
-                    // `Value::deserialize` visitor reconstructs
-                    // `Value::Tagged(...)` losslessly.
-                    self.wrap_err(visitor.visit_map(crate::value::TagPreservingMapAccess::new(
-                        tagged.tag().as_str(),
-                        tagged.value(),
-                    )))
-                } else {
-                    // Default path: typed targets see through the
-                    // tag transparently — `#[derive(Deserialize)]
-                    // struct Foo { x: i32 }` against `!Foo {x: 1}`
-                    // yields `Foo { x: 1 }`.
-                    let de = self.descend(tagged.value());
-                    de.deserialize_any(visitor)
-                }
+                // Typed targets see through the tag transparently —
+                // `#[derive(Deserialize)] struct Foo { x: i32 }` against
+                // `!Foo {x: 1}` yields `Foo { x: 1 }`. (Tag *preservation* for
+                // a `Value` target happens in the AST loader / `from_value`'s
+                // clone fast path, not here.)
+                let de = self.descend(tagged.value());
+                de.deserialize_any(visitor)
             }
         }
     }
@@ -581,10 +535,6 @@ pub(crate) struct ValueSeqAccess<'de> {
     iter: core::slice::Iter<'de, Value>,
     span_ctx: Option<&'de span_context::SpanContext>,
     ignore_binary_tag_for_string: bool,
-    /// Mirror of the parent [`Deserializer::preserve_tags`] so
-    /// nested `Value::Tagged(...)` nodes inside a sequence
-    /// survive the data-binding return path.
-    preserve_tags: bool,
 }
 
 impl<'de> ValueSeqAccess<'de> {
@@ -593,7 +543,6 @@ impl<'de> ValueSeqAccess<'de> {
             iter: seq.iter(),
             span_ctx: de.span_ctx,
             ignore_binary_tag_for_string: de.ignore_binary_tag_for_string,
-            preserve_tags: de.preserve_tags,
         }
     }
 }
@@ -611,7 +560,6 @@ impl<'de> SeqAccess<'de> for ValueSeqAccess<'de> {
                     value,
                     span_ctx: self.span_ctx,
                     ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-                    preserve_tags: self.preserve_tags,
                 };
                 seed.deserialize(de).map(Some)
             }
@@ -625,10 +573,6 @@ pub(crate) struct ValueMapAccess<'de> {
     value: Option<&'de Value>,
     span_ctx: Option<&'de span_context::SpanContext>,
     ignore_binary_tag_for_string: bool,
-    /// Mirror of the parent [`Deserializer::preserve_tags`] so
-    /// nested `Value::Tagged(...)` nodes inside a mapping survive
-    /// the data-binding return path. See `de::Deserializer` docs.
-    preserve_tags: bool,
 }
 
 impl<'de> ValueMapAccess<'de> {
@@ -638,19 +582,16 @@ impl<'de> ValueMapAccess<'de> {
             value: None,
             span_ctx: de.span_ctx,
             ignore_binary_tag_for_string: de.ignore_binary_tag_for_string,
-            preserve_tags: de.preserve_tags,
         }
     }
 
     /// Build the child [`Deserializer`] used to read each map
-    /// value — propagates every per-call toggle including
-    /// `preserve_tags`.
+    /// value — propagates every per-call toggle.
     fn child_de(&self, value: &'de Value) -> Deserializer<'de> {
         Deserializer {
             value,
             span_ctx: self.span_ctx,
             ignore_binary_tag_for_string: self.ignore_binary_tag_for_string,
-            preserve_tags: self.preserve_tags,
         }
     }
 }

--- a/crates/noyalib/src/parallel.rs
+++ b/crates/noyalib/src/parallel.rs
@@ -248,6 +248,19 @@ mod tests {
         assert_eq!(docs.len(), 1, "got: {docs:?}");
     }
 
+    // Rayon's global thread pool pulls in `crossbeam-epoch`, whose
+    // epoch-based reclamation performs integer-to-pointer casts that
+    // Miri rejects under `-Zmiri-strict-provenance` (see the weekly
+    // `soak-miri` job). The provenance issue is entirely inside the
+    // third-party dep — noyalib's own call sites stay
+    // `#![forbid(unsafe_code)]` — so the rayon-invoking tests are
+    // skipped under Miri while every other test still runs. Mirrors
+    // `scripts/miri.sh`, which excludes rayon from the focused sweep
+    // for the same reason.
+    #[cfg_attr(
+        miri,
+        ignore = "rayon/crossbeam-epoch uses int-to-ptr casts unsupported under -Zmiri-strict-provenance"
+    )]
     #[test]
     fn parse_round_trips_typed_records() {
         #[derive(Debug, Deserialize, PartialEq)]
@@ -262,6 +275,10 @@ mod tests {
         );
     }
 
+    #[cfg_attr(
+        miri,
+        ignore = "rayon/crossbeam-epoch uses int-to-ptr casts unsupported under -Zmiri-strict-provenance"
+    )]
     #[test]
     fn values_yields_value_per_document() {
         let yaml = "---\na: 1\n---\nb: 2\n";
@@ -271,6 +288,10 @@ mod tests {
         assert_eq!(docs[1]["b"].as_i64(), Some(2));
     }
 
+    #[cfg_attr(
+        miri,
+        ignore = "rayon/crossbeam-epoch uses int-to-ptr casts unsupported under -Zmiri-strict-provenance"
+    )]
     #[test]
     fn parse_propagates_first_error() {
         #[derive(Debug, Deserialize)]
@@ -284,6 +305,10 @@ mod tests {
         assert!(res.is_err());
     }
 
+    #[cfg_attr(
+        miri,
+        ignore = "rayon/crossbeam-epoch uses int-to-ptr casts unsupported under -Zmiri-strict-provenance"
+    )]
     #[test]
     fn parse_matches_sequential_for_correctness() {
         // Stress test: 50 small documents. The parallel and

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -1266,7 +1266,7 @@ impl<'a> NoSpanLoader<'a> {
 /// sequences and mappings use a deterministic inline YAML-like representation
 /// so the parser can still build a `Mapping<String, Value>` from YAML with
 /// complex keys (common in the official YAML Test Suite).
-fn value_to_key_string(value: Value) -> Option<String> {
+pub(crate) fn value_to_key_string(value: Value) -> Option<String> {
     use core::fmt::Write as _;
     match value {
         Value::String(s) => Some(s),

--- a/crates/noyalib/src/parser/loader.rs
+++ b/crates/noyalib/src/parser/loader.rs
@@ -876,6 +876,12 @@ struct NoSpanLoader<'a> {
     // `max_merge_keys`). Mirrors the span-full loader's counter so a
     // billion-merges DoS is refused on the `Value` fast path too.
     merge_key_count: usize,
+    /// Total parser events seen (for `max_events`).
+    event_count: usize,
+    /// Cumulative scalar bytes seen (for `max_total_scalar_bytes`).
+    scalar_bytes: usize,
+    /// Anchors defined (denominator for the `alias_anchor_ratio` heuristic).
+    anchor_count: usize,
     config: &'a ParseConfig,
     depth: usize,
     in_document: bool,
@@ -891,6 +897,9 @@ impl<'a> NoSpanLoader<'a> {
             alias_count: 0,
             alias_bytes: 0,
             merge_key_count: 0,
+            event_count: 0,
+            scalar_bytes: 0,
+            anchor_count: 0,
             config,
             depth: 0,
             in_document: false,
@@ -905,6 +914,37 @@ impl<'a> NoSpanLoader<'a> {
     fn process_event(&mut self, event: Event<'_>, input: &str) -> Result<()> {
         if !self.config.policies.is_empty() {
             run_event_policies(&event, &self.config.policies)?;
+        }
+        // Budget parity with the span-full Loader (see its `process_event`):
+        // total events, cumulative scalar bytes, and the anchor counter that
+        // the `alias_anchor_ratio` heuristic divides by.
+        self.event_count += 1;
+        if self.event_count > self.config.max_events {
+            return Err(Error::Budget(crate::BudgetBreach::MaxEvents {
+                limit: self.config.max_events,
+                observed: self.event_count,
+            }));
+        }
+        if let Event::Scalar { value, .. } = &event {
+            self.scalar_bytes = self.scalar_bytes.saturating_add(value.len());
+            if self.scalar_bytes > self.config.max_total_scalar_bytes {
+                return Err(Error::Budget(crate::BudgetBreach::MaxTotalScalarBytes {
+                    limit: self.config.max_total_scalar_bytes,
+                    observed: self.scalar_bytes,
+                }));
+            }
+        }
+        if let Event::Scalar {
+            anchor: Some(_), ..
+        }
+        | Event::SequenceStart {
+            anchor: Some(_), ..
+        }
+        | Event::MappingStart {
+            anchor: Some(_), ..
+        } = &event
+        {
+            self.anchor_count = self.anchor_count.saturating_add(1);
         }
         match event {
             Event::StreamStart | Event::StreamEnd => {}
@@ -934,9 +974,24 @@ impl<'a> NoSpanLoader<'a> {
                 self.in_document = false;
             }
             Event::Alias { anchor, span } => {
+                if !self.in_document {
+                    return Err(Error::parse_at("alias outside document", input, span.start));
+                }
                 self.alias_count += 1;
                 if self.alias_count > self.config.max_alias_expansions {
                     return Err(Error::RepetitionLimitExceeded);
+                }
+                // Budget: alias_anchor_ratio (billion-laughs amplification
+                // fingerprint), mirroring the span-full Loader.
+                if let Some(ratio) = self.config.alias_anchor_ratio {
+                    let anchors = self.anchor_count.max(1) as f64;
+                    if (self.alias_count as f64) > ratio * anchors {
+                        return Err(Error::Budget(crate::BudgetBreach::AliasAnchorRatio {
+                            ratio,
+                            anchors: self.anchor_count,
+                            aliases: self.alias_count,
+                        }));
+                    }
                 }
                 let value = self.anchor_map.get(&anchor).cloned().ok_or_else(|| {
                     let alias_loc = crate::error::Location::from_index(input, span.start);

--- a/crates/noyalib/src/parser/mod.rs
+++ b/crates/noyalib/src/parser/mod.rs
@@ -12,7 +12,9 @@ mod loader;
 mod scanner;
 
 pub(crate) use events::{Event, Parser};
-pub(crate) use loader::{DuplicateKeyPolicy as InternalDuplicateKeyPolicy, ParseConfig};
+pub(crate) use loader::{
+    DuplicateKeyPolicy as InternalDuplicateKeyPolicy, ParseConfig, value_to_key_string,
+};
 pub(crate) use scanner::ScalarStyle;
 // CST builder is the only consumer; gate the re-exports to match.
 #[cfg(feature = "std")]

--- a/crates/noyalib/src/streaming.rs
+++ b/crates/noyalib/src/streaming.rs
@@ -17,6 +17,7 @@ use smallvec::SmallVec;
 
 use crate::error::{Error, Result, closest_name};
 use crate::parser::{Event, ParseConfig, Parser, ScalarStyle};
+use crate::value::Value;
 use core::fmt;
 
 /// Sentinel error message used to signal fallback to the Value-based path.
@@ -661,6 +662,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                     has_emitted_key: false,
                     key_count: 0,
                     seen_keys: FxHashSet::default(),
+                    seen_typed: FxHashMap::default(),
                 });
                 // Decrement on both Ok and Err so a failed inner
                 // visit_map doesn't leak a depth count into the
@@ -961,6 +963,7 @@ impl<'de> de::Deserializer<'de> for &mut StreamingDeserializer<'de> {
                 has_emitted_key: false,
                 key_count: 0,
                 seen_keys: FxHashSet::default(),
+                seen_typed: FxHashMap::default(),
             });
             // Decrement on Ok and Err (issue #46).
             self.depth = self.depth.saturating_sub(1);
@@ -1208,6 +1211,21 @@ impl Drop for StreamingSeqAccess<'_, '_> {
     }
 }
 
+/// Convert a resolved streaming `Scalar` into an owned `Value` — used only to
+/// canonicalise a mapping key for distinct-typed collision detection, matching
+/// the AST loader's untagged-scalar resolution.
+fn scalar_to_value(s: Scalar<'_>) -> Value {
+    match s {
+        Scalar::Null => Value::Null,
+        Scalar::Bool(b) => Value::Bool(b),
+        Scalar::Int(n) => Value::Number(crate::value::Number::Integer(n)),
+        #[cfg(feature = "lossless-u64")]
+        Scalar::Uint(n) => Value::Number(crate::value::Number::Unsigned(n)),
+        Scalar::Float(f) => Value::Number(crate::value::Number::Float(f)),
+        Scalar::Str(s) => Value::String(s.into_owned()),
+    }
+}
+
 struct StreamingMapAccess<'a, 'de> {
     de: &'a mut StreamingDeserializer<'de>,
     finished: bool,
@@ -1217,6 +1235,11 @@ struct StreamingMapAccess<'a, 'de> {
     /// `DuplicateKeyPolicy`. Populated lazily; bypassed when the policy
     /// is `First` (the visitor's own insertion order already matches).
     seen_keys: FxHashSet<String>,
+    /// Canonical key string → the typed key `Value` first seen for it, to
+    /// detect distinct-typed key collisions (`1` vs `"1"`, `~` vs `"null"`)
+    /// in parity with the AST loader. Separate from `DuplicateKeyPolicy`:
+    /// a same-string/different-type clash is always a `KeyCollision` error.
+    seen_typed: FxHashMap<String, Value>,
 }
 
 impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
@@ -1296,11 +1319,39 @@ impl<'de> MapAccess<'de> for StreamingMapAccess<'_, 'de> {
             // is applied before the visitor sees it. Extract the key
             // eagerly so the `ev` borrow is released before we touch
             // `self.de` again.
-            let key_str_opt = if let Event::Scalar { value: key_val, .. } = ev {
-                Some(key_val.to_string())
+            let key_info = if let Event::Scalar {
+                value: key_val,
+                style,
+                tag,
+                ..
+            } = ev
+            {
+                Some((key_val.to_string(), *style, tag.is_none()))
             } else {
                 None
             };
+            // Distinct-typed key-collision guard (parity with the AST loader):
+            // two keys whose canonical map-key string matches but whose typed
+            // Value differs (`1` vs `"1"`, `~` vs `"null"`, `true` vs `"true"`)
+            // are a `KeyCollision`, independent of `DuplicateKeyPolicy`. This is
+            // the guard the streaming path lacked, so `from_str::<map/struct>`
+            // and `from_str_borrowing::<Value>` silently collapsed such keys.
+            // Untagged scalar keys only; tagged keys keep their prior behaviour.
+            if let Some((ref raw, style, true)) = key_info {
+                let typed = scalar_to_value(self.de.resolve_scalar(raw, style));
+                if let Some(canon) = crate::parser::value_to_key_string(typed.clone()) {
+                    match self.seen_typed.get(&canon) {
+                        Some(prev) if *prev != typed => {
+                            return Err(Error::KeyCollision(canon));
+                        }
+                        Some(_) => {}
+                        None => {
+                            let _ = self.seen_typed.insert(canon, typed);
+                        }
+                    }
+                }
+            }
+            let key_str_opt = key_info.map(|(s, _, _)| s);
             let policy = self.de.config.duplicate_key_policy;
             if let Some(key_str) = key_str_opt {
                 if policy != crate::parser::InternalDuplicateKeyPolicy::Last {

--- a/crates/noyalib/src/value.rs
+++ b/crates/noyalib/src/value.rs
@@ -19,7 +19,6 @@ pub type Sequence = Vec<Value>;
 
 mod tag;
 pub use tag::{MaybeTag, Tag, TaggedValue, check_for_tag, nobang};
-pub(crate) use tag::{TAGGED_VALUE_FIELD_TAG, TAGGED_VALUE_FIELD_VALUE, TagPreservingMapAccess};
 
 /// Represents any valid YAML value.
 #[derive(Debug, Clone, Default)]

--- a/crates/noyalib/src/value/serde_impl.rs
+++ b/crates/noyalib/src/value/serde_impl.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-use super::{
-    Mapping, Number, TAGGED_VALUE_FIELD_TAG, TAGGED_VALUE_FIELD_VALUE, Tag, TaggedValue, Value,
-};
+use super::{Mapping, Number, TaggedValue, Value};
 use crate::prelude::*;
 use indexmap::map::Iter;
 use serde::{Deserialize, Serialize};
@@ -81,43 +79,7 @@ impl<'de> Deserialize<'de> for Value {
             where
                 A: MapAccess<'de>,
             {
-                // Tag-preserving fast path: noyalib's own
-                // [`crate::de::Deserializer::deserialize_any`]
-                // routes `Value::Tagged(...)` through a
-                // [`TagPreservingMapAccess`] when its
-                // `preserve_tags` flag is on (set automatically
-                // for `from_str::<Value>` / `from_value::<Value>`
-                // — see [`crate::de::is_value_target`]). The first
-                // key of that map is the [`TAGGED_VALUE_FIELD_TAG`]
-                // sentinel; detect it and reconstruct
-                // `Value::Tagged` so the tag survives the
-                // data-binding return path.
-                //
-                // Other Deserializers (serde_json, FlatMap, …)
-                // never see this magic shape, so this branch is
-                // strictly additive.
                 let first_key: Option<String> = map.next_key()?;
-                if let Some(k) = first_key.as_deref() {
-                    if k == TAGGED_VALUE_FIELD_TAG {
-                        let tag_str: String = map.next_value()?;
-                        let second_key: String = map.next_key()?.ok_or_else(|| {
-                            <A::Error as serde::de::Error>::custom(
-                                "tag-preserving map missing $__noyalib_value entry",
-                            )
-                        })?;
-                        if second_key != TAGGED_VALUE_FIELD_VALUE {
-                            return Err(<A::Error as serde::de::Error>::custom(format!(
-                                "tag-preserving map: expected `{}`, got `{}`",
-                                TAGGED_VALUE_FIELD_VALUE, second_key
-                            )));
-                        }
-                        let inner: Value = map.next_value()?;
-                        return Ok(Value::Tagged(Box::new(TaggedValue::new(
-                            Tag::new(tag_str),
-                            inner,
-                        ))));
-                    }
-                }
                 // Regular mapping path — collect every (k, v) pair
                 // including the (k, v) we already consumed.
                 // Pre-size when the MapAccess provides a usable

--- a/crates/noyalib/src/value/tag.rs
+++ b/crates/noyalib/src/value/tag.rs
@@ -62,16 +62,6 @@ pub fn check_for_tag<T: fmt::Display>(value: &T) -> MaybeTag<String> {
     }
 }
 
-/// Magic key in the [`TagPreservingMapAccess`] map shape that
-/// signals "the next entry is the tag string". Recognised by
-/// `Value::deserialize`'s visitor on the tag-preserving path
-/// driven by [`crate::de::Deserializer::preserve_tags`].
-pub(crate) const TAGGED_VALUE_FIELD_TAG: &str = "$__noyalib_tag";
-
-/// Magic key in the [`TagPreservingMapAccess`] map shape that
-/// signals "the next entry is the inner [`Value`]".
-pub(crate) const TAGGED_VALUE_FIELD_VALUE: &str = "$__noyalib_value";
-
 /// A YAML tag.
 ///
 /// Tags are used in YAML to denote the type of a value.
@@ -430,108 +420,6 @@ impl<'de> serde::de::MapAccess<'de> for TaggedValueMapAccess<'de> {
         match self.value.take() {
             Some(value) => seed.deserialize(value),
             None => Err(serde::de::Error::custom("value is missing")),
-        }
-    }
-}
-
-/// MapAccess emitted on the [`TAGGED_VALUE_TYPE_NAME`] code path.
-///
-/// Surfaces a tagged scalar as a two-entry map with magic keys
-/// (`$__noyalib_tag` → tag string; `$__noyalib_value` → inner
-/// `Value`) so [`Value`]'s own visitor can pattern-match the
-/// shape and reconstruct `Value::Tagged(...)` on the
-/// data-binding return path. Distinct from the existing
-/// [`TaggedValueMapAccess`] (which uses the *real* tag as the
-/// map key for typed-enum deserialise) to avoid colliding with
-/// user data that legitimately has a key of the same name.
-pub(crate) struct TagPreservingMapAccess<'de> {
-    state: TagPreservingState<'de>,
-}
-
-#[derive(Clone, Copy)]
-enum TagPreservingState<'de> {
-    EmitTagKey { tag: &'de str, value: &'de Value },
-    EmitTagValue { tag: &'de str, value: &'de Value },
-    EmitValueKey { value: &'de Value },
-    EmitValueValue { value: &'de Value },
-    Done,
-}
-
-impl<'de> TagPreservingMapAccess<'de> {
-    pub(crate) fn new(tag: &'de str, value: &'de Value) -> Self {
-        Self {
-            state: TagPreservingState::EmitTagKey { tag, value },
-        }
-    }
-}
-
-impl<'de> serde::de::MapAccess<'de> for TagPreservingMapAccess<'de> {
-    type Error = crate::Error;
-
-    fn next_key_seed<K>(&mut self, seed: K) -> crate::Result<Option<K::Value>>
-    where
-        K: serde::de::DeserializeSeed<'de>,
-    {
-        match self.state {
-            TagPreservingState::EmitTagKey { tag, value } => {
-                self.state = TagPreservingState::EmitTagValue { tag, value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
-                        TAGGED_VALUE_FIELD_TAG,
-                    ),
-                )
-                .map(Some)
-            }
-            TagPreservingState::EmitValueKey { value } => {
-                self.state = TagPreservingState::EmitValueValue { value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(
-                        TAGGED_VALUE_FIELD_VALUE,
-                    ),
-                )
-                .map(Some)
-            }
-            TagPreservingState::Done => Ok(None),
-            // Calling next_key without consuming the previous value
-            // is a serde misuse — surface as a custom error rather
-            // than panicking.
-            TagPreservingState::EmitTagValue { .. } | TagPreservingState::EmitValueValue { .. } => {
-                Err(serde::de::Error::custom(
-                    "TagPreservingMapAccess: next_key called before next_value",
-                ))
-            }
-        }
-    }
-
-    fn next_value_seed<V>(&mut self, seed: V) -> crate::Result<V::Value>
-    where
-        V: serde::de::DeserializeSeed<'de>,
-    {
-        match self.state {
-            TagPreservingState::EmitTagValue { tag, value } => {
-                self.state = TagPreservingState::EmitValueKey { value };
-                seed.deserialize(
-                    serde::de::value::BorrowedStrDeserializer::<crate::Error>::new(tag),
-                )
-            }
-            TagPreservingState::EmitValueValue { value } => {
-                self.state = TagPreservingState::Done;
-                // Route through the preserve-tags-aware Deserializer
-                // so any nested `Value::Tagged` inside `value` also
-                // survives the round-trip — without this wrapping,
-                // a tagged scalar inside a tagged collection would
-                // collapse to the single-key `Mapping{"!tag": …}`
-                // shape that the standard `&'de Value` Deserializer
-                // produces for `Value::Tagged` (BUG: noyalib v0.0.1
-                // C4HZ regression — global tags inside a tagged
-                // sequence).
-                seed.deserialize(crate::de::Deserializer::with_options_preserving_tags(
-                    value, None, false,
-                ))
-            }
-            _ => Err(serde::de::Error::custom(
-                "TagPreservingMapAccess: next_value called out of order",
-            )),
         }
     }
 }

--- a/crates/noyalib/tests/cov_number_ord.rs
+++ b/crates/noyalib/tests/cov_number_ord.rs
@@ -36,7 +36,7 @@ fn number_ord_integer_vs_unsigned() {
 #[test]
 fn number_ord_unsigned_vs_float_and_nan() {
     let umax = Value::from(u64::MAX);
-    let flt = Value::from(3.14_f64);
+    let flt = Value::from(2.5_f64);
     let nan = Value::from(f64::NAN);
 
     // Unsigned vs Float and the symmetric Float vs Unsigned.
@@ -50,7 +50,7 @@ fn number_ord_unsigned_vs_float_and_nan() {
 #[test]
 fn number_ord_integer_vs_float() {
     let neg = Value::from(-5_i64);
-    let flt = Value::from(3.14_f64);
+    let flt = Value::from(2.5_f64);
     assert_eq!(neg.cmp(&flt), Ordering::Less);
     assert_eq!(flt.cmp(&neg), Ordering::Greater);
 }
@@ -58,10 +58,10 @@ fn number_ord_integer_vs_float() {
 #[test]
 fn number_ord_sort_mixed_types() {
     // A sort exercises many cross-type comparisons at once.
-    let mut xs = vec![
+    let mut xs = [
         Value::from(u64::MAX),
         Value::from(-5_i64),
-        Value::from(3.14_f64),
+        Value::from(2.5_f64),
         Value::from(5_i64),
         Value::from(0_i64),
     ];

--- a/crates/noyalib/tests/cov_number_ord.rs
+++ b/crates/noyalib/tests/cov_number_ord.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Coverage: `Number::cmp` cross-type arms (Integer / Unsigned / Float),
+//! reachable because `Value::cmp` delegates to `Number::cmp` for two numeric
+//! values. The `Unsigned` arms are `#[cfg(feature = "lossless-u64")]`.
+//!
+//! NB: values are built with `Value::from(u64/i64/f64)` — `from_str` with the
+//! default config never yields `Number::Unsigned` (lossless-u64 is a config
+//! toggle, not just a feature), so it would not reach the `Unsigned` arms.
+
+#![cfg(feature = "lossless-u64")]
+#![allow(clippy::unwrap_used)]
+
+use std::cmp::Ordering;
+
+use noyalib::Value;
+
+#[test]
+fn number_ord_integer_vs_unsigned() {
+    let umax = Value::from(u64::MAX); // Number::Unsigned
+    let neg = Value::from(-5_i64); // Number::Integer(-5)
+    let pos = Value::from(5_i64); // Number::Integer(5)
+
+    // Integer vs Unsigned: a negative integer is always Less.
+    assert_eq!(neg.cmp(&umax), Ordering::Less);
+    // A non-negative integer widens to u64 and compares.
+    assert_eq!(pos.cmp(&umax), Ordering::Less);
+    // Unsigned vs Integer (the symmetric arm).
+    assert_eq!(umax.cmp(&neg), Ordering::Greater);
+    assert_eq!(umax.cmp(&pos), Ordering::Greater);
+    // Unsigned vs Unsigned.
+    assert_eq!(umax.cmp(&Value::from(u64::MAX)), Ordering::Equal);
+}
+
+#[test]
+fn number_ord_unsigned_vs_float_and_nan() {
+    let umax = Value::from(u64::MAX);
+    let flt = Value::from(3.14_f64);
+    let nan = Value::from(f64::NAN);
+
+    // Unsigned vs Float and the symmetric Float vs Unsigned.
+    assert_eq!(umax.cmp(&flt), Ordering::Greater);
+    assert_eq!(flt.cmp(&umax), Ordering::Less);
+    // NaN arms must not panic and must yield a total order.
+    let _ = umax.cmp(&nan);
+    let _ = nan.cmp(&umax);
+}
+
+#[test]
+fn number_ord_integer_vs_float() {
+    let neg = Value::from(-5_i64);
+    let flt = Value::from(3.14_f64);
+    assert_eq!(neg.cmp(&flt), Ordering::Less);
+    assert_eq!(flt.cmp(&neg), Ordering::Greater);
+}
+
+#[test]
+fn number_ord_sort_mixed_types() {
+    // A sort exercises many cross-type comparisons at once.
+    let mut xs = vec![
+        Value::from(u64::MAX),
+        Value::from(-5_i64),
+        Value::from(3.14_f64),
+        Value::from(5_i64),
+        Value::from(0_i64),
+    ];
+    xs.sort();
+    assert_eq!(xs.first(), Some(&Value::from(-5_i64)));
+    assert_eq!(xs.last(), Some(&Value::from(u64::MAX)));
+}

--- a/crates/noyalib/tests/issue_46.rs
+++ b/crates/noyalib/tests/issue_46.rs
@@ -154,7 +154,14 @@ fn pnpm_lockfile_with_deep_peer_suffixes() {
 #[test]
 fn pnpm_lockfile_50000_pkgs_does_not_recursion_limit() {
     let yaml = make_lockfile(50_000);
-    let v: noyalib::Value = noyalib::from_str(&yaml).expect("50k packages should parse cleanly");
+    // 50k packages is deliberately larger than any real pnpm-lock and exceeds
+    // the default `max_events` DoS budget (~1M events) — which the `Value`
+    // fast path now enforces in parity with the span-full loader (v0.0.15).
+    // Lift the event budget so the test exercises its actual concern (linear
+    // scaling / no recursion limit) rather than the DoS budget.
+    let cfg = noyalib::ParserConfig::new().max_events(usize::MAX);
+    let v: noyalib::Value =
+        noyalib::from_str_with_config(&yaml, &cfg).expect("50k packages should parse cleanly");
     match v {
         noyalib::Value::Mapping(m) => assert!(m.contains_key("packages")),
         _ => panic!("expected top-level mapping"),

--- a/crates/noyalib/tests/key_collision_streaming.rs
+++ b/crates/noyalib/tests/key_collision_streaming.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Copyright (c) 2026 Noyalib. All rights reserved.
+
+//! Distinct-typed key-collision parity on the STREAMING path (v0.0.15).
+//!
+//! v0.0.14 gave `from_str::<Value>` (the AST fast path) the KeyCollision
+//! guard, but the streaming path — used for typed/struct/map targets and the
+//! borrowing API — still stringified keys and silently collapsed a distinct-
+//! typed collision (`1` vs `"1"`). This suite pins the fix: the streaming
+//! path now detects collisions in parity with the loader.
+
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+
+use noyalib::{Error, Value, from_str, from_str_borrowing};
+
+fn assert_collision<T: std::fmt::Debug>(r: Result<T, Error>, ctx: &str) {
+    assert!(
+        matches!(r, Err(Error::KeyCollision(_))),
+        "{ctx}: expected KeyCollision, got {r:?}"
+    );
+}
+
+#[test]
+fn typed_map_target_detects_distinct_typed_collision() {
+    // The typed/map target routes through streaming; `1` (int) and `"1"`
+    // (string) both stringify to "1" and used to silently collapse.
+    assert_collision(
+        from_str::<BTreeMap<String, String>>("1: a\n\"1\": b\n"),
+        "BTreeMap 1 vs \"1\"",
+    );
+    assert_collision(
+        from_str::<BTreeMap<String, String>>("true: a\n\"true\": b\n"),
+        "BTreeMap true vs \"true\"",
+    );
+    assert_collision(
+        from_str::<BTreeMap<String, String>>("~: a\n\"null\": b\n"),
+        "BTreeMap ~ vs \"null\"",
+    );
+}
+
+#[test]
+fn borrowing_value_target_detects_distinct_typed_collision() {
+    // BUG004: the zero-copy entry point built a StreamingDeserializer
+    // unconditionally, so `Value` collisions collapsed silently there.
+    assert_collision(
+        from_str_borrowing::<Value>("1: a\n\"1\": b\n"),
+        "from_str_borrowing::<Value>",
+    );
+}
+
+#[test]
+fn streaming_collision_does_not_over_fire() {
+    // Distinct keys and genuine same-typed duplicates are NOT collisions.
+    let ok: BTreeMap<String, i64> = from_str("a: 1\nb: 2\n").unwrap();
+    assert_eq!(ok.len(), 2);
+    let ints: BTreeMap<String, i64> = from_str("1: 10\n2: 20\n").unwrap();
+    assert_eq!(ints.len(), 2);
+    // Same-typed duplicate key resolves under DuplicateKeyPolicy (last wins),
+    // not a collision.
+    let dup: BTreeMap<String, i64> = from_str("a: 1\na: 2\n").unwrap();
+    assert_eq!(dup.get("a"), Some(&2));
+}

--- a/crates/noyalib/tests/no_span_loader_parity.rs
+++ b/crates/noyalib/tests/no_span_loader_parity.rs
@@ -193,3 +193,43 @@ fn value_fast_path_enforces_max_documents() {
         "expected MaxDocuments budget error, got {err:?}"
     );
 }
+
+// ── Further DoS-budget parity on the Value fast path (v0.0.15, bug_003) ──
+
+#[test]
+fn value_fast_path_enforces_alias_anchor_ratio() {
+    // 1 anchor, 10 aliases, ratio 2.0 — the billion-laughs amplification
+    // fingerprint the span-full loader / cst::parse_document already catch.
+    let cfg = ParserConfig::new().alias_anchor_ratio(Some(2.0));
+    let src = "a: &x 1\nb: [*x, *x, *x, *x, *x, *x, *x, *x, *x, *x]\n";
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("alias_anchor_ratio must be enforced on the Value fast path");
+    assert!(
+        matches!(err, Error::Budget(BudgetBreach::AliasAnchorRatio { .. })),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn value_fast_path_enforces_max_events() {
+    let cfg = ParserConfig::new().max_events(3);
+    let src = "a: 1\nb: 2\nc: 3\nd: 4\n"; // well over 3 events
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("max_events must be enforced on the Value fast path");
+    assert!(
+        matches!(err, Error::Budget(BudgetBreach::MaxEvents { .. })),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn value_fast_path_enforces_max_total_scalar_bytes() {
+    let cfg = ParserConfig::new().max_total_scalar_bytes(4);
+    let src = "key: aaaaaaaaaa\n"; // 10-byte scalar > 4
+    let err = from_str_with_config::<Value>(src, &cfg)
+        .expect_err("max_total_scalar_bytes must be enforced on the Value fast path");
+    assert!(
+        matches!(err, Error::Budget(BudgetBreach::MaxTotalScalarBytes { .. })),
+        "got {err:?}"
+    );
+}


### PR DESCRIPTION
## Why this exists

PR #172 was marked **MERGED** but its changes never actually landed on
`main` — its squash commit (`25dbb22e`) is on no ref, its commits
(`4bac025`, `9baffab`, …) are ancestors of neither `v0.0.14` nor `main`,
and two of its added test files are absent from `main`. GitHub closed it
as merged (a lost ref-update during the admin-merge, likely the
TLS-timeout window), so the fixes silently disappeared.

This re-lands the identical, already-signed commits.

## What it restores

- **`fix(loader): NoSpanLoader DoS-budget parity`** — `max_events`,
  total-scalar-bytes, and alias-ratio budgets on the `NoSpanLoader` path,
  matching the streaming and span-full loaders. This is a **loader-parity
  invariant** (a repo non-negotiable); without it, `main` / shipped
  v0.0.14 has a NoSpanLoader DoS-budget gap.
- **`fix(streaming): distinct-typed key-collision guard`** on the
  streaming path.
- `refactor(de)`: remove the orphaned tag-preserving deserializer dead
  code; `ci(miri)`: skip rayon tests under strict-provenance; the
  `Number::cmp` cross-type Ord tests; the `cov_number_ord` clippy fix.

## Verification

- Merges **cleanly** into current `main` (no conflicts) — the coverage
  PRs since #172 touched disjoint files (`de.rs` vs `de/deserializer.rs`,
  test-only additions elsewhere).
- Loader-parity + key-collision tests pass on the merged tree:
  `no_span_loader_parity` (13) and `key_collision_streaming` (3) green.
- All 6 commits are signed.

Holding the v0.0.15 release until this is in.

Assisted-by: Claude <noreply@anthropic.com>