### PR TITLE
docs: accuracy & consistency sweep (README, rustdoc, examples, benches, doc/)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -90,13 +90,13 @@ make fmt            # rustfmt --check
 make deny           # cargo-deny supply-chain audit
 ```
 
-Prerequisites: **Rust 1.75.0+** for the core library, **1.85.0+**
-for the CLI / LSP satellite crates (their dep trees pull edition-2024
-transitives). `make` orchestrates the full local check suite.
+Prerequisites: **Rust 1.85.0+** (edition 2024) for the core library and
+the CLI / LSP satellite crates alike. `make` orchestrates the full local
+check suite.
 
 ## Running examples
 
-The `crates/noyalib/examples/` directory contains 50+ runnable
+The `crates/noyalib/examples/` directory contains 76 runnable
 examples covering every public surface — schema validation,
 borrowed-path parsing, CST editing, no_std, robotics newtypes,
 figment integration, and more. Each compiles independently:

--- a/README.md
+++ b/README.md
@@ -136,15 +136,15 @@ downstream users pinned to the core's floor.
 | `noyalib-lsp` | 1.85.0 | LSP transport-stack transitives (`litemap`, `uuid`) require recent stables. |
 
 Optional core-lib features pull in ergonomics deps that have
-themselves bumped past 1.75 — `miette` → backtrace 1.82+,
+themselves bumped past 1.85 — `miette` → backtrace 1.82+,
 `garde` → 1.84+, `validate-schema` / `figment` → ICU chain
 1.86+, `parallel` → rayon-core 1.80+. Use those with a current
 stable toolchain; the core lib stays buildable on the Ubuntu
-24.04 LTS rustc-1.75 floor.
+24.04 LTS rustc-1.85 floor.
 
 `rust-toolchain.toml` itself selects `stable` for local
-development; the 1.75.0 floor on the core surface is enforced
-by the dedicated `msrv-1-75-core` CI job (Ubuntu,
+development; the 1.85.0 floor on the core surface is enforced
+by the dedicated `msrv-1-85-core` CI job (Ubuntu,
 no-default-features + default-features build paths).
 
 ### Cargo features
@@ -156,6 +156,9 @@ the application needs.
 | :--- | :--- | :--- | :--- |
 | `std` *(default)* | — | `from_reader`, `to_writer`, `Spanned<T>`, CST module | [Install](#install) |
 | `miette` | `miette` 7 | Rich terminal diagnostics with source spans | [Library Usage](#library-usage), `examples/diagnostic.rs` |
+| `ariadne` | `ariadne` | Alternative `ariadne`-rendered diagnostics | `examples/ariadne_diagnostic.rs` |
+| `include` | — | `$include` directive resolution via an in-memory resolver | `examples/include_directive.rs` |
+| `include_fs` | `include` + `std` | Filesystem include resolver (`SafeFileResolver`) | `examples/include_directive.rs` |
 | `schema` | `schemars`, `serde_json` | `JsonSchema` derive + `schema_for::<T>()`. **Downstream callers that derive `JsonSchema` must add `schemars = "1.2"` to their own `Cargo.toml`** — the proc-macro emits `::schemars::*` paths that need to resolve in the call-site dep graph. | [Capabilities in 0.0.1](#capabilities-in-001) |
 | `validate-schema` | `schema` + `jsonschema` | `validate_against_schema`, `coerce_to_schema` | [Governance: schema-driven autofix](#governance-schema-driven-autofix) |
 | `figment` | `figment` 0.10 | `noyalib::figment::Yaml` provider | `examples/figment.rs` |
@@ -166,12 +169,13 @@ the application needs.
 | `recovery` | — | `noyalib::recovery::parse_lenient` — best-effort tree + error list for LSP / IDE half-typed documents | `examples/recovery_lenient.rs`, `benches/v006_features.rs` |
 | `sval` | `sval` 2 | `impl sval::Value` for `Value` / `Number` / `Mapping` / `MappingAny` / `TaggedValue`, `noyalib::sval_adapter::to_sval_writer` | `examples/sval_streaming.rs`, `benches/v006_features.rs` |
 | `tokio` | `tokio`, `tokio-util`, `bytes` | `noyalib::tokio_async::from_async_reader` / `from_async_reader_multi` and `YamlDecoder` codec for `tokio_util::codec::Framed` pipelines | `examples/tokio_async_reader.rs`, `benches/v006_features.rs` |
-| `simd` | — | `noyalib::simd::*` primitives + parser hot path | [Benchmarks](#benchmarks) |
+| `simd` | — | Forward-compat no-op — `noyalib::simd::*` is always available and the parser hot path uses it unconditionally | [Benchmarks](#benchmarks) |
 | `nightly-simd` | `simd` (nightly toolchain) | `core::simd`-backed `StructuralIter` (32-byte chunks) | [Benchmarks](#benchmarks) |
 | `compat-serde-yaml` | — | `noyalib::compat::serde_yaml` shim for migration | [When not to use noyalib](#when-not-to-use-noyalib) |
 | `lossless-u64` | — | `Number::Unsigned(u64)` plus opt-in parser/serializer config for scalars in `(i64::MAX, u64::MAX]` | [`doc/adr/0004-lossless-u64-integers.md`](doc/adr/0004-lossless-u64-integers.md), `examples/lossless_u64.rs`, `benches/lossless_u64.rs` |
 | `compare-saphyr` | `serde-saphyr` *(dev only)* | Cross-library bench comparison arms | `benches/comparison.rs` |
-| `noyavalidate` | `std` + `miette` + `validate-schema` | The `noyavalidate` CLI binary | [Tooling](#tooling) |
+| `wasm-opt` | — | Build-time flag opting the `noyalib-wasm` bundle into `wasm-opt` size passes (no API surface) | [`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm) |
+| `noyavalidate` | `std` + `miette` + `validate-schema` | Enables the schema-validation surface the `noyavalidate` CLI is built on | [`doc/USER-GUIDE.md` §11](doc/USER-GUIDE.md) |
 
 ```toml
 # Example: rich diagnostics + schema validation
@@ -357,10 +361,10 @@ noyalib targets the niche `serde_yaml` / `serde_yml` / `libyml`
 occupy — read YAML into typed Rust structs, write Rust structs back
 as YAML — and is written from scratch against the YAML 1.2 spec.
 The implementation runs the official YAML test suite to **100%
-strict compliance — 387/387 attempted cases pass, 0 failures**;
-19 cases are deliberately skipped (tracked alongside the suite in
-[`tests/yaml_compliance_report.rs`](crates/noyalib/tests/yaml_compliance_report.rs)
-so the gap is explicit). It is not a fork of `serde_yaml`; the parser,
+strict compliance — 406/406 attempted cases pass, 0 failures, 0
+skips** (rebuilt on every CI run via
+[`tests/yaml_compliance_report.rs`](crates/noyalib/tests/yaml_compliance_report.rs)).
+It is not a fork of `serde_yaml`; the parser,
 scanner, serialiser, and CST are independent code.
 
 Two architectural choices motivate the rewrite:
@@ -420,7 +424,7 @@ table below groups the inventory by capability theme.
 
 | Theme | Headline deliverables |
 | :--- | :--- |
-| Spec compliance | YAML 1.2 official test suite at 100% strict (387/387 attempted, 0 failures, 19 deliberately skipped — gap tracked in `tests/yaml_compliance_report.rs`); YAML 1.1 opt-in compatibility for the "Norway problem"; multi-document streams |
+| Spec compliance | YAML 1.2 official test suite at 100% strict (406/406 attempted, 0 failures, 0 skips — verified by `tests/yaml_compliance_report.rs`); YAML 1.1 opt-in compatibility for the "Norway problem"; multi-document streams |
 | Migration from `serde_yaml` | `compat-serde-yaml` feature with name-for-name re-exports; `From`/`TryFrom` parity for `Value`/`Mapping`/`Number`; `Document::validate`; comment-aware reads via `load_comments` |
 | Binary scalars | First-class `!!binary` tag; RFC 4648 base64 round-trip with `serde_bytes::ByteBuf`/`Bytes`; non-UTF-8 payloads supported |
 | Flatten guard | `Spanned<Value>` in `#[serde(flatten)]` returns an actionable error pointing at the working alternative |
@@ -1276,7 +1280,7 @@ disagreement on priorities.
 - **You have a hard dependency budget that cannot tolerate a
   Grisu / Ryu float formatter and a hash-randomised lookup
   table.** Default profile carries 8 runtime deps. `noyalib =
-  { version = "0.0.1", default-features = false, features =
+  { version = "0.0.15", default-features = false, features =
   ["std"] }` (or the equivalent `features = ["minimal"]`) drops
   to 5 — `itoa`, `ryu`, and `serde_ignored` become opt-in via
   the `fast-int` / `fast-float` / `strict-deserialise` features.
@@ -1387,7 +1391,8 @@ strictness:
 
 - **Tagged data is fully preserved.**
   `from_str::<Value>("!Custom 'hello'\n")` returns
