### PR TITLE
test(ci): run all examples + smoke-run all benches (fixes 3 budget-broken benches)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,58 @@ jobs:
     # shared workflow's `if:`).
     uses: ./.github/workflows/shared-verify-signatures.yml
 
+  # ── Run every example to completion ─────────────────────────────
+  # The main test job only *compiles* examples. A compiled example
+  # can still panic at run time. scripts/run-all-examples.sh
+  # auto-discovers every `[[example]]` target from `cargo metadata`
+  # and runs each with its own `required-features`, so a runtime
+  # regression (or a newly added example) is caught automatically.
+  # Isolated CARGO_TARGET_DIR per the cache-poisoning doctrine.
+  run-examples:
+    name: Run all examples
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-run-examples
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-run-examples"
+          key: run-examples
+      - name: Run every example to completion
+        run: bash scripts/run-all-examples.sh
+
+  # ── Smoke-run every benchmark ───────────────────────────────────
+  # `cargo build --benches` only compiles the benches; a bench can
+  # compile yet panic on its first iteration (a stale fixture, a
+  # renamed API, a tightened DoS budget). scripts/smoke-benches.sh
+  # runs each bench once via Criterion's `--test` fast path — no
+  # measurement, just execution — auto-discovered from cargo
+  # metadata with their required-features.
+  smoke-benches:
+    name: Smoke-run all benches
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target-smoke-benches
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target-smoke-benches"
+          key: smoke-benches
+      - name: Smoke-run every bench (Criterion --test)
+        run: bash scripts/smoke-benches.sh
+
   # ── Feature-matrix guard: `lossless-u64` ────────────────────────
   # `lossless-u64` is an opt-in Cargo feature that adds a public
   # enum variant (`Number::Unsigned`). Ships with its own compile

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #   make examples  — run all examples sequentially
 #   make clean    — remove build artifacts
 
-.PHONY: all check clippy test fmt deny doc miri miri-full miri-bigendian sbom notice vendor vendor-build msrv-per-crate coverage-gap examples compliance clean
+.PHONY: all check clippy test fmt deny doc miri miri-full miri-bigendian sbom notice vendor vendor-build msrv-per-crate coverage-gap examples bench-smoke compliance clean
 
 all: check clippy test
 
@@ -98,26 +98,16 @@ msrv-per-crate:
 coverage-gap:
 	./scripts/coverage-gap-report.sh
 
+# Run every `[[example]]` target to completion (auto-discovered
+# from cargo metadata with per-example required-features). Mirrors
+# the `run-examples` CI gate. No hand-maintained list to drift.
 examples:
-	@for ex in hello std variants deep dynamic modify tags \
-	           alias smart overlay inherit stream types binary \
-	           strict secure schema env \
-	           errors trace source style \
-	           emit rename flatten bridge pipes global \
-	           portable mask patch suggest schema_ext \
-	           untagged borrow transcode comments \
-	           diagnostic nostd preserve \
-	           replay registry scientific validation anchor_shared \
-	           async_io recursive bench; do \
-	    printf "\033[90m%-25s\033[0m" "$$ex" ; \
-	    if cargo run --example $$ex --quiet 2>/dev/null 1>/dev/null; then \
-	        printf "\033[32m[ok]\033[0m\n" ; \
-	    else \
-	        printf "\033[31m[fail]\033[0m\n" ; \
-	        exit 1; \
-	    fi; \
-	done
-	@printf "\n\033[1;32mAll examples passed.\033[0m\n"
+	./scripts/run-all-examples.sh
+
+# Smoke-run every `[[bench]]` once via Criterion `--test` (no
+# measurement). Mirrors the `smoke-benches` CI gate.
+bench-smoke:
+	./scripts/smoke-benches.sh
 
 clean:
 	cargo clean

--- a/crates/noyalib/benches/large_doc_soak.rs
+++ b/crates/noyalib/benches/large_doc_soak.rs
@@ -25,8 +25,23 @@
 #![allow(missing_docs, unused_results)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use noyalib::{StreamingDeserializer, Value, from_str};
+use noyalib::{ParserConfig, StreamingDeserializer, Value, from_str_with_config};
 use serde::Deserialize;
