### PR TITLE
release: v0.0.15 — loader-parity completion + coverage hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-(Nothing yet — `[v0.0.14]` is the cut.)
+(Nothing yet — `[v0.0.15]` is the cut.)
+
+## [v0.0.15] - 2026-07-11
+
+The **loader-parity completion + coverage-hardening** cut. Finishes the
+three-loader DoS-budget parity started in v0.0.14 by extending the
+remaining budgets to the `NoSpanLoader` fast path and the
+distinct-typed-key collision guard to the streaming loader, then drives a
+workspace-wide coverage campaign (≈16 files to effective-100%) with no
+change to public API or behaviour beyond the parity fixes.
+
+Lockstep versioning: `noyalib` bumps `0.0.14` → `0.0.15`.
+Satellites publish `=0.0.15` from their own repos:
+- [`sebastienrousseau/noyalib-wasm@0.0.15`](https://github.com/sebastienrousseau/noyalib-wasm)
+- [`sebastienrousseau/noyalib-mcp@0.0.15`](https://github.com/sebastienrousseau/noyalib-mcp)
+- [`sebastienrousseau/noyalib-lsp@0.0.15`](https://github.com/sebastienrousseau/noyalib-lsp)
+- [`sebastienrousseau/noya-cli@0.0.15`](https://github.com/sebastienrousseau/noya-cli)
+
+### Fixed — loader parity (security)
+
+- **`NoSpanLoader` DoS-budget parity, completed.** The `Value` fast path
+  now also enforces `max_events`, the total-scalar-bytes budget, and the
+  `alias_anchor_ratio` — the three budgets still span-full-only after
+  v0.0.14. All three loaders (streaming, span-full `Loader`,
+  `NoSpanLoader`) now enforce the same DoS budgets, with cross-path
+  tests (`no_span_loader_parity`).
+- **Distinct-typed key-collision guard on the streaming loader.** The
+  guard that raises `Error::KeyCollision` for `1: a` vs `"1": b` (added
+  to the AST paths in v0.0.14) now also runs on the streaming
+  deserialiser, closing the last loader where the collision could
+  silently collapse (`key_collision_streaming`).
+
+### Testing / tooling
+
+- Workspace coverage campaign: ~16 files driven to effective-100%
+  (`de`, `include`, `schema_validate`, `compat/serde_yaml`, `base64`,
+  `cst/coerce`, `error`, `ser`, `value/number`, `cst/green`, `recovery`,
+  and more). Region/line/function coverage rises across the workspace;
+  no behavioural change.
+- `make coverage-gap` restored under `cargo-llvm-cov ≥ 0.8.7` (the
+  empty `--ignore-filename-regex` is now guarded, matching CI).
 
 ## [v0.0.14] - 2026-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "noyalib"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "ariadne",
  "bytes",

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ wants to *use* the library. The full reference is the
 
 ```toml
 [dependencies]
-noyalib = "0.0.14"
+noyalib = "0.0.15"
 ```
 
 `no_std` (alloc-only) and lean profiles are documented in the

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,7 +45,7 @@ to crates.io as before:
 
 ```toml
 [dependencies]
-noyalib = "0.0.14"
+noyalib = "0.0.15"
 ```
 
 ### Consuming a satellite crate
@@ -56,8 +56,8 @@ version pin:
 
 ```toml
 [dependencies]
-noyalib-wasm = "0.0.14"   # crates.io — repo doesn't matter to Cargo
-noyalib-mcp  = "0.0.14"
+noyalib-wasm = "0.0.15"   # crates.io — repo doesn't matter to Cargo
+noyalib-mcp  = "0.0.15"
 ```
 
 The [ADR-0005 strict-lockstep contract](doc/adr/0005-workspace-split.md#versioning-contract)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.14"
+noyalib = "0.0.15"
 ```
 
 ### As a CLI tool
@@ -106,7 +106,7 @@ maintainer runbook.
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.14", default-features = false }
+noyalib = { version = "0.0.15", default-features = false }
 ```
 
 Requires `alloc`. Core data binding (`from_str`, `to_string`, `Value`,
@@ -176,7 +176,7 @@ the application needs.
 ```toml
 # Example: rich diagnostics + schema validation
 [dependencies]
-noyalib = { version = "0.0.14", features = ["miette", "validate-schema"] }
+noyalib = { version = "0.0.15", features = ["miette", "validate-schema"] }
 ```
 
 **Optional features:** `lossless-u64` preserves YAML integer scalars above
@@ -290,7 +290,7 @@ tables for each.
 -[dependencies]
 -serde_yaml = "0.9"
 +[dependencies]
-+noyalib = "0.0.14"
++noyalib = "0.0.15"
 ```
 
 ```diff

--- a/RELEASE-NOTES-v0.0.15.md
+++ b/RELEASE-NOTES-v0.0.15.md
@@ -1,0 +1,87 @@
+<!-- SPDX-FileCopyrightText: 2026 Noyalib -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# noyalib v0.0.15 Release Notes
+
+The **loader-parity completion + coverage-hardening** cut. Finishes the
+three-loader DoS-budget parity begun in v0.0.14 — extending the remaining
+budgets to the span-free `NoSpanLoader` and the distinct-typed key-collision
+guard to the streaming loader — and lands a workspace-wide coverage
+campaign that drives roughly sixteen files to effective-100%.
+
+No breaking API changes. No MSRV change (still 1.85). No new runtime
+dependencies. The only behavioural change is that a few previously
+under-guarded DoS budgets and one collision case are now enforced on the
+loader paths that were still missing them.
+
+## Why this release exists
+
+v0.0.14 was the loader-parity cut: it brought the `NoSpanLoader` (`Value`
+fast path) up to par with the span-full `Loader` on the key-collision
+guard and four DoS budgets. Two gaps remained after that cut, and are
+closed here:
+
+1. Three budgets — `max_events`, the total-scalar-bytes cap, and the
+   `alias_anchor_ratio` — were still span-full-only. On adversarial
+   input, the `NoSpanLoader` path could exceed limits the span-full path
+   rejects.
+2. The distinct-typed key-collision guard ran on the AST loaders but not
+   on the **streaming** deserialiser — the third of the three loaders.
+   `1: a\n"1": b\n` deserialised through the streaming path could still
+   silently collapse.
+
+Both are now fixed, so all three loaders — streaming, span-full `Loader`,
+and `NoSpanLoader` — enforce the same DoS budgets and the same
+collision semantics, with cross-path tests proving it.
+
+Alongside the parity work, this release folds in a workspace coverage
+campaign (test-only) that hardens the regression suite substantially.
+
+## What changed
+
+### Loader parity (security)
+
+- **`NoSpanLoader` DoS-budget parity completed** — `max_events`,
+  total-scalar-bytes, and `alias_anchor_ratio` budgets now enforced on
+  the `Value` fast path, matching the streaming and span-full loaders.
+  Covered by `tests/no_span_loader_parity.rs`.
+- **Streaming key-collision guard** — the distinct-typed-key
+  `Error::KeyCollision` guard now runs on the streaming deserialiser,
+  closing the last loader where `1` vs `"1"` could collapse. Covered by
+  `tests/key_collision_streaming.rs`.
+- Removed an orphaned, unreachable tag-preserving deserialiser path in
+  `de/deserializer.rs` (dead code; no behavioural effect).
+
+### Testing / tooling (no behavioural change)
+
+- Workspace coverage campaign: ~16 files driven to effective-100% —
+  `de` / `include`, `schema_validate`, `compat/serde_yaml` (100% fn),
+  `base64` (99.4% line), `cst/coerce`, `error` (98.7% region),
+  `ser`, `value/number` (97.5% region), `cst/green` (100%), `recovery`,
+  and the CST formatter.
+- Corrected a **wrong-but-green** regression test (an `!include`
+  depth-cap test that tripped the cycle guard instead of the depth
+  guard) and an over-claimed "defensive" annotation (formatter arms that
+  malformed input actually reaches).
+- `make coverage-gap` restored under `cargo-llvm-cov ≥ 0.8.7` — the
+  empty `--ignore-filename-regex` is now guarded, matching the CI
+  workflow.
+
+## What did not change
+
+- Public API surface — no additions, removals, or signature changes.
+- MSRV — still Rust 1.85.
+- Dependencies — no new runtime deps; `#![forbid(unsafe_code)]` intact.
+- Default parse/serialise behaviour for well-formed input — identical.
+
+## Follow-ups noted for v0.0.16
+
+- Still open from v0.0.14: migrate `max_sequence_length` /
+  `max_mapping_keys` from `Error::Serialize("… limit exceeded")` to
+  `Error::Budget(BudgetBreach::…)` for full `Error::kind()` classifier
+  parity; and wire `cargo-semver-checks` into the release workflow.
+- Coverage floor: literal 98% region is not reachable by tests alone —
+  defensive arms (`invariant_violated`, `unreachable!()`, in-file test
+  `panic!`) are permanently counted, and `#[coverage(off)]` can only
+  exclude whole functions. The remaining region gap is that floor, not
+  missing tests.

--- a/crates/noyalib/Cargo.toml
+++ b/crates/noyalib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noyalib"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -44,14 +44,14 @@
 
 ```toml
 [dependencies]
-noyalib = "0.0.14"
+noyalib = "0.0.15"
 ```
 
 `no_std` (alloc-only) builds:
 
 ```toml
 [dependencies]
-noyalib = { version = "0.0.14", default-features = false }
+noyalib = { version = "0.0.15", default-features = false }
 ```
 
 Core data binding (`from_str`, `to_string`, `Value`, schemas) and

--- a/crates/noyalib/tests/coverage_value_serde.rs
+++ b/crates/noyalib/tests/coverage_value_serde.rs
@@ -1,40 +1,20 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-//! Coverage for `value/serde_impl.rs` — the tag-preserving map
-//! deserialization path (`$__noyalib_*` magic fields), the enum-from-
-//! string deserializer, and the lossless-u64 visitor arm.
+//! Coverage for `value/serde_impl.rs` — the enum-from-string
+//! deserializer and the lossless-u64 visitor arm.
+//!
+//! (An earlier revision also tested a tag-preserving magic-map
+//! deserialize path; that path was genuinely orphaned — `Value::Tagged`
+//! serialises to a foreign serde format as `{tag: value}`, never as the
+//! `$__noyalib_*` magic map, so nothing produces that input — and was
+//! removed as dead code in #172, so the test is gone with it.)
 
 #![allow(missing_docs)]
 #![allow(clippy::unwrap_used)]
 
 use noyalib::{Value, from_value, to_value};
 use serde::Deserialize;
-
-#[test]
-fn tag_preserving_magic_map_reconstructs_tagged_value() {
-    // When a `Value::Tagged` is serialized to a *foreign* serde format
-    // (one with no native tag concept), it becomes the tag-preserving
-    // magic map `{$__noyalib_tag, $__noyalib_value}`. Reading that map
-    // back through `Value::deserialize` (here via serde_json, so the
-    // `Value`-clone fast path in `from_value` is bypassed) exercises the
-    // visit_map tag-reconstruction branch and rebuilds the tagged node.
-    let json = serde_json::json!({
-        "$__noyalib_tag": "!Celsius",
-        "$__noyalib_value": 42_i64,
-    });
-    let back: Value = serde_json::from_value(json).unwrap();
-    let t = back
-        .as_tagged()
-        .expect("magic map must rebuild a tagged value");
-    assert_eq!(t.tag().as_str(), "!Celsius");
-    assert_eq!(t.value().as_i64(), Some(42));
-
-    // A magic map missing the `$__noyalib_value` entry is a hard error.
-    let bad = serde_json::json!({ "$__noyalib_tag": "!x", "other": 1 });
-    let res: Result<Value, _> = serde_json::from_value(bad);
-    assert!(res.is_err(), "missing value field must error");
-}
 
 #[test]
 fn enum_deserializes_from_bare_string() {

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -487,7 +487,7 @@ diagnostics list and offer autocomplete on the recoverable
 subtrees.
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.14", features = ["recovery"] }
+// Cargo.toml: noyalib = { version = "0.0.15", features = ["recovery"] }
 use noyalib::recovery::parse_lenient;
 
 let half_typed = "name: noyalib\nfeatures: [recovery, sval\n# ^ unclosed\n";
@@ -510,7 +510,7 @@ For high-concurrency services parsing YAML from network sources,
 the `tokio` feature lets you skip `spawn_blocking`:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.14", features = ["tokio"] }
+// Cargo.toml: noyalib = { version = "0.0.15", features = ["tokio"] }
 use noyalib::tokio_async::{from_async_reader_multi, YamlDecoder};
 
 // Pattern 1: drain-and-parse
@@ -534,7 +534,7 @@ cost of serde monomorphisation. The adapter implements
 `sval::Stream` consumer can read it:
 
 ```rust
-// Cargo.toml: noyalib = { version = "0.0.14", features = ["sval"] }
+// Cargo.toml: noyalib = { version = "0.0.15", features = ["sval"] }
 let value: noyalib::Value = noyalib::from_str("name: noyalib")?;
 sval::Value::stream(&value, &mut my_stream)?;
 ```


### PR DESCRIPTION
## v0.0.15 — loader-parity completion (security) + coverage hardening

### Fixed — loader parity (security)
- **`NoSpanLoader` DoS-budget parity completed** — `max_events`,
  total-scalar-bytes, and `alias_anchor_ratio` now enforced on the
  `Value` fast path (span-full-only after v0.0.14). All three loaders
  (streaming, span-full `Loader`, `NoSpanLoader`) now enforce the same
  DoS budgets. Cross-path test: `no_span_loader_parity`.
- **Streaming key-collision guard** — the distinct-typed-key
  `Error::KeyCollision` guard now runs on the streaming loader, closing
  the last path where `1` vs `"1"` could silently collapse. Test:
  `key_collision_streaming`.

### Testing / tooling
- Workspace coverage campaign: ~16 files to effective-100%.
- `make coverage-gap` restored under `cargo-llvm-cov ≥ 0.8.7`.

### This PR
- Version 0.0.14 → 0.0.15 (`Cargo.toml` + `Cargo.lock`).
- CHANGELOG `[v0.0.15]` entry; `RELEASE-NOTES-v0.0.15.md`.
- Version-ref audit: README ×2 / GETTING_STARTED / MIGRATION / USER-GUIDE
  install refs bumped; historical `v0.0.14` prose preserved; no stragglers.

No breaking API changes. No MSRV change (1.85). No new runtime deps.

Satellites (`noyalib-wasm`, `noyalib-mcp`, `noyalib-lsp`, `noya-cli`)
publish `=0.0.15` in lockstep from their own repos after this tags.

Assisted-by: Claude <noreply@anthropic.com>