-  `Value::Tagged(Tag("!Custom"), Value::String("hello"))` — the
+  `Value::Tagged(t)` where `t.tag() == "!Custom"` and
+  `t.value() == Value::String("hello")` — the
   same shape that already covered tagged sequences and tagged
   mappings. Downstream code can read the tag via
   `Value::Tagged(t)` pattern matching, dispatch on it, or step

--- a/crates/noyalib/README.md
+++ b/crates/noyalib/README.md
@@ -34,7 +34,7 @@
 - [Examples](#examples) — runnable example index
 - [Benchmarks](#benchmarks) — performance evidence
 - [When not to use noyalib](#when-not-to-use-noyalib) — limitations
-- [Migrating from `serde_yaml`](#migrating-from-serde_yaml) — name-for-name mapping
+- [Migrating from another YAML crate](#migrating-from-another-yaml-crate) — name-for-name mapping
 - [Documentation](#documentation) — extended reading
 - [License](#license)
 
@@ -69,7 +69,7 @@ to `core::fmt` (slower, output remains valid YAML); the
 typo-detection helpers are absent. Re-enable individually with
 `features = ["fast-int", "fast-float", "strict-deserialise"]`.
 
-**MSRV: Rust 1.75.0**, enforced by the `msrv-1-75-core` CI job.
+**MSRV: Rust 1.85.0** (edition 2024), enforced by the `msrv-1-85-core` CI job.
 
 ---
 
@@ -101,9 +101,9 @@ noyalib targets the niche `serde_yaml` / `serde_yml` / `libyml`
 occupy — read YAML into typed Rust structs, write Rust structs
 back as YAML — and is written from scratch against the YAML 1.2
 spec. The implementation runs the official YAML test suite to
-**100% strict compliance — 387/387 attempted cases pass, 0
-failures**; 19 cases are deliberately skipped (tracked in
-`tests/yaml_compliance_report.rs`). It is not a fork of `serde_yaml`;
+**100% strict compliance — 406/406 attempted cases pass, 0
+failures, 0 skips** (verified by `tests/yaml_compliance_report.rs`).
+It is not a fork of `serde_yaml`;
 the parser, scanner, serialiser, and CST are independent code.
 
 Two architectural choices motivate the rewrite:
@@ -164,10 +164,9 @@ and `thiserror` are all absent. `cargo audit`, `cargo deny`, and
 
 Validated against the
 [official YAML test suite](https://github.com/yaml/yaml-test-suite)
-at **100% strict compliance — 387 / 387 attempted cases pass, 0
-failures, 19 deliberately skipped**. The skip list is tracked in
-`tests/yaml_compliance_report.rs` so the gap is explicit and
-audit-friendly. The conformance report rebuilds on every CI run
+at **100% strict compliance — 406 / 406 attempted cases pass, 0
+failures, 0 skips**. The conformance report is tracked in
+`tests/yaml_compliance_report.rs` and rebuilds on every CI run
 via `cargo test --test yaml_compliance_report`.
 
 The same suite also exercises:
@@ -281,7 +280,7 @@ assert_eq!(cfg.port.start.line(), 1);
 
 ## Examples
 
-60+ runnable examples under
+76 runnable examples under
 [`crates/noyalib/examples/`](examples/):
 
 ```bash
@@ -336,7 +335,7 @@ throughput tables sit in the
 [Benchmarks section of the workspace README](https://github.com/sebastienrousseau/noyalib#benchmarks):
 `noyalib` is **faster than every other pure-Rust YAML library
 on every deserialize fixture measured**. Speedup ranges:
-**1.69×–2.00×** vs `serde-saphyr`, **1.48×–1.96×** vs `serde_yml`,
+**1.69×–2.00×** vs `serde-saphyr`,
 **1.42×–1.84×** vs `serde_yaml_ng`, **1.38×–1.74×** vs
 `yaml-spanned`, **1.11×–1.36×** vs `yaml-rust2`. Serialize is
 **3.00×–4.34×** ahead of `serde_yaml_ng`. The structural-bitmask

--- a/crates/noyalib/benches/benchmarks.rs
+++ b/crates/noyalib/benches/benchmarks.rs
@@ -5,7 +5,7 @@
 //! Path, schema validation, Spanned, fmt wrappers, anchors, singleton_map
 //! helpers, Error, and Location.
 //!
-//! Run with: cargo bench
+//! Run with: `cargo bench --bench benchmarks`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/benches/comparison.rs
+++ b/crates/noyalib/benches/comparison.rs
@@ -1,4 +1,5 @@
-//! Head-to-head benchmarks: noyalib vs serde_yaml_ng vs yaml-rust2.
+//! Head-to-head benchmarks: noyalib vs serde_yaml_ng, yaml-rust2, and
+//! yaml-spanned (plus serde-saphyr under `--features compare-saphyr`).
 //!
 //! Run: `cargo bench --bench comparison`
 

--- a/crates/noyalib/benches/validation_overhead.rs
+++ b/crates/noyalib/benches/validation_overhead.rs
@@ -4,6 +4,8 @@
 //! Microbenchmark that stresses span resolution on a large `Spanned<T>`
 //! document with a trailing error, isolating the cost of the span
 //! lookup + `Location` computation per field.
+//!
+//! Run: `cargo bench --bench validation_overhead`
 
 #![allow(missing_docs, unused_results, clippy::unwrap_used)]
 

--- a/crates/noyalib/examples/alias.rs
+++ b/crates/noyalib/examples/alias.rs
@@ -3,7 +3,7 @@
 
 //! Anchors, aliases, and merge keys.
 //!
-//! Run: `cargo run --example anchors`
+//! Run: `cargo run --example alias`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/all.rs
+++ b/crates/noyalib/examples/all.rs
@@ -3,7 +3,7 @@
 
 //! Run all noyalib examples in sequence.
 //!
-//! Usage: `cargo run --example run_all`
+//! Usage: `cargo run --example all`
 
 use std::process::Command;
 use std::time::Instant;

--- a/crates/noyalib/examples/ariadne_diagnostic.rs
+++ b/crates/noyalib/examples/ariadne_diagnostic.rs
@@ -3,11 +3,11 @@
 
 //! Render a noyalib parse error through `ariadne`.
 //!
-//! Pairs with the existing `miette` adapter (\`cargo run --example
-//! diagnostic\`); same source position information rendered with
+//! Pairs with the existing `miette` adapter (`cargo run --example
+//! diagnostic`); same source position information rendered with
 //! whichever diagnostic crate the caller's pipeline already uses.
 //!
-//! Run: \`cargo run --example ariadne_diagnostic --features ariadne\`
+//! Run: `cargo run --example ariadne_diagnostic --features ariadne`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/bench.rs
+++ b/crates/noyalib/examples/bench.rs
@@ -3,7 +3,7 @@
 
 //! Quick performance overview.
 //!
-//! Run: `cargo run --example bench-comparison --release`
+//! Run: `cargo run --example bench --release`
 
 #![allow(unused_results)]
 

--- a/crates/noyalib/examples/binary.rs
+++ b/crates/noyalib/examples/binary.rs
@@ -6,7 +6,7 @@
 //! Demonstrates how noyalib handles edge cases at the boundary of YAML's
 //! type system and Rust's numeric types.
 //!
-//! Run: `cargo run --example binary_data`
+//! Run: `cargo run --example binary`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/borrow.rs
+++ b/crates/noyalib/examples/borrow.rs
@@ -3,11 +3,12 @@
 
 //! Zero-copy patterns: minimize allocations during deserialization.
 //!
-//! noyalib currently materializes a Value AST before deserializing into
-//! structs. True zero-copy `&'de str` from the input is planned for v0.0.3.
+//! For true zero-copy `&'de str` borrowing straight from the input, use
+//! `from_str_borrowing` (typed) or `from_str_borrowed` → `BorrowedValue`
+//! (untyped) — demonstrated in `zero_copy_borrow.rs`.
 //!
-//! This example demonstrates the patterns available today for reducing
-//! allocations: Cow<str>, from_value with references, and Value-as-view.
+//! This example demonstrates the complementary allocation-reduction
+//! patterns: Cow<str>, from_value with references, and Value-as-view.
 //!
 //! Run: `cargo run --example borrow`
 
@@ -117,13 +118,15 @@ fn main() {
         ]
     });
 
-    // ── Status: zero-copy roadmap ────────────────────────────────────
+    // ── Status: zero-copy options ────────────────────────────────────
     support::task_with_output("Zero-copy status", || {
         vec![
             "Today:   Value::as_str() borrows from parsed AST".to_string(),
             "Today:   get_path() traverses without cloning".to_string(),
             "Today:   Cow<str> for conditional ownership".to_string(),
-            "Planned: &'de str from input (v0.0.3, issue #8)".to_string(),
+            "Today:   from_str_borrowing / BorrowedValue borrow &'de str \
+                      from input (see zero_copy_borrow.rs)"
+                .to_string(),
         ]
     });
 

--- a/crates/noyalib/examples/bridge.rs
+++ b/crates/noyalib/examples/bridge.rs
@@ -3,7 +3,7 @@
 
 //! Serde interop: bridge between noyalib and serde_json.
 //!
-//! Run: `cargo run --example serde_interop`
+//! Run: `cargo run --example bridge`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/comments.rs
+++ b/crates/noyalib/examples/comments.rs
@@ -8,8 +8,9 @@
 //! attaching comments during serialization.
 //!
 //! For true comment preservation (read → modify → write with comments
-//! intact), a CST-based approach is needed. This is tracked as a future
-//! enhancement.
+//! intact), use the shipped CST layer: `noyalib::cst::parse_document` +
+//! `Document::comments_at` (see `comments_at.rs`, `lossless_edit.rs`,
+//! `entry_api.rs`).
 //!
 //! Run: `cargo run --example comments`
 
@@ -97,13 +98,15 @@ pool_size: 10    # max connections
         output.lines().map(|l| l.to_string()).collect()
     });
 
-    // ── Limitation: no roundtrip preservation ────────────────────────
+    // ── Preservation: data path vs CST path ──────────────────────────
     support::task_with_output("Comment preservation status", || {
         vec![
-            "Parsing:  comments stripped (YAML spec compliant)".to_string(),
-            "Writing:  Commented<T> adds inline comments".to_string(),
-            "Roundtrip: comments NOT preserved (by design)".to_string(),
-            "Future:   CST-based editing for preservation".to_string(),
+            "Data path: comments stripped (YAML spec compliant)".to_string(),
+            "Writing:   Commented<T> adds inline comments".to_string(),
+            "Data roundtrip: comments NOT preserved (by design)".to_string(),
+            "CST path:  comments preserved byte-for-byte via \
+                        noyalib::cst (see comments_at.rs)"
+                .to_string(),
         ]
     });
 

--- a/crates/noyalib/examples/comments_at.rs
+++ b/crates/noyalib/examples/comments_at.rs
@@ -9,6 +9,8 @@
 //! value is the natural source. With this API, the agent reads the
 //! value AND the human's annotation in a single call — and edits via
 //! `Document::set` round-trip both untouched.
+//!
+//! Run: `cargo run --example comments_at`
 
 use noyalib::cst::parse_document;
 

--- a/crates/noyalib/examples/deep.rs
+++ b/crates/noyalib/examples/deep.rs
@@ -3,7 +3,7 @@
 
 //! Nested structure serialization and roundtrip.
 //!
-//! Run: `cargo run --example nested`
+//! Run: `cargo run --example deep`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/dynamic.rs
+++ b/crates/noyalib/examples/dynamic.rs
@@ -4,6 +4,8 @@
 //! Value type example for noyalib.
 //!
 //! Demonstrates working with the dynamic Value type.
+//!
+//! Run: `cargo run --example dynamic`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/emit.rs
+++ b/crates/noyalib/examples/emit.rs
@@ -3,7 +3,7 @@
 
 //! Serializer configuration: every output knob demonstrated.
 //!
-//! Run: `cargo run --example serializer_config`
+//! Run: `cargo run --example emit`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/env.rs
+++ b/crates/noyalib/examples/env.rs
@@ -7,7 +7,7 @@
 //! This is a user-space pattern — noyalib parses the YAML, then you walk the
 //! tree and expand variables.
 //!
-//! Run: `cargo run --example env_expansion`
+//! Run: `cargo run --example env`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/errors.rs
+++ b/crates/noyalib/examples/errors.rs
@@ -3,7 +3,7 @@
 
 //! Error handling: error types, locations, formatted diagnostics.
 //!
-//! Run: `cargo run --example error_handling`
+//! Run: `cargo run --example errors`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/flatten.rs
+++ b/crates/noyalib/examples/flatten.rs
@@ -3,7 +3,7 @@
 
 //! Serde flatten and untagged enums in YAML context.
 //!
-//! Run: `cargo run --example flattened_data`
+//! Run: `cargo run --example flatten`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/global.rs
+++ b/crates/noyalib/examples/global.rs
@@ -1,6 +1,8 @@
 //! Serialization configuration example for noyalib.
 //!
 //! Demonstrates using SerializerConfig to customize YAML output.
+//!
+//! Run: `cargo run --example global`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/examples/hello.rs
+++ b/crates/noyalib/examples/hello.rs
@@ -3,7 +3,7 @@
 
 //! Basic usage: serialize and deserialize structs.
 //!
-//! Run: `cargo run --example basic`
+//! Run: `cargo run --example hello`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/inherit.rs
+++ b/crates/noyalib/examples/inherit.rs
@@ -6,7 +6,7 @@
 //! Merge keys are resolved automatically during parsing. `apply_merge()`
 //! is available for post-parse resolution on manually constructed Values.
 //!
-//! Run: `cargo run --example merge_keys`
+//! Run: `cargo run --example inherit`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/modify.rs
+++ b/crates/noyalib/examples/modify.rs
@@ -3,7 +3,7 @@
 
 //! Value manipulation: to_value, from_value, MappingAny, get_path_mut, ValueIndex.
 //!
-//! Run: `cargo run --example value_manipulation`
+//! Run: `cargo run --example modify`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/overlay.rs
+++ b/crates/noyalib/examples/overlay.rs
@@ -2,6 +2,8 @@
 //!
 //! Demonstrates merging YAML values together, useful for configuration
 //! layering.
+//!
+//! Run: `cargo run --example overlay`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/examples/pipes.rs
+++ b/crates/noyalib/examples/pipes.rs
@@ -3,7 +3,7 @@
 
 //! I/O format examples: from_slice, from_reader, to_writer, to_fmt_writer.
 //!
-//! Run: `cargo run --example io_formats`
+//! Run: `cargo run --example pipes`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/portable.rs
+++ b/crates/noyalib/examples/portable.rs
@@ -10,7 +10,7 @@
 //! Serve:       `cd examples/wasm && python3 -m http.server 8080`
 //! Open:        `http://localhost:8080/index.html`
 //!
-//! Run native:  `cargo run --example wasm`
+//! Run native:  `cargo run --example portable`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/preserve.rs
+++ b/crates/noyalib/examples/preserve.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.
 
-//! CST preservation foundations: what's possible today and what's planned.
+//! CST preservation: comment injection and formatting control.
 //!
-//! Demonstrates the current approach to comment injection, formatting
-//! control, and the structural hooks that will enable full CST
-//! round-tripping in v0.0.6.
+//! Demonstrates comment injection and formatting control on the
+//! serialization side. For full lossless CST round-tripping (byte-for-byte
+//! preserving edits), see the shipped `noyalib::cst` layer and the
+//! `lossless_edit.rs` / `entry_api.rs` examples.
 //!
 //! Run: `cargo run --example preserve`
 
@@ -105,23 +106,25 @@ fn main() {
                 output.lines().count()
             ),
             "YAML spec: comments are not part of the data model.".to_string(),
-            "Full CST preservation planned for v0.0.6 (#20).".to_string(),
+            "Full CST preservation ships in noyalib::cst (see \
+             lossless_edit.rs)."
+                .to_string(),
         ]
     });
 
-    // ── Future: CST roadmap ──────────────────────────────────────────
-    support::task_with_output("CST roadmap (v0.0.6)", || {
+    // ── Two paths: serialization hooks vs the lossless CST ────────────
+    support::task_with_output("Preservation options", || {
         vec![
-            "Today:".to_string(),
+            "Serialization hooks (this example):".to_string(),
             "  Commented<T>   — inject comments on write".to_string(),
             "  SpaceAfter<T>  — control blank lines".to_string(),
             "  FlowSeq/Map    — preserve inline style".to_string(),
             "  LitStr/FoldStr — preserve block scalar style".to_string(),
             "  Tagged values  — structural extensibility".to_string(),
             String::new(),
-            "v0.0.6 (#20):".to_string(),
-            "  CstDocument    — preserves all source bytes".to_string(),
-            "  CstNode        — retains comments + whitespace".to_string(),
+            "Lossless CST (noyalib::cst):".to_string(),
+            "  cst::Document  — preserves all source bytes".to_string(),
+            "  span_at/comments_at — retains comments + whitespace".to_string(),
             "  Surgical edits — modify one value, keep rest intact".to_string(),
             "  Full round-trip — read -> modify -> write without loss".to_string(),
         ]

--- a/crates/noyalib/examples/rename.rs
+++ b/crates/noyalib/examples/rename.rs
@@ -3,7 +3,7 @@
 
 //! Custom key transformations with singleton_map_with.
 //!
-//! Run: `cargo run --example custom_serialization`
+//! Run: `cargo run --example rename`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/schema.rs
+++ b/crates/noyalib/examples/schema.rs
@@ -3,7 +3,7 @@
 
 //! YAML schema validation (core, JSON, failsafe).
 //!
-//! Run: `cargo run --example schema_validation`
+//! Run: `cargo run --example schema`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/secure.rs
+++ b/crates/noyalib/examples/secure.rs
@@ -3,7 +3,7 @@
 
 //! ParserConfig: security limits for untrusted input.
 //!
-//! Run: `cargo run --example parser_config`
+//! Run: `cargo run --example secure`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/smart.rs
+++ b/crates/noyalib/examples/smart.rs
@@ -3,7 +3,7 @@
 
 //! Smart pointer anchors: RcAnchor, ArcAnchor for shared YAML data.
 //!
-//! Run: `cargo run --example shared_anchors`
+//! Run: `cargo run --example smart`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/source.rs
+++ b/crates/noyalib/examples/source.rs
@@ -3,7 +3,7 @@
 
 //! Spanned<T>: track exact source locations for deserialized fields.
 //!
-//! Run: `cargo run --example spanned`
+//! Run: `cargo run --example source`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/std.rs
+++ b/crates/noyalib/examples/std.rs
@@ -1,6 +1,8 @@
 //! Collection serialization example for noyalib.
 //!
 //! Demonstrates serializing Vec, HashMap, and other collections.
+//!
+//! Run: `cargo run --example std`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/examples/stream.rs
+++ b/crates/noyalib/examples/stream.rs
@@ -3,7 +3,7 @@
 
 //! Multi-document YAML streams separated by `---`.
 //!
-//! Run: `cargo run --example multi_document`
+//! Run: `cargo run --example stream`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/strict.rs
+++ b/crates/noyalib/examples/strict.rs
@@ -3,7 +3,7 @@
 
 //! Strict parsing: strict_booleans, duplicate key policies, security limits.
 //!
-//! Run: `cargo run --example strict_parsing`
+//! Run: `cargo run --example strict`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/style.rs
+++ b/crates/noyalib/examples/style.rs
@@ -3,7 +3,7 @@
 
 //! Formatting wrappers for per-value output control.
 //!
-//! Run: `cargo run --example fmt_wrappers`
+//! Run: `cargo run --example style`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/tags.rs
+++ b/crates/noyalib/examples/tags.rs
@@ -3,7 +3,7 @@
 
 //! Singleton map enum serialization: singleton_map, optional, recursive.
 //!
-//! Run: `cargo run --example singleton_map`
+//! Run: `cargo run --example tags`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/trace.rs
+++ b/crates/noyalib/examples/trace.rs
@@ -3,6 +3,8 @@
 //! Demonstrates the `Path` type for tracking locations within YAML structures.
 //! Useful for providing detailed error messages that show exactly where
 //! in the document a problem occurred.
+//!
+//! Run: `cargo run --example trace`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/examples/types.rs
+++ b/crates/noyalib/examples/types.rs
@@ -3,7 +3,7 @@
 
 //! Custom YAML tags: local (!), global (!!), and user-defined types.
 //!
-//! Run: `cargo run --example custom_tags`
+//! Run: `cargo run --example types`
 
 #[path = "support.rs"]
 mod support;

--- a/crates/noyalib/examples/variants.rs
+++ b/crates/noyalib/examples/variants.rs
@@ -1,6 +1,8 @@
 //! Enum serialization example for noyalib.
 //!
 //! Demonstrates serializing various enum types.
+//!
+//! Run: `cargo run --example variants`
 
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2026 Noyalib. All rights reserved.

--- a/crates/noyalib/src/lib.rs
+++ b/crates/noyalib/src/lib.rs
@@ -202,7 +202,7 @@
 //! | `validator` | ⛔ | `validator 0.19` | [`ValidatedValidator<T>`] | — |
 //! | `robotics` | ⛔ | — | `Degrees` / `Radians` / `StrictFloat` newtypes | — |
 //! | `parallel` | ⛔ | `rayon 1.10` | [`parallel::parse`], [`parallel::values`] | `std` |
-//! | `simd` | ⛔ | — | `noyalib::simd::*` primitives | — |
+//! | `simd` | ⛔ | — | forward-compat no-op — `noyalib::simd::*` is always available; the hot path uses it unconditionally | — |
 //! | `nightly-simd` | ⛔ | nightly rustc | 32-byte `StructuralIter` | `simd` |
 //! | `compat-serde-yaml` | ⛔ | — | `noyalib::compat::serde_yaml` shim | — |
 //! | `compare-saphyr` | ⛔ | `serde-saphyr` | comparison-bench arms (dev-only — do **not** ship in release builds) | — |

--- a/crates/noyalib/src/policy.rs
+++ b/crates/noyalib/src/policy.rs
@@ -89,7 +89,8 @@ pub struct PolicyEvent<'a> {
     /// The fully-reconstructed tag on this node, if any (e.g.
     /// `"!!str"`, `"!Custom"`, or `"tag:yaml.org,2002:binary"`).
     pub tag: Option<&'a str>,
-    /// The raw scalar text, present only for [`PolicyEventKind::Scalar`].
+    /// The decoded scalar content (escapes already resolved), present
+    /// only for [`PolicyEventKind::Scalar`].
     pub scalar: Option<&'a str>,
 }
 
@@ -211,9 +212,10 @@ impl Policy for DenyTags {
 
 /// Cap the byte length of any individual scalar.
 ///
-/// Counts the raw scalar text, *not* the post-resolution value;
-/// numeric / boolean scalars are measured by their source
-/// representation. Helpful for resource-constrained pipelines that
+/// Counts the decoded scalar content (escape sequences resolved),
+/// *not* the post-resolution typed value; numeric / boolean scalars
+/// are measured by their textual representation. Helpful for
+/// resource-constrained pipelines that
 /// cannot trust upstream input size.
 ///
 /// # Examples

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -25,21 +25,24 @@ crates/
 │   │   ├── simd.rs       # find_any_of, SWAR decimals, structural-bitmask
 │   │   └── …
 │   ├── tests/            # integration tests + YAML 1.2 official suite
-│   ├── examples/         # 56+ runnable usage examples
+│   ├── examples/         # 76 runnable usage examples
 │   └── benches/          # Criterion benches
-├── noya-cli/             # noyafmt + noyavalidate binaries
-├── noyalib-lsp/          # Language Server Protocol implementation
-└── xtask/                # internal release tooling
 ```
 
-Two crates that used to live under `crates/` have been split
-into their own repositories per ADR-0005:
+The only workspace member is `crates/noyalib`
+(`members = ["crates/noyalib"]`). Crates that used to live
+under `crates/` have been split into their own repositories per
+ADR-0005, and the `xtask` crate was removed:
 
+- `noya-cli` (noyafmt + noyavalidate binaries) → [`sebastienrousseau/noya-cli`](https://github.com/sebastienrousseau/noya-cli) (split at v0.0.13)
+- `noyalib-lsp` (Language Server Protocol implementation) → [`sebastienrousseau/noyalib-lsp`](https://github.com/sebastienrousseau/noyalib-lsp) (split at v0.0.13)
 - `noyalib-mcp` → [`sebastienrousseau/noyalib-mcp`](https://github.com/sebastienrousseau/noyalib-mcp) (split at v0.0.13)
 - `noyalib-wasm` → [`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm) (split at v0.0.12)
+- `xtask` (internal release tooling) → removed; PGO and release
+  tasks now run from `scripts/`
 
-Both consume `noyalib` from crates.io via strict-lockstep
-`=X.Y.Z` version pins.
+The split satellite crates consume `noyalib` from crates.io via
+strict-lockstep `=X.Y.Z` version pins.
 
 The lib crate is `#![forbid(unsafe_code)]` workspace-wide. The
 satellite crates inherit the same forbid; only the third-party
@@ -325,11 +328,11 @@ arms in
 | Suite | Where | What |
 |---|---|---|
 | Unit | inline `#[cfg(test)]` blocks | Per-module logic |
-| Integration | `crates/noyalib/tests/` | Cross-module surfaces (~30 files) |
+| Integration | `crates/noyalib/tests/` | Cross-module surfaces (139 files) |
 | Doc-tests | every `///` block with a code-fence | Public-API examples |
 | Property | `crates/noyalib/tests/proptest_*.rs` | Roundtrip invariants via `proptest` |
-| Official YAML 1.2 suite | `crates/noyalib/tests/yaml-test-suite/**` | 387/387 strict-pass, 0 failures, 19 deliberate skips |
-| CLI smoke | `crates/noya-cli/tests/` | End-to-end `noyafmt` / `noyavalidate` runs |
+| Official YAML 1.2 suite | `crates/noyalib/tests/yaml-test-suite/**` | 406/406 strict-pass, 0 failures, 0 deliberate skips |
+| CLI smoke | `crates/noya-cli/tests/` | End-to-end `noyafmt` / `noyavalidate` runs (in the split `noya-cli` repo) |
 
 Total: ~4100 tests. Runtime: ~110 s for `cargo test --workspace
 --all-features --no-fail-fast` on an M-series Mac.
@@ -337,12 +340,13 @@ Total: ~4100 tests. Runtime: ~110 s for `cargo test --workspace
 ## Coverage
 
 Workspace coverage is measured by `cargo +nightly llvm-cov` and
-gated in CI at 95 % functions / 92 % regions / 93 % lines.
+gated in CI at 96 % functions / 94 % lines / 93 % regions.
 Excluded from instrumentation:
 
-- `crates/noyalib-{mcp,lsp}/tests/protocol*.rs` (subprocess-
-  driven smoke tests; the same logic is covered by per-module
-  unit tests).
+- subprocess-driven protocol smoke tests (the same logic is
+  covered by per-module unit tests). These live in the split
+  `noyalib-mcp` / `noyalib-lsp` repos per ADR-0005, so they are
+  no longer part of this workspace's instrumentation set.
 
 (Prior to v0.0.12, `crates/noyalib-wasm/src/lib.rs` was also
 excluded — its JsValue marshalling requires the wasm-bindgen

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -8,7 +8,7 @@ Rust 1.95 stable**, criterion `--warm-up-time 2 --measurement-time 4`.
 All libraries compiled with `--release` (LTO=fat, codegen-units=1,
 panic=abort). Run locally via `cargo bench --bench comparison`.
 
-> **PGO** — `cargo xtask pgo-build` runs the full LLVM
+> **PGO** — `scripts/pgo.sh` runs the full LLVM
 > profile-guided optimisation pipeline (instrument → train against
 > the YAML test suite + `benches/fixtures/` → merge profdata →
 > optimised rebuild). Adds 5-15% on top of the numbers below;
@@ -237,8 +237,8 @@ cargo bench --bench v006_features --features recovery,sval,tokio
 | **Source** | 26,000+ lines across the workspace |
 | **Test suite** | 3,686 tests + 431 doctests + CLI smoke + 13 stress/load |
 | **YAML Test Suite** | 100% strict compliance: 406/406 attempted cases pass, 0 failures, 0 deliberate skips |
-| **Examples** | 60+ runnable examples across all crates |
-| **Coverage** | 95%+ function coverage / 92%+ region coverage / 93%+ line coverage (CI-gated) |
+| **Examples** | 76 runnable examples |
+| **Coverage** | 96%+ function coverage / 94%+ line coverage / 93%+ region coverage (CI-gated) |
 | **Dependencies** | 5 unconditional + 3 default-on optional (`itoa`, `ryu`, `serde_ignored`) + 12 opt-in optional (`miette`, `garde`, `validator`, `schemars`, `serde_json`, `jsonschema`, `figment`, `rayon`, `serde-saphyr`, plus the three default-on opt-outs) |
 | **WASM binary** | 338 KB (release, LTO) |
 | **MSRV** | Rust 1.85.0 (core, since v0.0.5 — edition 2024); newer for optional features (see [POLICIES.md](POLICIES.md#1-msrv-minimum-supported-rust-version)) |

--- a/doc/CII-BEST-PRACTICES.md
+++ b/doc/CII-BEST-PRACTICES.md
@@ -63,7 +63,7 @@ artefact that satisfies it.
 | Working build system | `cargo build --workspace --all-features` |
 | Working test system | `cargo test --workspace --all-features` (~5 400 tests) |
 | Tests run on every change | `.github/workflows/ci.yml` triggers on push + pull_request |
-| Code-coverage measurement | `.github/workflows/ci.yml` § `Coverage gate (≥95%)` — `cargo llvm-cov` |
+| Code-coverage measurement | `.github/workflows/ci.yml` § `Coverage gate (≥96%)` — `cargo llvm-cov` |
 | Coverage tool integration | Same |
 | New features include tests | Required by review process; enforced by `cargo-machete`, strict-doc gate |
 | Documented coding style | Workspace-level lints in `crates/noyalib/Cargo.toml`; `cargo fmt` enforced by CI |
@@ -75,7 +75,7 @@ artefact that satisfies it.
 | :--- | :--- |
 | Cryptographic best practices | Releases signed via cosign keyless + SLSA L3 build provenance attestations on every artefact |
 | Inputs validated before use | Parser enforces `ParserConfig` limits (`max_depth`, `max_document_length`, `max_alias_expansions`, …) |
-| Hardened against vulnerabilities | `#![forbid(unsafe_code)]` workspace-wide, fuzz suite (4 targets) + Miri soak runs in `.github/workflows/security.yml` |
+| Hardened against vulnerabilities | `#![forbid(unsafe_code)]` workspace-wide, fuzz suite (10 targets) + Miri soak runs in `.github/workflows/security.yml` |
 | Vulnerability disclosure tested | One historical CVE-equivalent (issue #46 RecursionLimitExceeded false-positive) — patched in v0.0.6 within the same release cycle |
 | Security expertise consulted | Audit pipeline: `cargo-deny`, `cargo-vet`, `cargo-audit`, `cargo-machete`, CodeQL — see `doc/POLICIES.md` |
 
@@ -85,7 +85,7 @@ artefact that satisfies it.
 | :--- | :--- |
 | Static analysis applied | `cargo clippy --workspace --all-features -- -D warnings` on every PR; CodeQL on `.github/workflows/security.yml` |
 | Dynamic analysis applied | Differential fuzz (10 s smoke per PR) + soak fuzz (1 h per target weekly); Miri (focused per PR + full weekly) |
-| Coverage-guided fuzzing | `cargo-fuzz` with `libFuzzer`, 4 targets: `fuzz_parse`, `fuzz_roundtrip`, `fuzz_diff`, `fuzz_strict` |
+| Coverage-guided fuzzing | `cargo-fuzz` with `libFuzzer`, 10 targets: `fuzz_borrowed_alias`, `fuzz_diff`, `fuzz_double_quoted`, `fuzz_from_value`, `fuzz_multi_doc`, `fuzz_no_span_loader`, `fuzz_parse`, `fuzz_roundtrip`, `fuzz_strict`, `fuzz_yaml_v1_1` |
 | Memory-safety analysis | `#![forbid(unsafe_code)]` (the strongest possible static guarantee) + Miri runs to verify transitive `unsafe` blocks in dev-deps |
 
 ## Silver / Gold level (future)

--- a/doc/COMPARISON.md
+++ b/doc/COMPARISON.md
@@ -25,7 +25,7 @@ linked from there.
 | **SIMD scanning** | Yes (memchr + bitmask) | No | No | No | No | No |
 | **SWAR numeric parse** | Yes | No | No | No | No | No |
 | **Parallel multi-doc** | Yes (`parallel::parse`) | No | No | No | No | No |
-| **DoS hardened** | 7 budgets | Basic | Basic | Yes | No | Yes |
+| **DoS hardened** | ~12 budgets | Basic | Basic | Yes | No | Yes |
 | **Pluggable policies** | Yes (`policy::Policy`) | No | No | No | No | No |
 | **Secret interpolation** | Yes (`${VAR}`) | No | No | Yes | No | No |
 | **CST manipulation** | Yes (`cst::Document`) | No | No | No | No | No |
@@ -58,10 +58,12 @@ linked from there.
   events directly into the typed target without building an
   intermediate `Value` AST. The other crates that *do* have
   serde integration build the AST first.
-- **DoS hardening (7 budgets)** — `max_depth`,
+- **DoS hardening (~12 budgets)** — `max_depth`,
   `max_alias_expansions`, `max_document_length`,
-  `max_sequence_length`, `max_mapping_keys`, plus the
-  cumulative-alias-byte budget and the per-document size
+  `max_sequence_length`, `max_mapping_keys`, `max_events`,
+  `max_nodes`, `max_total_scalar_bytes`, `max_documents`,
+  `max_merge_keys`, plus the cumulative-alias-byte budget, the
+  alias/anchor ratio guard, and the per-document size
   cap. See [`POLICIES.md`](POLICIES.md#3-security--audits)
   for defaults and override knobs.
 

--- a/doc/MIGRATION-FROM-SERDE-NORWAY.md
+++ b/doc/MIGRATION-FROM-SERDE-NORWAY.md
@@ -78,7 +78,7 @@ fork apply here too. Full discussion in
 
 1. **`Value::Tagged` is preserved through the `Value` data path.**
    `from_str::<Value>("!Custom 'hi'\n")` returns
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))`. Call
+   `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`). Call
    `.untag()` to get the inner if you used the unwrapped form.
 2. **YAML 1.2 strict booleans by default.** Same default as
    `serde_norway` — no behavioural change.

--- a/doc/MIGRATION-FROM-SERDE-SAPHYR.md
+++ b/doc/MIGRATION-FROM-SERDE-SAPHYR.md
@@ -54,7 +54,7 @@ the `Value` DOM, the `Spanned<T>` wrapper, the lossless
 | `serde_saphyr::from_str_with_options(input, options)` | `noyalib::from_str_with_config(input, &cfg)` |
 | `serde_saphyr::from_slice_with_options` | `noyalib::from_slice_with_config` |
 | `serde_saphyr::from_reader_with_options` | `noyalib::from_reader_with_config` |
-| `serde_saphyr::from_multiple_with_options` | `noyalib::load_all_as_with_config` |
+| `serde_saphyr::from_multiple_with_options` | `noyalib::load_all_with_config` (untyped `DocumentIterator`; deserialize each item, or `load_all_as::<T>` without a config) |
 | `serde_saphyr::to_string` | `noyalib::to_string` |
 | `serde_saphyr::to_io_writer` | `noyalib::to_writer` |
 | `serde_saphyr::to_fmt_writer` | `noyalib::to_fmt_writer` |
@@ -119,7 +119,7 @@ mappings via `IndexMap`).
    (`max_depth`, `max_alias_expansions`, `max_document_length`).
 3. **`Value::Tagged` exists in noyalib.** Custom-tag scalars
    like `!Custom 'hi'` surface as
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))`. If
+   `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`). If
    you hit a tagged scalar in `serde_saphyr`'s typed path the
    tag was simply preserved in the YAML 1.2 sense; noyalib
    typed deserialise sees through the tag transparently to the

--- a/doc/MIGRATION-FROM-SERDE-YAML-BW.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML-BW.md
@@ -156,7 +156,8 @@ If you relied on `serde_yaml_bw`'s anchor metadata on each
 scalar variant, noyalib does not surface that on the `Value`
 tree directly. The CST layer (`noyalib::cst::Document`) keeps
 anchor / alias source spans and exposes them via the
-`Document::annotations` API for editor-grade tooling.
+`Document::span_at(path)` and `Document::comments_at(path)`
+APIs for editor-grade tooling.
 
 ## Behavioural differences worth knowing
 
@@ -172,12 +173,12 @@ anchor / alias source spans and exposes them via the
    `ParserConfig::new().max_alias_expansions(...)`.
 3. **Merge keys (`<<`)** — both crates support YAML 1.1 merge
    keys. noyalib's `MergeKeyPolicy` enum lets you choose:
-   `Merge` (default), `AsOrdinary` (treat `<<` as a literal
+   `Auto` (default), `AsOrdinary` (treat `<<` as a literal
    key), or `Error` (reject).
 4. **`Value::Tagged` is preserved.**
    `from_str::<Value>("!Custom 'hi'\n")` returns
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))` — same
-   as `serde_yaml_bw`.
+   `Value::Tagged(t)` where `t.tag() == "!Custom"` and
+   `t.value() == Value::String("hi")` — same as `serde_yaml_bw`.
 5. **YAML 1.2 strict booleans by default.** `country: NO`
    stays `Value::String("NO")`. Opt into YAML 1.1 boolean
    recognition via `ParserConfig::new().legacy_booleans(true)`.

--- a/doc/MIGRATION-FROM-SERDE-YAML-NG.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML-NG.md
@@ -72,7 +72,7 @@ here. Full discussion in
 headlines:
 
 1. **`Value::Tagged` is preserved.** `from_str::<Value>("!Custom 'hi'\n")`
-   returns `Value::Tagged(Tag("!Custom"), Value::String("hi"))`.
+   returns `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`).
    `serde_yaml_ng` matched `serde_yaml`'s pre-Tagged behaviour;
    noyalib preserves the wrapper. Call `.untag()` to get the
    inner.

--- a/doc/MIGRATION-FROM-SERDE-YAML.md
+++ b/doc/MIGRATION-FROM-SERDE-YAML.md
@@ -74,9 +74,9 @@ type — there's no transitive dependency on the archived
 | `serde_yaml::with::singleton_map` | `noyalib::with::singleton_map` | Identical. |
 | `serde_yaml::with::singleton_map_optional` | `noyalib::with::singleton_map_optional` | Identical. |
 | `serde_yaml::with::singleton_map_recursive` | `noyalib::with::singleton_map_recursive` | Identical. |
-| `serde_yaml::Index` | `noyalib::value::Index` | Same trait surface (`get`, `get_mut`). |
+| `serde_yaml::Index` | `noyalib::ValueIndex` | Same trait surface (`get`, `get_mut`). |
 | `serde_yaml::value::Mapping::get_mut` | `noyalib::Mapping::get_mut` | Identical. |
-| `serde_yaml::Deserializer::from_str` | `noyalib::Deserializer::new` | Constructor name differs; behaviour identical. |
+| `serde_yaml::Deserializer::from_str` | `noyalib::from_str` | To parse a `&str` use `from_str`. `noyalib::Deserializer::new` wraps an already-parsed `&Value` (a serde driver), it does not parse source text. |
 | `serde_yaml::Serializer::new` | `noyalib::Serializer::new` | Identical. |
 
 ## Things `noyalib` adds (no equivalent in `serde_yaml`)
@@ -90,7 +90,7 @@ migration above doesn't require any of them.
 | `noyalib::Spanned<T>` | Wraps `T` and tracks the source `(line, column, byte offset)` of every deserialised value. Survives `flatten`. |
 | `noyalib::cst::Document` | Lossless CST — read YAML in, mutate via `Document::set("server.port", "9090")`, write out byte-for-byte preserved (only the touched span changes). Foundation of the `noyafmt` / `noyavalidate --fix` tools. |
 | `noyalib::policy::{DenyAnchors, DenyTags, MaxScalarLength}` | Pluggable parser policies. Reject documents that violate organisational constraints at parse time (e.g. ban anchors to defeat billion-laughs). |
-| `noyalib::interpolate_properties` | Substitute `${VAR}` references inside string scalars from a property map; pair with `secrecy::Secret<T>` for redacted-by-default credential handling. |
+| `Value::interpolate_properties` | Substitute `${VAR}` references inside string scalars from a property map; pair with `secrecy::Secret<T>` for redacted-by-default credential handling. |
 | `noyalib::parallel::parse<T>` | Parse `---`-separated multi-document streams across the Rayon thread pool. Linear with cores. (Requires the `parallel` feature.) |
 | `noyalib::Error::format_with_source(input)` | Renders a rustc-style snippet pointing at the offending line + column. Always available; richer output under `--features miette`. |
 | `noyalib::diagnostic::*` | First-class `miette::Diagnostic` integration: error codes, help text, source spans, ANSI-coloured terminal output. Under `--features miette`. |
@@ -107,7 +107,7 @@ See the public API surface map at the top of `crates/noyalib/src/lib.rs`.
 - **Implicit `<<:` merge keys outside of explicit handling.**
   YAML 1.2 dropped merge keys from the spec; `noyalib` follows
   1.2 by default but ships an opt-in
-  `MergeKeyPolicy::AutoExpand` for backwards compatibility.
+  `MergeKeyPolicy::Auto` for backwards compatibility.
 - **Custom-tag dispatch via `serde(rename)`.** `noyalib`
   surfaces non-core tags as `Value::Tagged(...)` rather than
   routing them to a typed enum variant by tag-string. Adopt
@@ -131,7 +131,7 @@ See the public API surface map at the top of `crates/noyalib/src/lib.rs`.
      Value::String(s)    => …,
      Value::Sequence(s)  => …,
      Value::Mapping(m)   => …,
-+    Value::Tagged(t)    => handle_tag(&t.tag, &t.value),
++    Value::Tagged(t)    => handle_tag(t.tag(), t.value()),
  }
 ```
 
@@ -140,7 +140,7 @@ drops custom-tag scalars from the `Value` tree by default — a
 `!Custom 'hello'` scalar deserialises into `Value::String("hello")`
 and the tag is lost. `noyalib` preserves the tag:
 `from_str::<Value>("!Custom 'hello'\n")` returns
-`Value::Tagged(Tag("!Custom"), Value::String("hello"))`. This
+`Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hello")`). This
 matches noyalib's behaviour for tagged sequences and tagged
 mappings — three Tagged shapes, one consistent rule.
 
@@ -193,8 +193,8 @@ assert_eq!(v["country"].as_bool(), Some(false));
 // Eager parse, returns Vec<T>.
 let docs: Vec<MyType> = noyalib::load_all_as::<MyType>(stream)?;
 
-// Or iterate Values lazily.
-let docs: Vec<noyalib::Value> = noyalib::load_all(stream)?;
+// Or collect Values — `load_all` yields a lazy `Result<Value>` iterator.
+let docs: Vec<noyalib::Value> = noyalib::load_all(stream)?.collect::<Result<_, _>>()?;
 ```
 
 For very large streams (audit logs, Kubernetes-resource snapshots),
@@ -224,7 +224,7 @@ error: expected ',' or ']'
 
 `from_str_with_config` accepts a `ParserConfig` carrying every
 limit you might want (`max_depth`, `max_alias_expansions`,
-`max_scalar_length`, `duplicate_key_policy`,
+`max_total_scalar_bytes`, `duplicate_key_policy`,
 `strict_booleans`, etc.). The factory `ParserConfig::strict()`
 turns every dial up for untrusted input.
 

--- a/doc/MIGRATION-FROM-SERDE-YML.md
+++ b/doc/MIGRATION-FROM-SERDE-YML.md
@@ -79,7 +79,7 @@ for the full discussion; the headlines:
 
 1. **`Value::Tagged` is preserved through the `Value` data path.**
    `noyalib::from_str::<Value>("!Custom 'hi'\n")` returns
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))`, not the
+   `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`), not the
    transparent-unwrapped `Value::String("hi")`. `serde_yml`'s
    behaviour matched `serde_yaml`'s pre-Tagged behaviour. To get
    the unwrapped string, call `value.untag().as_str()`.