+
+/// Budgets sized for the soak fixtures. The default `ParserConfig` DoS
+/// guards (max_events 1M, max_nodes 250k, etc.) legitimately reject a
+/// 50 MiB document; a large-doc soak is exactly the case where a caller
+/// raises them, so parse the fixtures with the guards lifted.
+fn soak_config() -> ParserConfig {
+    let mut cfg = ParserConfig::default();
+    cfg.max_events = usize::MAX;
+    cfg.max_nodes = usize::MAX;
+    cfg.max_document_length = usize::MAX;
+    cfg.max_total_scalar_bytes = usize::MAX;
+    cfg.max_sequence_length = usize::MAX;
+    cfg.max_mapping_keys = usize::MAX;
+    cfg
+}
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -85,6 +100,7 @@ fn bench_soak(c: &mut Criterion) {
         ("50MiB", 50 * (1usize << 20)),
     ] {
         let yaml = synthetic_yaml(target_bytes);
+        let cfg = soak_config();
         group.throughput(Throughput::Bytes(yaml.len() as u64));
 
         group.bench_with_input(
@@ -92,7 +108,7 @@ fn bench_soak(c: &mut Criterion) {
             &yaml,
             |b, yaml| {
                 b.iter(|| {
-                    let v: Value = from_str(black_box(yaml.as_str())).unwrap();
+                    let v: Value = from_str_with_config(black_box(yaml.as_str()), &cfg).unwrap();
                     black_box(v);
                 });
             },
@@ -103,7 +119,7 @@ fn bench_soak(c: &mut Criterion) {
             &yaml,
             |b, yaml| {
                 b.iter(|| {
-                    let mut de = StreamingDeserializer::new(black_box(yaml.as_str()));
+                    let mut de = StreamingDeserializer::with_config(black_box(yaml.as_str()), &cfg);
                     let doc: Doc = Deserialize::deserialize(&mut de).unwrap();
                     black_box(doc);
                 });

--- a/crates/noyalib/benches/mapping_key_clone.rs
+++ b/crates/noyalib/benches/mapping_key_clone.rs
@@ -37,6 +37,10 @@ fn permissive_config() -> ParserConfig {
     let mut cfg = ParserConfig::default();
     cfg.max_alias_expansions = 100_000;
     cfg.max_merge_keys = 100_000;
+    // The merge-heavy fixture aliases one anchor many times, which trips
+    // the alias/anchor-ratio DoS guard added in v0.0.15. This bench
+    // measures the key-insert path, not the guard, so disable the ratio.
+    cfg.alias_anchor_ratio = None;
     cfg
 }
 

--- a/crates/noyalib/benches/parallel.rs
+++ b/crates/noyalib/benches/parallel.rs
@@ -29,11 +29,14 @@ struct Record {
 fn build_stream(doc_count: usize, body_repeats: usize) -> String {
     let mut s = String::with_capacity(doc_count * (48 + body_repeats * 24));
     for i in 0..doc_count {
-        s.push_str(&format!("---\nid: {i}\nkind: audit\npayload: "));
+        // Quote the payload so the `tiny_docs` shape (body_repeats == 0)
+        // yields an empty string rather than YAML null, which would fail
+        // to deserialize into `Record::payload: String`.
+        s.push_str(&format!("---\nid: {i}\nkind: audit\npayload: \""));
         for j in 0..body_repeats {
             s.push_str(&format!("field-{j}-{i} "));
         }
-        s.push('\n');
+        s.push_str("\"\n");
     }
     s
 }

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Run EVERY `[[example]]` target to completion — not just compile it.
+#
+# WHY THIS EXISTS
+#
+# CI already compiles every example (`cargo build --examples
+# --all-features`), but a compiled example can still panic at run time.
+# `make examples` used to run a hand-maintained subset that silently
+# drifted out of date and skipped every feature-gated example. This
+# script closes that hole: it auto-discovers all example targets from
+# `cargo metadata`, runs each one with EXACTLY its `required-features`
+# (matching the command a user would copy from the example header), and
+# fails if any example exits non-zero. Auto-discovery means a newly
+# added example is covered the moment it lands — nothing to update here.
+#
+# Run locally:   bash scripts/run-all-examples.sh
+# CI wiring:     .github/workflows/ci.yml (run-examples job)
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# name<TAB>comma,separated,features   (one line per example target)
+mapfile -t EXAMPLES < <(
+  cargo metadata --format-version 1 --no-deps \
+    | jq -r '
+        .packages[].targets[]
+        | select(.kind[] == "example")
+        | "\(.name)\t\((.["required-features"] // []) | join(","))"
+      ' \
+    | sort
+)
+
+total=${#EXAMPLES[@]}
+[ "$total" -gt 0 ] || { echo "ERROR: no example targets discovered." >&2; exit 1; }
+
+echo "Running $total example targets to completion…"
+pass=0
+fail=0
+failed=()
+for row in "${EXAMPLES[@]}"; do
+  name="${row%%$'\t'*}"
+  feats="${row#*$'\t'}"
+  args=(run --example "$name" --quiet --locked)
+  [ -n "$feats" ] && args+=(--features "$feats")
+  printf '  %-28s %s' "$name" "${feats:+[$feats] }"
+  if cargo "${args[@]}" >/dev/null 2>&1; then
+    printf '\033[32mok\033[0m\n'; pass=$((pass + 1))
+  else
+    printf '\033[31mFAIL\033[0m\n'; fail=$((fail + 1)); failed+=("$name")
+  fi
+done
+
+echo
+echo "examples: $pass passed, $fail failed (of $total)"
+if [ "$fail" -ne 0 ]; then
+  printf 'FAILED: %s\n' "${failed[*]}" >&2
+  exit 1
+fi
+echo "All $total examples ran to completion."

--- a/scripts/smoke-benches.sh
+++ b/scripts/smoke-benches.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Noyalib
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Smoke-run EVERY `[[bench]]` target — execute each benchmark once via
+# Criterion's `--test` mode (runs every benchmark function a single time
+# without collecting measurements). This guarantees the benchmark
+# harnesses actually run against the current API, not merely compile.
+#
+# WHY THIS EXISTS
+#
+# `cargo build --benches` (and the CI check job) only *compiles* the
+# benches. A bench can compile yet panic on the first iteration (bad
+# fixture, renamed API, changed default). Full `cargo bench` is far too
+# slow for a per-PR gate, so this runs the `--test` fast path: every
+# bench executes once, any panic fails the gate, no measurement noise.
+# Bench targets are auto-discovered from `cargo metadata` with their
+# `required-features`, so new benches are covered automatically.
+#
+# Run locally:   bash scripts/smoke-benches.sh
+# CI wiring:     .github/workflows/ci.yml (smoke-benches job)
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+mapfile -t BENCHES < <(
+  cargo metadata --format-version 1 --no-deps \
+    | jq -r '
+        .packages[].targets[]
+        | select(.kind[] == "bench")
+        | "\(.name)\t\((.["required-features"] // []) | join(","))"
+      ' \
+    | sort
+)
+
+total=${#BENCHES[@]}
+[ "$total" -gt 0 ] || { echo "ERROR: no bench targets discovered." >&2; exit 1; }
+
+echo "Smoke-running $total bench targets (Criterion --test, one iteration each)…"
+pass=0
+fail=0
+failed=()
+for row in "${BENCHES[@]}"; do
+  name="${row%%$'\t'*}"
+  feats="${row#*$'\t'}"
+  args=(bench --bench "$name" --locked)
+  [ -n "$feats" ] && args+=(--features "$feats")
+  args+=(-- --test)
+  printf '  %-24s %s' "$name" "${feats:+[$feats] }"
+  if cargo "${args[@]}" >/dev/null 2>&1; then
+    printf '\033[32mok\033[0m\n'; pass=$((pass + 1))
+  else
+    printf '\033[31mFAIL\033[0m\n'; fail=$((fail + 1)); failed+=("$name")
+  fi
+done
+
+echo
+echo "benches: $pass passed, $fail failed (of $total)"
+if [ "$fail" -ne 0 ]; then
+  printf 'FAILED: %s\n' "${failed[*]}" >&2
+  exit 1
+fi
+echo "All $total bench harnesses ran."


### PR DESCRIPTION
Adds two CI gates that **run** (not just compile) every example and benchmark, auto-discovered from cargo metadata. The bench gate immediately caught three benches that panic on `cargo bench` — collateral from the v0.0.15 DoS-budget tightening, never noticed because nothing ran them (large_doc_soak 50 MiB > max_events, mapping_key_clone merge_heavy > alias/anchor ratio, parallel tiny_docs null payload). Verified locally: 75/75 examples run, 16/16 benches run. Also rewires `make examples` to the complete script and adds `make bench-smoke`.