--- a/doc/MIGRATION-FROM-YAML-SERDE.md
+++ b/doc/MIGRATION-FROM-YAML-SERDE.md
@@ -94,7 +94,7 @@ the headlines:
 
 1. **`Value::Tagged` is preserved through the `Value` data path.**
    `noyalib::from_str::<Value>("!Custom 'hi'\n")` returns
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))`. To get
+   `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`). To get
    the unwrapped inner, call `value.untag().as_str()`.
 2. **YAML 1.2 strict booleans by default.** `country: NO`
    stays `Value::String("NO")`. Opt into legacy YAML 1.1

--- a/doc/MIGRATION-FROM-YAML-SPANNED.md
+++ b/doc/MIGRATION-FROM-YAML-SPANNED.md
@@ -108,8 +108,8 @@ println!(
 );
 println!(
     "port range: bytes {}..{}",
-    cfg.port.span().0,
-    cfg.port.span().1,
+    cfg.port.start.index(),
+    cfg.port.end.index(),
 );
 ```
 
@@ -132,7 +132,7 @@ preserve.
 
 `yaml-spanned`'s `from_str_lossy*` family silently drops
 documents that fail to parse. noyalib's `load_all` returns a
-`DocumentIterator<Result<T, Error>>` — the caller decides
+`DocumentIterator` yielding `Result<Value>` — the caller decides
 whether to drop, log, or fail-fast:
 
 ```diff

--- a/doc/MIGRATION.md
+++ b/doc/MIGRATION.md
@@ -34,7 +34,7 @@ its forks; opt-outs are documented per guide.
 
 1. **`Value::Tagged` is preserved through the `Value` data path.**
    `from_str::<Value>("!Custom 'hi'\n")` returns
-   `Value::Tagged(Tag("!Custom"), Value::String("hi"))`. Typed
+   `Value::Tagged(t)` (`t.tag() == "!Custom"`, `t.value() == Value::String("hi")`). Typed
    targets (`#[derive(Deserialize)] struct Foo { … }`) still
    see through the tag transparently — the preservation only
    affects the dynamic `Value` path.

--- a/doc/PGO.md
+++ b/doc/PGO.md
@@ -53,8 +53,8 @@ the non-PGO baseline.
 
 ## Requirements
 
-- **rustc 1.75+**. PGO has been stable since Rust 1.45;
-  noyalib's MSRV (1.75) easily clears that.
+- **rustc 1.85.0+**. PGO has been stable since Rust 1.45;
+  noyalib's MSRV (1.85.0) easily clears that.
 - **`llvm-profdata`** on `$PATH`. Install via
   `rustup component add llvm-tools-preview`. The script
   auto-discovers the rustup-shipped binary if `$PATH` lookup

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -35,9 +35,8 @@ file wins.
 
 | Crate | MSRV | Rationale |
 |---|---|---|
-| `noyalib` (library core) | **1.75.0** | The lowest published MSRV; chosen so embedded / RHEL / FIPS shops on older toolchains can adopt the parser without forcing a toolchain bump. |
-| `xtask` (internal release tooling) | 1.75.0 | Matches the library to keep one toolchain across the workspace where possible. |
-| `noyalib-mcp` | 1.75.0 | Stays at library MSRV; the MCP wire surface is text-only JSON-RPC and pulls no nightly-only deps. |
+| `noyalib` (library core) | **1.85.0** | The committed floor since v0.0.5 (edition 2024). Enforced by the dedicated `msrv-1-85-core` CI job. |
+| `noyalib-mcp` | 1.85.0 | Same floor; the MCP wire surface is text-only JSON-RPC and pulls no nightly-only deps. |
 | `noya-cli` (binaries) | 1.85.0 | Newer binaries pull `clap_complete` 4.x and `miette` 7.x which require 1.85+. |
 | `noyalib-lsp` | 1.85.0 | Pulls `tower-lsp` and async deps that have set 1.85 floors. |
 | `noyalib-wasm` | 1.85.0 | `wasm-bindgen` 0.2 ecosystem floors at 1.85. |
@@ -139,13 +138,13 @@ Reference: [`SECURITY.md`](../SECURITY.md) at the repo root.
 The parser has explicit DoS guards. Defaults are conservative;
 override via `ParserConfig`.
 
-| Limit | Default | Purpose | Override |
-|---|---|---|---|
-| `max_depth` | 1024 | Stack-overflow guard on deeply-nested input | `ParserConfig::max_depth(N)` |
-| `max_alias_expansions` | 100 | Billion-laughs amplification cap | `ParserConfig::max_alias_expansions(N)` |
-| `max_document_length` | input length | Per-document size cap | `ParserConfig::max_document_length(N)` |
-| `max_sequence_length` | `usize::MAX` | Per-sequence item count cap | `ParserConfig::max_sequence_length(N)` |
-| `max_mapping_keys` | `usize::MAX` | Per-mapping key count cap | `ParserConfig::max_mapping_keys(N)` |
+| Limit | Default | `strict()` | Purpose | Override |
+|---|---|---|---|---|
+| `max_depth` | 128 | 64 | Stack-overflow guard on deeply-nested input | `ParserConfig::max_depth(N)` |
+| `max_alias_expansions` | 1024 | 100 | Billion-laughs amplification cap | `ParserConfig::max_alias_expansions(N)` |
+| `max_document_length` | 64 MiB | 1 MiB | Per-document size cap | `ParserConfig::max_document_length(N)` |
+| `max_sequence_length` | 65536 | 1024 | Per-sequence item count cap | `ParserConfig::max_sequence_length(N)` |
+| `max_mapping_keys` | 65536 | 1024 | Per-mapping key count cap | `ParserConfig::max_mapping_keys(N)` |
 
 The corresponding regression tests live in
 [`tests/stress_load.rs`](../crates/noyalib/tests/stress_load.rs).
@@ -380,7 +379,7 @@ Per-host-triple training is required — a Mac-trained
   *fast enough* that splitting a single doc across cores
   costs more than it gains for typical inputs.
 - **Multi-document streams** can be parsed in parallel via
-  `noyalib::parallel::par_load_all_as::<T>(input)` (gated
+  `noyalib::parallel::parse::<T>(input)` (gated
   behind the `parallel` feature). Each document parses on
   its own rayon job.
 - The `Deserializer` itself is not `Sync`-after-construction
@@ -476,7 +475,7 @@ When in `no_std` mode:
 | `garde` | no | `garde` validator integration | `garde` |
 | `validator` | no | `validator` validator integration | `validator` |
 | `figment` | no | Figment provider implementation | `figment` |
-| `parallel` | no | `par_load_all_as::<T>` on rayon | `rayon` |
+| `parallel` | no | `parallel::parse::<T>` on rayon | `rayon` |
 | `simd` | no | optional explicit SIMD acceleration | (none — uses portable_simd / std::simd via cfg) |
 | `compat-serde-yaml` | no | name-for-name shim under `noyalib::compat::serde_yaml` | (none) |
 | `robotics` | no | ROS-style overlay/redaction helpers | (none) |

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -9,12 +9,12 @@ runs, and how to extend it.
 ```mermaid
 graph TD
     A[Doctests<br/>~384] --> B[Unit tests<br/>inline #[cfg(test)]]
-    B --> C[Integration tests<br/>tests/*.rs · 107 files]
+    B --> C[Integration tests<br/>tests/*.rs · 139 files]
     C --> D[Property + proptest]
-    D --> E[Fuzz · libfuzzer<br/>9 targets]
+    D --> E[Fuzz · libfuzzer<br/>10 targets]
     F[Miri · UB detection] -.parallel.-> C
-    G[Bench · Criterion<br/>13 harnesses] -.parallel.-> C
-    H[Spec compliance<br/>387/387 strict yaml-test-suite] -.parallel.-> C
+    G[Bench · Criterion<br/>16 harnesses] -.parallel.-> C
+    H[Spec compliance<br/>406/406 strict yaml-test-suite] -.parallel.-> C
 ```
 
 Each layer catches a different bug class. None replaces another —
@@ -44,7 +44,7 @@ Used for tightly-scoped invariants — encoding tables, scanner
 state machines, format-config heuristics. Not the place for
 end-to-end flows; those live in `tests/`.
 
-## Integration tests (107 files in `crates/noyalib/tests/`)
+## Integration tests (139 files in `crates/noyalib/tests/`)
 
 Each file is a focused theme. Selection of the most load-bearing:
 
@@ -72,7 +72,7 @@ total over valid YAML, etc. Catches edge cases that case-by-case
 tests miss because the input space is hostile in shape, not just
 content.
 
-## Fuzz (9 targets, libfuzzer)
+## Fuzz (10 targets, libfuzzer)
 
 Located in `fuzz/fuzz_targets/`:
 
@@ -85,6 +85,7 @@ Located in `fuzz/fuzz_targets/`:
 | `fuzz_strict` | `from_str_strict<T>` unknown-key surfacing |
 | `fuzz_diff` | Differential against `yaml-rust2` / `saphyr` / `serde_yaml_ng` |
 | `fuzz_borrowed_alias` | P4 alias resolution + bomb cap |
+| `fuzz_no_span_loader` | `NoSpanLoader` path — three-loader parity |
 | `fuzz_yaml_v1_1` | P2 1.1 resolver bundle + individual flag overrides |
 | `fuzz_double_quoted` | Surrogate pair pairing + scalar escape branches |
 
@@ -123,17 +124,17 @@ Miri + big-endian sweep on schedule.
 
 **Run:** `./scripts/miri.sh`
 
-## Benchmarks (13 Criterion harnesses)
+## Benchmarks (16 Criterion harnesses)
 
 Performance is treated as a correctness invariant — regressions
 are bugs the same way wrong output is. Per-crate harnesses:
 
 | Crate | Harnesses | What they cover |
 |---|---|---|
-| `noyalib` | 10 | core parser, comparison vs serde_yaml_ng / yaml-rust2 / saphyr, SIMD, incremental repair, validation overhead, large-doc soak, structural bitmask, numeric parse |
-| `noya-cli` | 1 | clap argv parse + command-tree construction |
-| `noyalib-lsp` | 1 | `textDocument/formatting` + parse-for-diagnostics |
-| `noyalib-mcp` | 1 | the four `tools/call` operations |
+| `noyalib` | 16 | core parser, comparison vs serde_yaml_ng / yaml-rust2 / saphyr, SIMD, incremental repair, validation overhead, large-doc soak, structural bitmask, numeric parse |
+| `noya-cli` (split repo) | 1 | clap argv parse + command-tree construction |
+| `noyalib-lsp` (split repo) | 1 | `textDocument/formatting` + parse-for-diagnostics |
+| `noyalib-mcp` (split repo) | 1 | the four `tools/call` operations |
 
 CI runs the comparison + microbench suites via CodSpeed on every
 PR (the `CodSpeed perf dashboard` workflow); regressions block
@@ -141,15 +142,14 @@ merge.
 
 **Run:** `cargo bench --workspace`
 
-## Spec compliance: 387/387 strict
+## Spec compliance: 406/406 strict
 
 The `yaml-test-suite` is the canonical 1.2 conformance corpus.
-noyalib's compliance harness reports **387/387 strict-pass, 0
-failures, and 19 deliberate skips out of 406 total cases** (each
+noyalib's compliance harness reports **406/406 strict-pass, 0
+failures, and 0 skips out of 406 total cases** (each
 case directory yields one or more variant assertions; the totals
-reflect those variant counts). The full breakdown — including
-which tags each skipped case carries — rebuilds on every CI run
-into `target/yaml-compliance-report.md`.
+reflect those variant counts). The full breakdown rebuilds on
+every CI run into `target/yaml-compliance-report.md`.
 
 The strict-pass set is locked by `tests/official_suite.rs` so a
 regression — any case dropping from pass to skip / fail — fails
@@ -158,12 +158,12 @@ corresponding suite case unblocked.
 
 ## Coverage gate
 
-CI's `Coverage gate (≥95%)` job runs `cargo +nightly llvm-cov`
+CI's `Coverage gate (≥96%)` job runs `cargo +nightly llvm-cov`
 across the workspace and fails under:
 
-- `--fail-under-functions 95` — every public/private fn
-- `--fail-under-lines 93` — line coverage
-- `--fail-under-regions 92` — region (branch) coverage
+- `--fail-under-functions 96` — every public/private fn
+- `--fail-under-lines 94` — line coverage
+- `--fail-under-regions 93` — region (branch) coverage
 
 Excluded from the report: `noyalib-wasm/src/lib.rs` (JsValue
 marshalling needs a wasm-bindgen runtime; covered separately by

--- a/doc/USER-GUIDE.md
+++ b/doc/USER-GUIDE.md
@@ -104,7 +104,7 @@ use noyalib::{from_str, Value};
 let v: Value = from_str(yaml)?;
 
 // Dot-path traversal.
-let port = v.get_path("server.port").and_then(|n| n.as_u16());
+let port = v.get_path("server.port").and_then(|n| n.as_u64());
 
 // Sequence indexing.
 let first = v.get("items").and_then(|s| s.get(0));
@@ -371,9 +371,9 @@ This contract holds for all three tag-bearing shapes:
 
 | YAML | Resulting `Value` |
 | :--- | :--- |
-| `!Custom 'hello'` | `Value::Tagged(Tag("!Custom"), Value::String("hello"))` |
-| `!List [a, b]` | `Value::Tagged(Tag("!List"), Value::Sequence(...))` |
-| `!Map {k: v}` | `Value::Tagged(Tag("!Map"), Value::Mapping(...))` |
+| `!Custom 'hello'` | `Value::Tagged(t)`, `t.tag() == "!Custom"`, `t.value() == Value::String("hello")` |
+| `!List [a, b]` | `Value::Tagged(t)`, `t.tag() == "!List"`, `t.value() == Value::Sequence(...)` |
+| `!Map {k: v}` | `Value::Tagged(t)`, `t.tag() == "!Map"`, `t.value() == Value::Mapping(...)` |
 | `!!str 42` | `Value::String("42")` *(core tag — resolves)* |
 | `!!int 42` | `Value::Number(Integer(42))` *(core tag — resolves)* |
 
@@ -461,7 +461,9 @@ streams). The eager API:
 ```rust
 use noyalib::{load_all, load_all_as};
 
-let docs: Vec<Value>      = load_all(stream)?;
+// `load_all` yields a lazy iterator of `Result<Value>`; collect it.
+let docs: Vec<Value>      = load_all(stream)?.collect::<Result<_, _>>()?;
+// `load_all_as` deserializes every document and returns a `Vec<T>` directly.
 let typed: Vec<MyConfig>  = load_all_as::<MyConfig>(stream)?;
 ```
 
@@ -545,7 +547,9 @@ See [`crates/noyalib/examples/sval_streaming.rs`](../crates/noyalib/examples/sva
 
 ## 11. The CLI tools (`noyafmt`, `noyavalidate`)
 
-Two command-line companions ship under `crates/noya-cli/`:
+Two command-line companions ship from the split-out
+[`sebastienrousseau/noya-cli`](https://github.com/sebastienrousseau/noya-cli)
+repo (split at v0.0.13, ADR-0005; released in strict lockstep):
 
 ```bash
 # Format YAML in-place via the lossless CST.
@@ -568,8 +572,9 @@ other channels in [`pkg/PUBLISH.md`](../pkg/PUBLISH.md).
 
 ## 12. WASM, MCP, and LSP
 
-Three satellite crates in the workspace target specific
-deployment shapes:
+Three satellite crates — each split to its own repo (ADR-0005)
+and released in strict lockstep with this library — target
+specific deployment shapes:
 
 - **`noyalib-wasm`** ([`sebastienrousseau/noyalib-wasm`](https://github.com/sebastienrousseau/noyalib-wasm)).
   `wasm-pack` output published to npm as
@@ -589,7 +594,8 @@ deployment shapes:
   repo in v0.0.13 (ADR-0005); releases in strict lockstep with
   this workspace.
 
-- **`noyalib-lsp`** (`crates/noyalib-lsp/`). Language Server
+- **`noyalib-lsp`** ([`sebastienrousseau/noyalib-lsp`](https://github.com/sebastienrousseau/noyalib-lsp)).
+  Language Server
   Protocol implementation. Editors get format-on-save,
   inline diagnostics, schema-driven hover docs. Bundled into
   the noyalib VS Code / Open VSX extension (`pkg/vscode/`).

--- a/doc/pre-commit.md
+++ b/doc/pre-commit.md
@@ -50,7 +50,7 @@ repos:
 ```yaml
 - name: noyafmt --check
   run: |
-    cargo install noya-cli --version 0.0.1 --locked --no-default-features --features noyafmt
+    cargo install noya-cli --version 0.0.15 --locked --no-default-features --features noyafmt
     git ls-files '*.yaml' '*.yml' | xargs noyafmt --check
 ```
 


### PR DESCRIPTION
Cross-verified documentation accuracy pass. Corrects MSRV (1.75->1.85), POLICIES DoS-default table (5/6 rows), YAML-suite figure (387->406/406, 0 skips), coverage gate (96/94/93), a batch of dead/renamed APIs in the migration guides, stale workspace layout, fuzz/bench/example/test counts, 25 broken example run-commands, and stale 'planned for v0.0.x' claims that contradict shipped features. All fixes verified against source; examples compile, 533 doctests pass, 0 broken intra-doc links. See the commit body for the full itemised list.